### PR TITLE
Fix unwanted duplicated content when echo-via rich console

### DIFF
--- a/chatlas/_display.py
+++ b/chatlas/_display.py
@@ -46,6 +46,7 @@ class LiveMarkdownDisplay(MarkdownDisplay):
         self.content: str = ""
         self.live = Live(
             auto_refresh=False,
+            vertical_overflow="crop_above",
             console=Console(
                 **echo_options["rich_console"],
             ),

--- a/chatlas/_display.py
+++ b/chatlas/_display.py
@@ -46,7 +46,6 @@ class LiveMarkdownDisplay(MarkdownDisplay):
         self.content: str = ""
         self.live = Live(
             auto_refresh=False,
-            vertical_overflow="visible",
             console=Console(
                 **echo_options["rich_console"],
             ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.9"
 dependencies = [
   "pydantic>=2.0",
   "jinja2",
-  "rich",
+  "rich>13.9.4",
 ]
 classifiers = [
   "Development Status :: 4 - Beta",


### PR DESCRIPTION
Turns out there is an issue with duplicated content when `vertical_overflow="visible"` in a `Live()` console. See https://github.com/Textualize/rich/issues/3263

One fix would be to change that `vertical_overflow="ellipsis"`, but that has the downside of not being able to see the latest streaming results ([5fff5d6](https://github.com/posit-dev/chatlas/pull/58/commits/5fff5d64f90d76c720c3b0473991429b73e07c89))

A better fix would be to leverage the new `vertical_overflow="crop_above"` options that I've proposed in https://github.com/Textualize/rich/pull/3637 ([b3354f2](https://github.com/posit-dev/chatlas/pull/58/commits/b3354f27d83b9b7a2b66933715ca584315cb6acb))