### PR TITLE
Minor typo fix

### DIFF
--- a/docs/tool-calling.qmd
+++ b/docs/tool-calling.qmd
@@ -27,7 +27,7 @@ chat = ChatOpenAI(model="gpt-4o")
 _ = chat.chat("How long ago exactly was the moment Neil Armstrong touched down on the moon?")
 ```
 
-Unfortunately, the LLM doesn't hallucinates the current date. Let's give the chat model the ability to determine the current time and try again.
+Unfortunately, the LLM hallucinates the current date. Let's give the chat model the ability to determine the current time and try again.
 
 ### Defining a tool function
 


### PR DESCRIPTION
Fixing typo on [line 30 of tool-calling.qmd](https://github.com/posit-dev/chatlas/blob/3b7ccea32da4ba344103a78ca79e991a643628f7/docs/tool-calling.qmd#L30) from "Unfortunately, the LLM doesn't hallucinates the current..." to "Unfortunately, the LLM hallucinates the current..." to reflect the case in the motivating example.