### PR TITLE
bug: Use `repr()` for chat tool calls when exporting markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 -->
 
+## [Development]
+
+### New features
+
+### Bug fixes
+
+* Update formatting of exported markdown to use `repr()` instead of `str()` when exporting tool call results. (#30)
+
 ## [0.3.0] - 2024-12-20
 
 ### New features
@@ -23,4 +31,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.0] - 2024-12-11
 
-First stable release of `chatlas`, see the website to learn more <https://posit-dev.github.io/chatlas/> 
+First stable release of `chatlas`, see the website to learn more <https://posit-dev.github.io/chatlas/>

--- a/chatlas/_chat.py
+++ b/chatlas/_chat.py
@@ -948,11 +948,11 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         is_html = filename.suffix == ".html"
 
         # Get contents from each turn
-        contents = ""
+        content_arr: list[str] = []
         for turn in turns:
             turn_content = "\n\n".join(
                 [
-                    str(content)
+                    str(content).strip()
                     for content in turn.contents
                     if include == "all" or isinstance(content, ContentText)
                 ]
@@ -963,7 +963,8 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
                 turn_content = f"<shiny-{msg_type}-message content='{content_attr}'></shiny-{msg_type}-message>"
             else:
                 turn_content = f"## {turn.role.capitalize()}\n\n{turn_content}"
-            contents += f"{turn_content}\n\n"
+            content_arr.append(turn_content)
+        contents = "\n\n".join(content_arr)
 
         # Shiny chat message components requires container elements
         if is_html:

--- a/chatlas/_content.py
+++ b/chatlas/_content.py
@@ -198,7 +198,7 @@ class ContentToolResult(Content):
     def __str__(self):
         comment = f"# tool result ({self.id})"
         val = self.get_final_value()
-        return f"""\n```python\n{comment}\n"{val}"\n```\n"""
+        return f"""\n```python\n{comment}\n{val}\n```\n"""
 
     def _repr_markdown_(self):
         return self.__str__()
@@ -213,7 +213,7 @@ class ContentToolResult(Content):
     def get_final_value(self) -> str:
         if self.error:
             return f"Tool calling failed with error: '{self.error}'"
-        return str(self.value)
+        return repr(self.value)
 
 
 @dataclass

--- a/chatlas/_content.py
+++ b/chatlas/_content.py
@@ -155,7 +155,7 @@ class ContentToolRequest(Content):
         args_str = self._arguments_str()
         func_call = f"{self.name}({args_str})"
         comment = f"# tool request ({self.id})"
-        return f"\n```python\n{comment}\n{func_call}\n```\n"
+        return f"```python\n{comment}\n{func_call}\n```\n"
 
     def _repr_markdown_(self):
         return self.__str__()
@@ -246,7 +246,7 @@ class ContentJson(Content):
         return json.dumps(self.value, indent=2)
 
     def _repr_markdown_(self):
-        return f"""\n```json\n{self.__str__()}\n```\n"""
+        return f"""```json\n{self.__str__()}\n```"""
 
     def __repr__(self, indent: int = 0):
         return " " * indent + f"<ContentJson value={self.value}>"

--- a/chatlas/_content.py
+++ b/chatlas/_content.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
+from pprint import pformat
 from typing import Any, Literal, Optional
 
 ImageContentTypes = Literal[
@@ -195,10 +196,20 @@ class ContentToolResult(Content):
     value: Any = None
     error: Optional[str] = None
 
+    def _get_value_and_language(self) -> tuple[str, str]:
+        if self.error:
+            return f"Tool calling failed with error: '{self.error}'", ""
+        try:
+            json_val = json.loads(self.value)
+            return pformat(json_val, indent=2, sort_dicts=False), "python"
+        except:  # noqa: E722
+            return str(self.value), ""
+
     def __str__(self):
         comment = f"# tool result ({self.id})"
-        val = self.get_final_value()
-        return f"""\n```python\n{comment}\n{val}\n```\n"""
+        value, language = self._get_value_and_language()
+
+        return f"""```{language}\n{comment}\n{value}\n```"""
 
     def _repr_markdown_(self):
         return self.__str__()
@@ -211,9 +222,8 @@ class ContentToolResult(Content):
         return res + ">"
 
     def get_final_value(self) -> str:
-        if self.error:
-            return f"Tool calling failed with error: '{self.error}'"
-        return repr(self.value)
+        value, _language = self._get_value_and_language()
+        return value
 
 
 @dataclass

--- a/tests/__snapshots__/test_chat.ambr
+++ b/tests/__snapshots__/test_chat.ambr
@@ -17,8 +17,6 @@
   <shiny-user-message content='What&apos;s 1 + 1? What&apos;s 1 + 2?'></shiny-user-message>
   
   <shiny-chat-message content='2  3'></shiny-chat-message>
-  
-  
   </shiny-chat-messages></shiny-chat-container>
   <br><br>
   <details><summary>System prompt</summary>

--- a/tests/test_provider_openai.py
+++ b/tests/test_provider_openai.py
@@ -1,4 +1,5 @@
 import pytest
+
 from chatlas import ChatOpenAI
 
 from .conftest import (
@@ -21,7 +22,10 @@ def test_openai_simple_request():
     chat.chat("What is 1 + 1?")
     turn = chat.get_last_turn()
     assert turn is not None
-    assert turn.tokens == (27, 2)
+    assert turn.tokens is not None
+    assert len(turn.tokens) == 2
+    assert turn.tokens[0] == 27
+    # Not testing turn.tokens[1] because it's not deterministic. Typically 1 or 2.
     assert turn.finish_reason == "stop"
 
 


### PR DESCRIPTION
If we're putting the value in a python code block, then it is safe to assume the code can be run. `repr()` should return eval-able objects (which do not need an extra layer of quoting).

First seen in :

````
## User


```python
# tool result (toolu_bdrk_01CmkqJNgwQLAG4HseMnvAR6)
"{"email":"barret@posit.co"}"
```
````

Desired output:

````
## User


```python
# tool result (toolu_bdrk_01CmkqJNgwQLAG4HseMnvAR6)
{"email":"barret@posit.co"}
```
````

----------------------------

When using `repr()`, strings will be quoted. JSON will be given as is.

```
>>> a = str("asfd") 
>>> print(f"\n{a}\n")

asfd

>>> a = repr("asfd")
>>> 
>>> print(f"\n{a}\n")

'asfd'

```

```
>>> a = str({"a": 1, "b": 2})
>>> print(f"\n{a}\n")

{'a': 1, 'b': 2}

>>> a = repr({"a": 1, "b": 2})
>>> print(f"\n{a}\n")

{'a': 1, 'b': 2}

```
