### PR TITLE
Serializable `Turn`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 -->
 
+## [UNRELEASED]
+
+### Improvements
+
+* `Turn` and `Content` now inherit from `pydantic.BaseModel` to provide easier saving to and loading from JSON. (#72)
+
 ## [0.5.0] - 2025-03-18
 
 ### New features

--- a/chatlas/_anthropic.py
+++ b/chatlas/_anthropic.py
@@ -455,7 +455,7 @@ class AnthropicProvider(Provider[Message, RawMessageStreamEvent, Message]):
                 "type": "image",
                 "source": {
                     "type": "base64",
-                    "media_type": content.content_type,
+                    "media_type": content.image_content_type,
                     "data": content.data or "",
                 },
             }
@@ -504,7 +504,7 @@ class AnthropicProvider(Provider[Message, RawMessageStreamEvent, Message]):
         contents = []
         for content in completion.content:
             if content.type == "text":
-                contents.append(ContentText(content.text))
+                contents.append(ContentText(text=content.text))
             elif content.type == "tool_use":
                 if has_data_model and content.name == "_structured_tool_call":
                     if not isinstance(content.input, dict):
@@ -515,11 +515,11 @@ class AnthropicProvider(Provider[Message, RawMessageStreamEvent, Message]):
                         raise ValueError(
                             "Expected data extraction tool to return a 'data' field."
                         )
-                    contents.append(ContentJson(content.input["data"]))
+                    contents.append(ContentJson(value=content.input["data"]))
                 else:
                     contents.append(
                         ContentToolRequest(
-                            content.id,
+                            id=content.id,
                             name=content.name,
                             arguments=content.input,
                         )

--- a/chatlas/_chat.py
+++ b/chatlas/_chat.py
@@ -1248,7 +1248,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         id_: str,
     ) -> ContentToolResult:
         if func is None:
-            return ContentToolResult(id_, value=None, error="Unknown tool")
+            return ContentToolResult(id=id_, value=None, error="Unknown tool")
 
         name = func.__name__
 
@@ -1258,10 +1258,10 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
             else:
                 result = func(arguments)
 
-            return ContentToolResult(id_, value=result, error=None, name=name)
+            return ContentToolResult(id=id_, value=result, error=None, name=name)
         except Exception as e:
             log_tool_error(name, str(arguments), e)
-            return ContentToolResult(id_, value=None, error=str(e), name=name)
+            return ContentToolResult(id=id_, value=None, error=str(e), name=name)
 
     @staticmethod
     async def _invoke_tool_async(
@@ -1270,7 +1270,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         id_: str,
     ) -> ContentToolResult:
         if func is None:
-            return ContentToolResult(id_, value=None, error="Unknown tool")
+            return ContentToolResult(id=id_, value=None, error="Unknown tool")
 
         name = func.__name__
 
@@ -1280,10 +1280,10 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
             else:
                 result = await func(arguments)
 
-            return ContentToolResult(id_, value=result, error=None, name=name)
+            return ContentToolResult(id=id_, value=result, error=None, name=name)
         except Exception as e:
             log_tool_error(func.__name__, str(arguments), e)
-            return ContentToolResult(id_, value=None, error=str(e), name=name)
+            return ContentToolResult(id=id_, value=None, error=str(e), name=name)
 
     def _markdown_display(
         self, echo: Literal["text", "all", "none"]

--- a/chatlas/_content_image.py
+++ b/chatlas/_content_image.py
@@ -68,7 +68,7 @@ def content_image_url(
         if content_type not in ["image/png", "image/jpeg", "image/webp", "image/gif"]:
             raise ValueError(f"Unsupported image content type: {content_type}")
         content_type = cast(ImageContentTypes, content_type)
-        return ContentImageInline(content_type, base64_data)
+        return ContentImageInline(image_content_type=content_type, data=base64_data)
     else:
         return ContentImageRemote(url=url, detail=detail)
 
@@ -191,7 +191,7 @@ def content_image_file(
         img.save(buffer, format=img.format)
         base64_data = base64.b64encode(buffer.getvalue()).decode("utf-8")
 
-    return ContentImageInline(content_type, base64_data)
+    return ContentImageInline(image_content_type=content_type, data=base64_data)
 
 
 def content_image_plot(
@@ -263,7 +263,7 @@ def content_image_plot(
         fig.savefig(buf, format="png", dpi=dpi, bbox_inches="tight")
         buf.seek(0)
         base64_data = base64.b64encode(buf.getvalue()).decode("utf-8")
-        return ContentImageInline("image/png", base64_data)
+        return ContentImageInline(image_content_type="image/png", data=base64_data)
     finally:
         fig.set_size_inches(*size)
 

--- a/chatlas/_google.py
+++ b/chatlas/_google.py
@@ -402,7 +402,7 @@ class GoogleProvider(
         elif isinstance(content, ContentImageInline) and content.data:
             return Part.from_bytes(
                 data=base64.b64decode(content.data),
-                mime_type=content.content_type,
+                mime_type=content.image_content_type,
             )
         elif isinstance(content, ContentImageRemote):
             raise NotImplementedError(

--- a/chatlas/_google.py
+++ b/chatlas/_google.py
@@ -460,9 +460,9 @@ class GoogleProvider(
             text = part.get("text")
             if text:
                 if has_data_model:
-                    contents.append(ContentJson(json.loads(text)))
+                    contents.append(ContentJson(value=json.loads(text)))
                 else:
-                    contents.append(ContentText(text))
+                    contents.append(ContentText(text=text))
             function_call = part.get("function_call")
             if function_call:
                 # Seems name is required but id is optional?

--- a/chatlas/_openai.py
+++ b/chatlas/_openai.py
@@ -476,7 +476,7 @@ class OpenAIProvider(Provider[ChatCompletion, ChatCompletionChunk, ChatCompletio
                             {
                                 "type": "image_url",
                                 "image_url": {
-                                    "url": f"data:{x.content_type};base64,{x.data}"
+                                    "url": f"data:{x.image_content_type};base64,{x.data}"
                                 },
                             }
                         )
@@ -514,9 +514,9 @@ class OpenAIProvider(Provider[ChatCompletion, ChatCompletionChunk, ChatCompletio
         if message.content is not None:
             if has_data_model:
                 data = json.loads(message.content)
-                contents = [ContentJson(data)]
+                contents = [ContentJson(value=data)]
             else:
-                contents = [ContentText(message.content)]
+                contents = [ContentText(text=message.content)]
 
         tool_calls = message.tool_calls
 
@@ -540,7 +540,7 @@ class OpenAIProvider(Provider[ChatCompletion, ChatCompletionChunk, ChatCompletio
 
                 contents.append(
                     ContentToolRequest(
-                        call.id,
+                        id=call.id,
                         name=func.name,
                         arguments=args,
                     )

--- a/chatlas/_turn.py
+++ b/chatlas/_turn.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from typing import Any, Generic, Literal, Optional, Sequence, TypeVar
+from typing import Generic, Literal, Optional, Sequence, TypeVar
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field
 
 from ._content import Content, ContentText, ContentUnion, create_content
 
@@ -126,32 +126,6 @@ class Turn(BaseModel, Generic[CompletionT]):
         for content in self.contents:
             res += "\n" + content.__repr__(indent=indent + 2)
         return res + "\n"
-
-    @model_validator(mode="before")
-    @classmethod
-    def validate_contents(cls, data: dict[str, Any]) -> dict[str, Any]:
-        if not isinstance(data, dict):
-            return data
-        if "contents" not in data:
-            return data
-        contents = data["contents"]
-        if not isinstance(contents, list):
-            return data
-
-        validated_contents: list[Content] = []
-        for x in contents:
-            if not x:
-                continue
-            if isinstance(x, Content):
-                validated_contents.append(x)
-            elif isinstance(x, str):
-                validated_contents.append(ContentText(text=x))
-            if isinstance(x, dict):
-                validated_contents.append(create_content(x))
-
-        data["contents"] = validated_contents
-
-        return data
 
 
 def user_turn(*args: Content | str) -> Turn:

--- a/chatlas/types/__init__.py
+++ b/chatlas/types/__init__.py
@@ -1,8 +1,5 @@
-from .._chat import (  # noqa: A005
-  ChatResponse,
-  ChatResponseAsync,
-  SubmitInputArgsT,
-)
+from .._chat import ChatResponseAsync  # noqa: A005
+from .._chat import ChatResponse, SubmitInputArgsT
 from .._content import (
     Content,
     ContentImage,

--- a/chatlas/types/__init__.py
+++ b/chatlas/types/__init__.py
@@ -1,5 +1,8 @@
-from .._chat import ChatResponseAsync  # noqa: A005
-from .._chat import ChatResponse, SubmitInputArgsT
+from .._chat import (  # noqa: A005
+  ChatResponse,
+  ChatResponseAsync,
+  SubmitInputArgsT,
+)
 from .._content import (
     Content,
     ContentImage,

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -2,8 +2,9 @@ import re
 import tempfile
 
 import pytest
-from chatlas import ChatOpenAI, Turn
 from pydantic import BaseModel
+
+from chatlas import ChatOpenAI, Turn
 
 
 def test_simple_batch_chat():
@@ -162,3 +163,15 @@ def test_modify_system_prompt():
     # string -> NULL
     chat.system_prompt = None
     assert chat.system_prompt is None
+
+
+def test_json_serialize():
+    chat = ChatOpenAI()
+    chat.chat("Tell me a short joke", echo="none")
+    turns = chat.get_turns()
+    turns_json = [x.model_dump_json() for x in turns]
+    turns_restored = [Turn.model_validate_json(x) for x in turns_json]
+    assert len(turns) == 2
+    # Completion objects, at least of right now, aren't included in the JSON
+    turns[1].completion = None
+    assert turns == turns_restored

--- a/tests/test_content_image.py
+++ b/tests/test_content_image.py
@@ -13,7 +13,7 @@ def test_can_create_image_from_url():
 def test_can_create_inline_image_from_data_url():
     obj = content_image_url("data:image/png;base64,abcd")
     assert isinstance(obj, ContentImageInline)
-    assert obj.content_type == "image/png"
+    assert obj.image_content_type == "image/png"
     assert obj.data == "abcd"
 
 
@@ -47,7 +47,7 @@ def test_can_create_image_from_plot():
 
     obj = content_image_plot()
     assert isinstance(obj, ContentImageInline)
-    assert obj.content_type == "image/png"
+    assert obj.image_content_type == "image/png"
 
     plt.close()
 

--- a/tests/test_turns.py
+++ b/tests/test_turns.py
@@ -1,4 +1,5 @@
 import pytest
+
 from chatlas._turn import Turn, normalize_turns
 from chatlas.types import ContentImage, ContentText
 
@@ -26,5 +27,7 @@ def test_normalize_turns_errors():
 
 
 def test_can_extract_text_easily():
-    turn = Turn("assistant", [ContentText("ABC"), ContentImage(), ContentText("DEF")])
+    turn = Turn(
+        "assistant", [ContentText(text="ABC"), ContentImage(), ContentText(text="DEF")]
+    )
     assert turn.text == "ABCDEF"

--- a/tests/test_turns.py
+++ b/tests/test_turns.py
@@ -1,7 +1,7 @@
 import pytest
 
 from chatlas._turn import Turn, normalize_turns
-from chatlas.types import ContentImage, ContentText
+from chatlas.types import ContentJson, ContentText
 
 
 def test_system_prompt_applied_correctly():
@@ -28,6 +28,11 @@ def test_normalize_turns_errors():
 
 def test_can_extract_text_easily():
     turn = Turn(
-        "assistant", [ContentText(text="ABC"), ContentImage(), ContentText(text="DEF")]
+        "assistant",
+        [
+            ContentText(text="ABC"),
+            ContentJson(value=dict(a="1")),
+            ContentText(text="DEF"),
+        ],
     )
     assert turn.text == "ABCDEF"


### PR DESCRIPTION
With this PR, `Turn` and `Content` now inherit from `pydantic.BaseModel`. Most importantly, this means `Turn`s can now be serialized/unserialized via `.model_dump_json()` and `.model_validate_json()`. For example:

```python
from chatlas import ChatOpenAI, Turn

chat = ChatOpenAI()

chat.chat("Tell me a short joke", echo="none")

turns = chat.get_turns()
turns_json = [x.model_dump_json() for x in turns]
turns_restored = [Turn.model_validate_json(x) for x in turns_json]

assert turns[0] == turns_restored[0]
turns[1].completion = None
assert turns[1] == turns_restored[1]

```

For now, the (3rd party) completion object attached to `Turn(completion)` is excluded from serialization. It might be worthwhile including this someday, but in terms of what `chatlas` actually submits to the model, all the relevant information is contained within `.role` and `.contents`.

cc @schloerke 
