### PR TITLE
docs: Fix articles dropdown

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -30,7 +30,7 @@ website:
       - text: Reference
         href: reference/index.qmd
       - text: Articles
-      - menu: 
+        menu: 
           - text: Prompt design
             href: prompt-engineering.qmd
           - text: Structured data


### PR DESCRIPTION
Small typo fix to make the words "Articles" part of the dropdown menu.