### PR TITLE
Fix for duplicated content in `rich.live.Live()` console when content overflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* Fixed an issue with content getting duplicated when it overflows in a `Live()` console. (#71)
 * Fix an issue with tool calls not working with `ChatVertex()`. (#61)
 
 

--- a/chatlas/_live_render.py
+++ b/chatlas/_live_render.py
@@ -1,0 +1,116 @@
+# A 'patched' version of LiveRender that adds the 'crop_above' vertical overflow method.
+# Derives from https://github.com/Textualize/rich/pull/3637
+import sys
+from typing import Optional, Tuple
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal  # pragma: no cover
+
+from rich._loop import loop_last
+from rich.console import Console, ConsoleOptions, RenderableType, RenderResult
+from rich.control import Control
+from rich.segment import ControlType, Segment
+from rich.style import StyleType
+from rich.text import Text
+
+VerticalOverflowMethod = Literal["crop", "crop_above", "ellipsis", "visible"]
+
+
+class LiveRender:
+    """Creates a renderable that may be updated.
+
+    Args:
+        renderable (RenderableType): Any renderable object.
+        style (StyleType, optional): An optional style to apply to the renderable. Defaults to "".
+    """
+
+    def __init__(
+        self,
+        renderable: RenderableType,
+        style: StyleType = "",
+        vertical_overflow: VerticalOverflowMethod = "ellipsis",
+    ) -> None:
+        self.renderable = renderable
+        self.style = style
+        self.vertical_overflow = vertical_overflow
+        self._shape: Optional[Tuple[int, int]] = None
+
+    def set_renderable(self, renderable: RenderableType) -> None:
+        """Set a new renderable.
+
+        Args:
+            renderable (RenderableType): Any renderable object, including str.
+        """
+        self.renderable = renderable
+
+    def position_cursor(self) -> Control:
+        """Get control codes to move cursor to beginning of live render.
+
+        Returns:
+            Control: A control instance that may be printed.
+        """
+        if self._shape is not None:
+            _, height = self._shape
+            return Control(
+                ControlType.CARRIAGE_RETURN,
+                (ControlType.ERASE_IN_LINE, 2),
+                *(
+                    (
+                        (ControlType.CURSOR_UP, 1),
+                        (ControlType.ERASE_IN_LINE, 2),
+                    )
+                    * (height - 1)
+                ),
+            )
+        return Control()
+
+    def restore_cursor(self) -> Control:
+        """Get control codes to clear the render and restore the cursor to its previous position.
+
+        Returns:
+            Control: A Control instance that may be printed.
+        """
+        if self._shape is not None:
+            _, height = self._shape
+            return Control(
+                ControlType.CARRIAGE_RETURN,
+                *((ControlType.CURSOR_UP, 1), (ControlType.ERASE_IN_LINE, 2)) * height,
+            )
+        return Control()
+
+    def __rich_console__(
+        self, console: Console, options: ConsoleOptions
+    ) -> RenderResult:
+        renderable = self.renderable
+        style = console.get_style(self.style)
+        lines = console.render_lines(renderable, options, style=style, pad=False)
+        shape = Segment.get_shape(lines)
+
+        _, height = shape
+        if height > options.size.height:
+            if self.vertical_overflow == "crop":
+                lines = lines[: options.size.height]
+                shape = Segment.get_shape(lines)
+            elif self.vertical_overflow == "crop_above":
+                lines = lines[-(options.size.height) :]
+                shape = Segment.get_shape(lines)
+            elif self.vertical_overflow == "ellipsis":
+                lines = lines[: (options.size.height - 1)]
+                overflow_text = Text(
+                    "...",
+                    overflow="crop",
+                    justify="center",
+                    end="",
+                    style="live.ellipsis",
+                )
+                lines.append(list(console.render(overflow_text)))
+                shape = Segment.get_shape(lines)
+        self._shape = shape
+
+        new_line = Segment.line()
+        for last, line in loop_last(lines):
+            yield from line
+            if not last:
+                yield new_line

--- a/tests/test_provider_azure.py
+++ b/tests/test_provider_azure.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+
 from chatlas import ChatAzureOpenAI
 
 do_test = os.getenv("TEST_AZURE", "true")
@@ -20,7 +21,7 @@ def test_azure_simple_request():
     assert "2" == response.get_content()
     turn = chat.get_last_turn()
     assert turn is not None
-    assert turn.tokens == (27, 1)
+    assert turn.tokens == (27, 2)
 
 
 @pytest.mark.asyncio
@@ -36,4 +37,4 @@ async def test_azure_simple_request_async():
     assert "2" == await response.get_content()
     turn = chat.get_last_turn()
     assert turn is not None
-    assert turn.tokens == (27, 1)
+    assert turn.tokens == (27, 2)


### PR DESCRIPTION
Turns out there is an issue with duplicated content when `vertical_overflow="visible"` in a `Live()` console. See https://github.com/Textualize/rich/issues/3263

A few weeks ago, I submitted a PR to rich to fix this via a new `vertical_overflow="crop_above"` option https://github.com/Textualize/rich/pull/3637.

Given that rich hasn't been updated in many months, and there are many PRs with no feedback, I'm not hopeful it will be accepted.

Fortunately, it's fairly straightforward to monkeypatch the underlying `LiveRender()` with one that adds the  `vertical_overflow="crop_above"` capability