### PR TITLE
docs: Update Shiny example

### DIFF
--- a/docs/web-apps.qmd
+++ b/docs/web-apps.qmd
@@ -11,7 +11,7 @@ This is a great way to quickly test your model, but you'll likely want to embed 
 
 ## Shiny
 
-Pass the result of `chat.stream()` directly to Shiny's [`ui.Chat` component](https://shiny.posit.co/py/components/display-messages/chat/) to create a chat interface in your own [Shiny](https://shiny.rstudio.com/py) app.
+Using Shiny's [`ui.Chat` component](https://shiny.posit.co/py/components/display-messages/chat/), you can simply pass user input from the component into the `chat.stream()` method. This generate a response stream that can then be passed to `.append_message_stream()`.
 
 ```python
 from chatlas import ChatAnthropic

--- a/docs/web-apps.qmd
+++ b/docs/web-apps.qmd
@@ -11,23 +11,25 @@ This is a great way to quickly test your model, but you'll likely want to embed 
 
 ## Shiny
 
-Pass the result of `.chat()` directly to Shiny's [`ui.Chat` component](https://shiny.posit.co/py/components/display-messages/chat/) to create a chat interface in your own [Shiny](https://shiny.rstudio.com/py) app.
+Pass the result of `chat.stream()` directly to Shiny's [`ui.Chat` component](https://shiny.posit.co/py/components/display-messages/chat/) to create a chat interface in your own [Shiny](https://shiny.rstudio.com/py) app.
 
 ```python
 from chatlas import ChatAnthropic
-from shiny import ui
+from shiny.express import ui
 
-chat = ui.Chat(
-  id="chat", 
-  messages=["Hi! How can I help you today?"],
+chat = ChatAnthropic()
+
+chat_ui = ui.Chat(
+    id="ui_chat",
+    messages=["Hi! How can I help you today?"],
 )
+chat_ui.ui()
 
-chat_model = ChatAnthropic()
 
-@chat.on_user_submit
-def _():
-    response = chat_model.stream(chat.user_input())
-    chat.append_message_stream(response)
+@chat_ui.on_user_submit
+async def _():
+    response = chat.stream(chat_ui.user_input())
+    await chat_ui.append_message_stream(response)
 ```
 
 ## Streamlit


### PR DESCRIPTION
Makes the Shiny example runnable.

Also, because we're in chatlas, I'd prefer calling the actual chat model `chat` and separately calling the `ui.Chat()` instance `chat_ui()`. I think this naming makes it clearer which things are interacting (chatting) with the model (`chat`) and which things are just UI in the app `ui.Chat()`.