### PR TITLE
Add `content` argument to `.stream()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 -->
 
+## [UNRELEASED]
+
+### New features
+
+* `.stream()` and `.stream_async()` gain a `content` argument. Set this to `"all"` to include `ContentToolRequest` and `ContentToolResponse` instances in the stream. (#75)
+* `ContentToolRequest` and `ContentToolResponse` are now exported to `chatlas` namespace. (#75)
+* `ContentToolRequest` and `ContentToolResponse` now have `.tagify()` methods, making it so they can render automatically in a Shiny chatbot. (#75)
+* `ContentToolResult` instances can be returned from tools. This allows for custom rendering of the tool result. (#75)
+
 ## [0.6.1] - 2025-04-03
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `ContentToolRequest` and `ContentToolResponse` now have `.tagify()` methods, making it so they can render automatically in a Shiny chatbot. (#75)
 * `ContentToolResult` instances can be returned from tools. This allows for custom rendering of the tool result. (#75)
 
+### Breaking changes
+
+* The `.export()` method's `include` argument has been renamed to `content` (to match `.stream()`). (#75)
+
 ## [0.6.1] - 2025-04-03
 
 ### Bug fixes

--- a/chatlas/__init__.py
+++ b/chatlas/__init__.py
@@ -2,6 +2,7 @@ from . import types
 from ._anthropic import ChatAnthropic, ChatBedrockAnthropic
 from ._auto import ChatAuto
 from ._chat import Chat
+from ._content import ContentToolRequest, ContentToolResult
 from ._content_image import content_image_file, content_image_plot, content_image_url
 from ._content_pdf import content_pdf_file, content_pdf_url
 from ._github import ChatGithub
@@ -41,6 +42,8 @@ __all__ = (
     "content_image_url",
     "content_pdf_file",
     "content_pdf_url",
+    "ContentToolRequest",
+    "ContentToolResult",
     "interpolate",
     "interpolate_file",
     "Provider",

--- a/chatlas/_auto.py
+++ b/chatlas/_auto.py
@@ -55,7 +55,7 @@ def ChatAuto(
     """
     Use environment variables (env vars) to configure the Chat provider and model.
 
-    Creates a `:class:~chatlas.Chat` instance based on the specified provider.
+    Creates a :class:`~chatlas.Chat` instance based on the specified provider.
     The provider may be specified through the `provider` parameter and/or the
     `CHATLAS_CHAT_PROVIDER` env var. If both are set, the env var takes
     precedence. Similarly, the provider's model may be specified through the

--- a/chatlas/_chat.py
+++ b/chatlas/_chat.py
@@ -391,7 +391,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         launch_browser: bool = True,
         bg_thread: Optional[bool] = None,
         echo: Optional[Literal["text", "all", "none"]] = None,
-        include: Literal["text", "all"] = "all",
+        content: Literal["text", "all"] = "all",
         kwargs: Optional[SubmitInputArgsT] = None,
     ):
         """
@@ -452,7 +452,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
                             user_input,
                             kwargs=kwargs,
                             echo=echo or "none",
-                            include=include,
+                            content=content,
                         )
                     )
                 else:
@@ -562,7 +562,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
             self._chat_impl(
                 turn,
                 echo=echo,
-                include="text",
+                content="text",
                 display=display,
                 stream=stream,
                 kwargs=kwargs,
@@ -613,7 +613,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
             self._chat_impl_async(
                 turn,
                 echo=echo,
-                include="text",
+                content="text",
                 display=display,
                 stream=stream,
                 kwargs=kwargs,
@@ -631,7 +631,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         self,
         *args: Content | str,
         echo: Literal["text", "all", "none"],
-        include: Literal["text"],
+        content: Literal["text"],
         kwargs: Optional[SubmitInputArgsT],
     ) -> Generator[str, None, None]: ...
 
@@ -640,7 +640,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         self,
         *args: Content | str,
         echo: Literal["text", "all", "none"],
-        include: Literal["all"],
+        content: Literal["all"],
         kwargs: Optional[SubmitInputArgsT],
     ) -> Generator[str | ContentToolRequest | ContentToolResult, None, None]: ...
 
@@ -648,7 +648,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         self,
         *args: Content | str,
         echo: Literal["text", "all", "none"] = "none",
-        include: Literal["text", "all"],
+        content: Literal["text", "all"],
         kwargs: Optional[SubmitInputArgsT] = None,
     ) -> Generator[str | ContentToolRequest | ContentToolResult, None, None]:
         """
@@ -682,7 +682,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
             stream=True,
             display=display,
             echo=echo,
-            include=include,
+            content=content,
             kwargs=kwargs,
         )
 
@@ -700,7 +700,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         self,
         *args: Content | str,
         echo: Literal["text", "all", "none"],
-        include: Literal["text"],
+        content: Literal["text"],
         kwargs: Optional[SubmitInputArgsT],
     ) -> AsyncGenerator[str, None]: ...
 
@@ -709,7 +709,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         self,
         *args: Content | str,
         echo: Literal["text", "all", "none"],
-        include: Literal["all"],
+        content: Literal["all"],
         kwargs: Optional[SubmitInputArgsT],
     ) -> AsyncGenerator[str | ContentToolRequest | ContentToolResult, None]: ...
 
@@ -717,7 +717,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         self,
         *args: Content | str,
         echo: Literal["text", "all", "none"] = "none",
-        include: Literal["text", "all"],
+        content: Literal["text", "all"],
         kwargs: Optional[SubmitInputArgsT] = None,
     ) -> AsyncGenerator[str | ContentToolRequest | ContentToolResult, None]:
         """
@@ -755,7 +755,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
                     stream=True,
                     display=display,
                     echo=echo,
-                    include=include,
+                    content=content,
                     kwargs=kwargs,
                 ):
                     yield chunk
@@ -970,7 +970,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         *,
         turns: Optional[Sequence[Turn]] = None,
         title: Optional[str] = None,
-        include: Literal["text", "all"] = "text",
+        content: Literal["text", "all"] = "text",
         include_system_prompt: bool = True,
         overwrite: bool = False,
     ):
@@ -1027,7 +1027,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
                 [
                     str(content).strip()
                     for content in turn.contents
-                    if include == "all" or isinstance(content, ContentText)
+                    if content == "all" or isinstance(content, ContentText)
                 ]
             )
             if is_html:
@@ -1092,7 +1092,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         self,
         user_turn: Turn,
         echo: Literal["text", "all", "none"],
-        include: Literal["text"],
+        content: Literal["text"],
         display: MarkdownDisplay,
         stream: bool,
         kwargs: Optional[SubmitInputArgsT] = None,
@@ -1103,7 +1103,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         self,
         user_turn: Turn,
         echo: Literal["text", "all", "none"],
-        include: Literal["all"],
+        content: Literal["all"],
         display: MarkdownDisplay,
         stream: bool,
         kwargs: Optional[SubmitInputArgsT] = None,
@@ -1113,7 +1113,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         self,
         user_turn: Turn,
         echo: Literal["text", "all", "none"],
-        include: Literal["text", "all"],
+        content: Literal["text", "all"],
         display: MarkdownDisplay,
         stream: bool,
         kwargs: Optional[SubmitInputArgsT] = None,
@@ -1136,10 +1136,10 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
             results: list[ContentToolResult] = []
             for x in turn.contents:
                 if isinstance(x, ContentToolRequest):
-                    if include == "all":
+                    if content == "all":
                         yield x
                     res = self._invoke_tool_request(x)
-                    if include == "all":
+                    if content == "all":
                         yield res
                     results.append(res)
 
@@ -1151,7 +1151,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         self,
         user_turn: Turn,
         echo: Literal["text", "all", "none"],
-        include: Literal["text"],
+        content: Literal["text"],
         display: MarkdownDisplay,
         stream: bool,
         kwargs: Optional[SubmitInputArgsT] = None,
@@ -1162,7 +1162,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         self,
         user_turn: Turn,
         echo: Literal["text", "all", "none"],
-        include: Literal["all"],
+        content: Literal["all"],
         display: MarkdownDisplay,
         stream: bool,
         kwargs: Optional[SubmitInputArgsT] = None,
@@ -1172,7 +1172,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         self,
         user_turn: Turn,
         echo: Literal["text", "all", "none"],
-        include: Literal["text", "all"],
+        content: Literal["text", "all"],
         display: MarkdownDisplay,
         stream: bool,
         kwargs: Optional[SubmitInputArgsT] = None,
@@ -1195,10 +1195,10 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
             results: list[ContentToolResult] = []
             for x in turn.contents:
                 if isinstance(x, ContentToolRequest):
-                    if include == "all":
+                    if content == "all":
                         yield x
                     res = await self._invoke_tool_request_async(x)
-                    if include == "all":
+                    if content == "all":
                         yield res
                     results.append(res)
 

--- a/chatlas/_chat.py
+++ b/chatlas/_chat.py
@@ -1200,6 +1200,8 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
                     res = await self._invoke_tool_async(x)
                     if content == "all":
                         yield res
+                    else:
+                        yield "\n\n"
                     results.append(res)
 
             if results:

--- a/chatlas/_chat.py
+++ b/chatlas/_chat.py
@@ -412,7 +412,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
             Whether to echo text content, all content (i.e., tool calls), or no
             content. Defaults to `"none"` when `stream=True` and `"text"` when
             `stream=False`.
-        include
+        content
             Whether to display text content or all content (i.e., tool calls).
         kwargs
             Additional keyword arguments to pass to the method used for requesting
@@ -661,7 +661,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         echo
             Whether to echo text content, all content (i.e., tool calls), or no
             content.
-        include
+        content
             Whether to yield just text content, or all content (i.e., tool calls).
         kwargs
             Additional keyword arguments to pass to the method used for requesting
@@ -730,7 +730,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         echo
             Whether to echo text content, all content (i.e., tool calls), or no
             content.
-        include
+        content
             Whether to yield just text content, or all content (i.e., tool calls).
         kwargs
             Additional keyword arguments to pass to the method used for requesting
@@ -989,7 +989,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
             A title to place at the top of the exported file.
         overwrite
             Whether to overwrite the file if it already exists.
-        include
+        content
             Whether to include text content, all content (i.e., tool calls), or no
             content.
         include_system_prompt
@@ -1025,9 +1025,9 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         for turn in turns:
             turn_content = "\n\n".join(
                 [
-                    str(content).strip()
-                    for content in turn.contents
-                    if content == "all" or isinstance(content, ContentText)
+                    str(x).strip()
+                    for x in turn.contents
+                    if content == "all" or isinstance(x, ContentText)
                 ]
             )
             if is_html:

--- a/chatlas/_chat.py
+++ b/chatlas/_chat.py
@@ -391,7 +391,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         launch_browser: bool = True,
         bg_thread: Optional[bool] = None,
         echo: Optional[Literal["text", "all", "none"]] = None,
-        include_tools: bool = True,
+        include: Literal["text", "all"] = "all",
         kwargs: Optional[SubmitInputArgsT] = None,
     ):
         """
@@ -412,8 +412,8 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
             Whether to echo text content, all content (i.e., tool calls), or no
             content. Defaults to `"none"` when `stream=True` and `"text"` when
             `stream=False`.
-        include_tools
-            Whether to display request/result information when tool calls occur.
+        include
+            Whether to display text content or all content (i.e., tool calls).
         kwargs
             Additional keyword arguments to pass to the method used for requesting
             the response.
@@ -452,7 +452,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
                             user_input,
                             kwargs=kwargs,
                             echo=echo or "none",
-                            include_tools=include_tools,
+                            include=include,
                         )
                     )
                 else:
@@ -562,7 +562,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
             self._chat_impl(
                 turn,
                 echo=echo,
-                include_tools=False,
+                include="text",
                 display=display,
                 stream=stream,
                 kwargs=kwargs,
@@ -613,7 +613,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
             self._chat_impl_async(
                 turn,
                 echo=echo,
-                include_tools=False,
+                include="text",
                 display=display,
                 stream=stream,
                 kwargs=kwargs,
@@ -631,7 +631,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         self,
         *args: Content | str,
         echo: Literal["text", "all", "none"],
-        include_tools: Literal[False],
+        include: Literal["text"],
         kwargs: Optional[SubmitInputArgsT],
     ) -> Generator[str, None, None]: ...
 
@@ -640,7 +640,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         self,
         *args: Content | str,
         echo: Literal["text", "all", "none"],
-        include_tools: Literal[True],
+        include: Literal["all"],
         kwargs: Optional[SubmitInputArgsT],
     ) -> Generator[str | ContentToolRequest | ContentToolResult, None, None]: ...
 
@@ -648,7 +648,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         self,
         *args: Content | str,
         echo: Literal["text", "all", "none"] = "none",
-        include_tools: bool = False,
+        include: Literal["text", "all"],
         kwargs: Optional[SubmitInputArgsT] = None,
     ) -> Generator[str | ContentToolRequest | ContentToolResult, None, None]:
         """
@@ -661,9 +661,8 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         echo
             Whether to echo text content, all content (i.e., tool calls), or no
             content.
-        include_tools
-            Whether to yield :class:`~chatlas.ContentToolRequest` and
-            :class:`~chatlas.ContentToolResult` objects when tool calls occur.
+        include
+            Whether to yield just text content, or all content (i.e., tool calls).
         kwargs
             Additional keyword arguments to pass to the method used for requesting
             the response.
@@ -683,7 +682,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
             stream=True,
             display=display,
             echo=echo,
-            include_tools=include_tools,
+            include=include,
             kwargs=kwargs,
         )
 
@@ -701,7 +700,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         self,
         *args: Content | str,
         echo: Literal["text", "all", "none"],
-        include_tools: Literal[False],
+        include: Literal["text"],
         kwargs: Optional[SubmitInputArgsT],
     ) -> AsyncGenerator[str, None]: ...
 
@@ -710,7 +709,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         self,
         *args: Content | str,
         echo: Literal["text", "all", "none"],
-        include_tools: Literal[True],
+        include: Literal["all"],
         kwargs: Optional[SubmitInputArgsT],
     ) -> AsyncGenerator[str | ContentToolRequest | ContentToolResult, None]: ...
 
@@ -718,7 +717,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         self,
         *args: Content | str,
         echo: Literal["text", "all", "none"] = "none",
-        include_tools: bool = False,
+        include: Literal["text", "all"],
         kwargs: Optional[SubmitInputArgsT] = None,
     ) -> AsyncGenerator[str | ContentToolRequest | ContentToolResult, None]:
         """
@@ -731,9 +730,8 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         echo
             Whether to echo text content, all content (i.e., tool calls), or no
             content.
-        include_tools
-            Whether to yield :class:`~chatlas.ContentToolRequest` and
-            :class:`~chatlas.ContentToolResult` objects when tool calls occur.
+        include
+            Whether to yield just text content, or all content (i.e., tool calls).
         kwargs
             Additional keyword arguments to pass to the method used for requesting
             the response.
@@ -757,7 +755,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
                     stream=True,
                     display=display,
                     echo=echo,
-                    include_tools=include_tools,
+                    include=include,
                     kwargs=kwargs,
                 ):
                     yield chunk
@@ -1094,7 +1092,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         self,
         user_turn: Turn,
         echo: Literal["text", "all", "none"],
-        include_tools: Literal[False],
+        include: Literal["text"],
         display: MarkdownDisplay,
         stream: bool,
         kwargs: Optional[SubmitInputArgsT] = None,
@@ -1105,7 +1103,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         self,
         user_turn: Turn,
         echo: Literal["text", "all", "none"],
-        include_tools: Literal[True],
+        include: Literal["all"],
         display: MarkdownDisplay,
         stream: bool,
         kwargs: Optional[SubmitInputArgsT] = None,
@@ -1115,7 +1113,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         self,
         user_turn: Turn,
         echo: Literal["text", "all", "none"],
-        include_tools: bool,
+        include: Literal["text", "all"],
         display: MarkdownDisplay,
         stream: bool,
         kwargs: Optional[SubmitInputArgsT] = None,
@@ -1138,10 +1136,10 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
             results: list[ContentToolResult] = []
             for x in turn.contents:
                 if isinstance(x, ContentToolRequest):
-                    if include_tools:
+                    if include == "all":
                         yield x
                     res = self._invoke_tool_request(x)
-                    if include_tools:
+                    if include == "all":
                         yield res
                     results.append(res)
 
@@ -1153,7 +1151,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         self,
         user_turn: Turn,
         echo: Literal["text", "all", "none"],
-        include_tools: Literal[False],
+        include: Literal["text"],
         display: MarkdownDisplay,
         stream: bool,
         kwargs: Optional[SubmitInputArgsT] = None,
@@ -1164,7 +1162,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         self,
         user_turn: Turn,
         echo: Literal["text", "all", "none"],
-        include_tools: Literal[True],
+        include: Literal["all"],
         display: MarkdownDisplay,
         stream: bool,
         kwargs: Optional[SubmitInputArgsT] = None,
@@ -1174,7 +1172,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         self,
         user_turn: Turn,
         echo: Literal["text", "all", "none"],
-        include_tools: bool,
+        include: Literal["text", "all"],
         display: MarkdownDisplay,
         stream: bool,
         kwargs: Optional[SubmitInputArgsT] = None,
@@ -1197,10 +1195,10 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
             results: list[ContentToolResult] = []
             for x in turn.contents:
                 if isinstance(x, ContentToolRequest):
-                    if include_tools:
+                    if include == "all":
                         yield x
                     res = await self._invoke_tool_request_async(x)
-                    if include_tools:
+                    if include == "all":
                         yield res
                     results.append(res)
 

--- a/chatlas/_chat.py
+++ b/chatlas/_chat.py
@@ -648,7 +648,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         self,
         *args: Content | str,
         echo: Literal["text", "all", "none"] = "none",
-        content: Literal["text", "all"],
+        content: Literal["text", "all"] = "text",
         kwargs: Optional[SubmitInputArgsT] = None,
     ) -> Generator[str | ContentToolRequest | ContentToolResult, None, None]:
         """
@@ -717,7 +717,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         self,
         *args: Content | str,
         echo: Literal["text", "all", "none"] = "none",
-        content: Literal["text", "all"],
+        content: Literal["text", "all"] = "text",
         kwargs: Optional[SubmitInputArgsT] = None,
     ) -> AsyncGenerator[str | ContentToolRequest | ContentToolResult, None]:
         """

--- a/chatlas/_chat.py
+++ b/chatlas/_chat.py
@@ -1369,11 +1369,16 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
                 result = func(arguments)
 
             if isinstance(result, ContentToolResult):
+                result.arguments = arguments
                 return result
-            return ContentToolResult(id=id_, value=result, error=None, name=name)
+            return ContentToolResult(
+                id=id_, value=result, error=None, name=name, arguments=arguments
+            )
         except Exception as e:
             log_tool_error(name, str(arguments), e)
-            return ContentToolResult(id=id_, value=None, error=str(e), name=name)
+            return ContentToolResult(
+                id=id_, value=None, error=str(e), name=name, arguments=arguments
+            )
 
     @staticmethod
     async def _invoke_tool_async(
@@ -1393,11 +1398,16 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
                 result = await func(arguments)
 
             if isinstance(result, ContentToolResult):
+                result.arguments = arguments
                 return result
-            return ContentToolResult(id=id_, value=result, error=None, name=name)
+            return ContentToolResult(
+                id=id_, value=result, error=None, name=name, arguments=arguments
+            )
         except Exception as e:
             log_tool_error(func.__name__, str(arguments), e)
-            return ContentToolResult(id=id_, value=None, error=str(e), name=name)
+            return ContentToolResult(
+                id=id_, value=None, error=str(e), name=name, arguments=arguments
+            )
 
     def _markdown_display(
         self, echo: Literal["text", "all", "none"]

--- a/chatlas/_content.py
+++ b/chatlas/_content.py
@@ -409,7 +409,7 @@ def create_content(data: dict[str, Any]) -> ContentUnion:
 
 
 TOOL_CSS = """
-.chatlas-tool-request:has(+ .chatlas-tool-result) {
+.chatlas-tool-request:has(~ .chatlas-tool-result) {
   display: none;
 }
 
@@ -427,11 +427,11 @@ TOOL_CSS = """
 .chatlas-tool-result summary::after {
   content: "◄";
   color: var(--bs-primary, #0066cc);
+  margin-left: 0.25rem;
 }
 
 .chatlas-tool-result[open] summary::after {
   content: "▼";
-  color: var(--bs-primary, #0066cc);
 }
 
 .chatlas-tool-result-content {

--- a/chatlas/_content.py
+++ b/chatlas/_content.py
@@ -313,7 +313,7 @@ class ContentToolResult(Content):
         if not self.error:
             header = f"View result from <code>{self.name}</code>"
         else:
-            header = f"❌ Falled to call tool <code>{self.name}</code>"
+            header = f"❌ Failed to call tool <code>{self.name}</code>"
 
         args = self._arguments_str()
         content = self._get_value(pretty=True)

--- a/chatlas/_content.py
+++ b/chatlas/_content.py
@@ -206,7 +206,7 @@ class ContentToolRequest(Content):
                 "but htmltools is not installed. ",
             )
 
-        html = f"<p class='chatlas-tool-request'>🔧 Running tool: <code>{self.name}</code></p>"
+        html = f"<p></p><span class='chatlas-tool-request'>🔧 Running tool: <code>{self.name}</code></span>"
 
         return TagList(
             HTML(html),
@@ -409,6 +409,10 @@ def create_content(data: dict[str, Any]) -> ContentUnion:
 
 
 TOOL_CSS = """
+.chatlas-tool-request + p:has(.markdown-stream-dot) {
+  display: inline;
+}
+
 .chatlas-tool-request, .chatlas-tool-result {
   font-weight: 300;
   font-size: 0.9rem;

--- a/chatlas/_content.py
+++ b/chatlas/_content.py
@@ -248,21 +248,23 @@ class ContentToolResult(Content):
 
     @property
     def id(self):
-        if self.request:
-            return self.request.id
-        return None
+        if not self.request:
+            raise ValueError("id is only available after the tool has been called")
+        return self.request.id
 
     @property
     def name(self):
-        if self.request:
-            return self.request.name
-        return None
+        if not self.request:
+            raise ValueError("name is only available after the tool has been called")
+        return self.request.name
 
     @property
     def arguments(self):
-        if self.request:
-            return self.request.arguments
-        return None
+        if not self.request:
+            raise ValueError(
+                "arguments is only available after the tool has been called"
+            )
+        return self.request.arguments
 
     def _get_value(self, pretty: bool = False) -> str:
         if self.error:

--- a/chatlas/_content.py
+++ b/chatlas/_content.py
@@ -289,7 +289,7 @@ class ContentToolResult(Content):
             )
 
         if not self.error:
-            header = f"✅ View <code>{self.name}</code> tool result"
+            header = f"View result from <code>{self.name}</code>"
         else:
             header = f"❌ Falled to call tool <code>{self.name}</code>"
 
@@ -301,8 +301,8 @@ class ContentToolResult(Content):
               <details class="chatlas-tool-result">
                   <summary>{header}</summary>
                   <div class="chatlas-tool-result-content">
-                      <b>Result:</b> <p><code>{content}</code></p>
-                      <b>Arguments:</b> <p><code>{args}</code></p>
+                      Result: <p><code>{content}</code></p>
+                      Arguments: <p><code>{args}</code></p>
                   </div>
               </details>
             """)
@@ -409,6 +409,11 @@ def create_content(data: dict[str, Any]) -> ContentUnion:
 
 
 TOOL_CSS = """
+.chatlas-tool-request, .chatlas-tool-result {
+  font-weight: 300;
+  font-size: 0.9rem;
+}
+
 .chatlas-tool-request:has(~ .chatlas-tool-result) {
   display: none;
 }
@@ -425,13 +430,14 @@ TOOL_CSS = """
 }
 
 .chatlas-tool-result summary::after {
-  content: "◄";
-  color: var(--bs-primary, #0066cc);
+  content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='currentColor' class='bi bi-caret-right-fill' viewBox='0 0 16 16'%3E%3Cpath d='m12.14 8.753-5.482 4.796c-.646.566-1.658.106-1.658-.753V3.204a1 1 0 0 1 1.659-.753l5.48 4.796a1 1 0 0 1 0 1.506z'/%3E%3C/svg%3E");
+  font-size: 1.15rem;
   margin-left: 0.25rem;
+  vertical-align: middle;
 }
 
 .chatlas-tool-result[open] summary::after {
-  content: "▼";
+  content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='currentColor' class='bi bi-caret-down-fill' viewBox='0 0 16 16'%3E%3Cpath d='M7.247 11.14 2.451 5.658C1.885 5.013 2.345 4 3.204 4h9.592a1 1 0 0 1 .753 1.659l-4.796 5.48a1 1 0 0 1-1.506 0z'/%3E%3C/svg%3E");
 }
 
 .chatlas-tool-result-content {

--- a/chatlas/_google.py
+++ b/chatlas/_google.py
@@ -492,9 +492,13 @@ class GoogleProvider(
                 if name:
                     contents.append(
                         ContentToolResult(
-                            id=function_response.get("id") or name,
                             value=function_response.get("response"),
-                            name=name,
+                            request=ContentToolRequest(
+                                id=function_response.get("id") or name,
+                                name=name,
+                                # TODO: how to get the arguments?
+                                arguments={},
+                            ),
                         )
                     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,8 @@ dev = [
     "snowflake-ml-python",
     # torch (a dependency of snowflake-ml-python) is not yet compatible with Python >3.11
     "torch;python_version<='3.11'",
-    "htmltools"
+    "htmltools",
+    "tenacity"
 ]
 docs = [
     "griffe>=1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dev = [
     "snowflake-ml-python",
     # torch (a dependency of snowflake-ml-python) is not yet compatible with Python >3.11
     "torch;python_version<='3.11'",
+    "htmltools"
 ]
 docs = [
     "griffe>=1",

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -2,9 +2,8 @@ import re
 import tempfile
 
 import pytest
-from pydantic import BaseModel
-
 from chatlas import ChatOpenAI, Turn
+from pydantic import BaseModel
 
 
 def test_simple_batch_chat():

--- a/tests/test_content_tools.py
+++ b/tests/test_content_tools.py
@@ -1,9 +1,8 @@
-from typing import Union, Any, Optional
+from typing import Any, Optional, Union
 
 import pytest
-
 from chatlas import ChatOpenAI
-from chatlas.types import ContentToolResult, ContentToolRequest
+from chatlas.types import ContentToolRequest, ContentToolResult
 
 
 def test_register_tool():
@@ -105,11 +104,11 @@ def test_invoke_tool_returns_tool_result():
 
     def tool():
         return 1
-    
+
     chat.register_tool(tool)
 
     def new_tool_request(
-        name: Optional[str] = "tool", 
+        name: Optional[str] = "tool",
         args: Optional[dict[str, Any]] = None,
     ):
         return ContentToolRequest(
@@ -131,10 +130,12 @@ def test_invoke_tool_returns_tool_result():
     assert "got an unexpected keyword argument" in str(res.error)
     assert res.value is None
 
-    res = chat._invoke_tool(new_tool_request(
-        name="foo",
-        args={"x": 1},
-    ))
+    res = chat._invoke_tool(
+        new_tool_request(
+            name="foo",
+            args={"x": 1},
+        )
+    )
     assert isinstance(res, ContentToolResult)
     assert res.id == "id"
     assert str(res.error) == "Unknown tool: foo"
@@ -147,7 +148,7 @@ async def test_invoke_tool_returns_tool_result_async():
 
     async def tool():
         return 1
-    
+
     chat.register_tool(tool)
 
     def new_tool_request(
@@ -166,19 +167,113 @@ async def test_invoke_tool_returns_tool_result_async():
     assert res.error is None
     assert res.value == 1
 
-    res = await chat._invoke_tool_async(
-        new_tool_request(args={"x": 1})
-    )
+    res = await chat._invoke_tool_async(new_tool_request(args={"x": 1}))
     assert isinstance(res, ContentToolResult)
     assert res.id == "id"
     assert res.error is not None
     assert "got an unexpected keyword argument" in str(res.error)
     assert res.value is None
 
-    res = await chat._invoke_tool_async(
-        new_tool_request(name="foo", args={"x": 1})
-    )
+    res = await chat._invoke_tool_async(new_tool_request(name="foo", args={"x": 1}))
     assert isinstance(res, ContentToolResult)
     assert res.id == "id"
     assert str(res.error) == "Unknown tool: foo"
     assert res.value is None
+
+
+def test_tool_custom_result():
+    chat = ChatOpenAI()
+
+    class CustomResult(ContentToolResult):
+        pass
+
+    def custom_tool():
+        return CustomResult(value=1, extra={"foo": "bar"})
+
+    def custom_tool_err():
+        return CustomResult(
+            value=None,
+            error=Exception("foo"),
+            extra={"foo": "bar"},
+        )
+
+    chat.register_tool(custom_tool)
+    chat.register_tool(custom_tool_err)
+
+    req = ContentToolRequest(
+        id="id",
+        name="custom_tool",
+        arguments={},
+    )
+    req_err = ContentToolRequest(
+        id="id",
+        name="custom_tool_err",
+        arguments={},
+    )
+
+    res = chat._invoke_tool(req)
+    assert isinstance(res, CustomResult)
+    assert res.id == "id"
+    assert res.error is None
+    assert res.value == 1
+    assert res.extra == {"foo": "bar"}
+    assert res.request == req
+
+    res_err = chat._invoke_tool(req_err)
+    assert isinstance(res_err, CustomResult)
+    assert res_err.id == "id"
+    assert res_err.error is not None
+    assert str(res_err.error) == "foo"
+    assert res_err.value is None
+    assert res_err.extra == {"foo": "bar"}
+    assert res_err.request == req_err
+
+
+@pytest.mark.asyncio
+async def test_tool_custom_result_async():
+    chat = ChatOpenAI()
+
+    class CustomResult(ContentToolResult):
+        pass
+
+    async def custom_tool():
+        return CustomResult(value=1, extra={"foo": "bar"})
+
+    async def custom_tool_err():
+        return CustomResult(
+            value=None,
+            error=Exception("foo"),
+            extra={"foo": "bar"},
+        )
+
+    chat.register_tool(custom_tool)
+    chat.register_tool(custom_tool_err)
+
+    req = ContentToolRequest(
+        id="id",
+        name="custom_tool",
+        arguments={},
+    )
+
+    req_err = ContentToolRequest(
+        id="id",
+        name="custom_tool_err",
+        arguments={},
+    )
+
+    res = await chat._invoke_tool_async(req)
+    assert isinstance(res, CustomResult)
+    assert res.id == "id"
+    assert res.error is None
+    assert res.value == 1
+    assert res.extra == {"foo": "bar"}
+    assert res.request == req
+
+    res_err = await chat._invoke_tool_async(req_err)
+    assert isinstance(res_err, CustomResult)
+    assert res_err.id == "id"
+    assert res_err.error is not None
+    assert str(res_err.error) == "foo"
+    assert res_err.value is None
+    assert res_err.extra == {"foo": "bar"}
+    assert res_err.request == req_err

--- a/tests/test_content_tools.py
+++ b/tests/test_content_tools.py
@@ -117,29 +117,42 @@ def test_invoke_tool_returns_tool_result():
             arguments=args or {},
         )
 
-    res = chat._invoke_tool(new_tool_request())
+    req1 = new_tool_request()
+    res = chat._invoke_tool(req1)
     assert isinstance(res, ContentToolResult)
     assert res.id == "id"
     assert res.error is None
     assert res.value == 1
+    assert res.request == req1
+    assert res.id == req1.id
+    assert res.name == req1.name
+    assert res.arguments == req1.arguments
 
-    res = chat._invoke_tool(new_tool_request(args={"x": 1}))
+    req2 = new_tool_request(args={"x": 1})
+    res = chat._invoke_tool(req2)
     assert isinstance(res, ContentToolResult)
     assert res.id == "id"
     assert res.error is not None
     assert "got an unexpected keyword argument" in str(res.error)
     assert res.value is None
+    assert res.request == req2
+    assert res.id == req2.id
+    assert res.name == req2.name
+    assert res.arguments == req2.arguments
 
-    res = chat._invoke_tool(
-        new_tool_request(
-            name="foo",
-            args={"x": 1},
-        )
+    req3 = new_tool_request(
+        name="foo",
+        args={"x": 1},
     )
+    res = chat._invoke_tool(req3)
     assert isinstance(res, ContentToolResult)
     assert res.id == "id"
     assert str(res.error) == "Unknown tool: foo"
     assert res.value is None
+    assert res.request == req3
+    assert res.id == req3.id
+    assert res.name == req3.name
+    assert res.arguments == req3.arguments
 
 
 @pytest.mark.asyncio
@@ -161,24 +174,42 @@ async def test_invoke_tool_returns_tool_result_async():
             arguments=args or {},
         )
 
-    res = await chat._invoke_tool_async(new_tool_request())
+    req1 = new_tool_request()
+    res = await chat._invoke_tool_async(req1)
     assert isinstance(res, ContentToolResult)
     assert res.id == "id"
     assert res.error is None
     assert res.value == 1
+    assert res.request == req1
+    assert res.id == req1.id
+    assert res.name == req1.name
+    assert res.arguments == req1.arguments
 
-    res = await chat._invoke_tool_async(new_tool_request(args={"x": 1}))
+    req2 = new_tool_request(args={"x": 1})
+    res = await chat._invoke_tool_async(req2)
     assert isinstance(res, ContentToolResult)
     assert res.id == "id"
     assert res.error is not None
     assert "got an unexpected keyword argument" in str(res.error)
     assert res.value is None
+    assert res.request == req2
+    assert res.id == req2.id
+    assert res.name == req2.name
+    assert res.arguments == req2.arguments
 
-    res = await chat._invoke_tool_async(new_tool_request(name="foo", args={"x": 1}))
+    req3 = new_tool_request(
+        name="foo",
+        args={"x": 1},
+    )
+    res = await chat._invoke_tool_async(req3)
     assert isinstance(res, ContentToolResult)
     assert res.id == "id"
     assert str(res.error) == "Unknown tool: foo"
     assert res.value is None
+    assert res.request == req3
+    assert res.id == req3.id
+    assert res.name == req3.name
+    assert res.arguments == req3.arguments
 
 
 def test_tool_custom_result():
@@ -218,6 +249,9 @@ def test_tool_custom_result():
     assert res.value == 1
     assert res.extra == {"foo": "bar"}
     assert res.request == req
+    assert res.id == req.id
+    assert res.name == req.name
+    assert res.arguments == req.arguments
 
     res_err = chat._invoke_tool(req_err)
     assert isinstance(res_err, CustomResult)
@@ -227,6 +261,9 @@ def test_tool_custom_result():
     assert res_err.value is None
     assert res_err.extra == {"foo": "bar"}
     assert res_err.request == req_err
+    assert res_err.id == req_err.id
+    assert res_err.name == req_err.name
+    assert res_err.arguments == req_err.arguments
 
 
 @pytest.mark.asyncio
@@ -268,6 +305,9 @@ async def test_tool_custom_result_async():
     assert res.value == 1
     assert res.extra == {"foo": "bar"}
     assert res.request == req
+    assert res.id == req.id
+    assert res.name == req.name
+    assert res.arguments == req.arguments
 
     res_err = await chat._invoke_tool_async(req_err)
     assert isinstance(res_err, CustomResult)
@@ -277,3 +317,6 @@ async def test_tool_custom_result_async():
     assert res_err.value is None
     assert res_err.extra == {"foo": "bar"}
     assert res_err.request == req_err
+    assert res_err.id == req_err.id
+    assert res_err.name == req_err.name
+    assert res_err.arguments == req_err.arguments

--- a/tests/test_provider_anthropic.py
+++ b/tests/test_provider_anthropic.py
@@ -1,5 +1,4 @@
 import pytest
-
 from chatlas import ChatAnthropic
 
 from .conftest import (
@@ -11,6 +10,7 @@ from .conftest import (
     assert_tools_parallel,
     assert_tools_sequential,
     assert_tools_simple,
+    assert_tools_simple_stream_content,
     assert_turns_existing,
     assert_turns_system,
     retryassert,
@@ -57,6 +57,8 @@ def test_anthropic_tool_variations():
         assert_tools_simple(chat_fun)
 
     retryassert(run_simpleassert, retries=5)
+
+    assert_tools_simple_stream_content(chat_fun)
 
     def run_parallelassert():
         # For some reason, at the time of writing, Claude 3.7 doesn't

--- a/tests/test_provider_google.py
+++ b/tests/test_provider_google.py
@@ -2,17 +2,16 @@ import os
 import time
 
 import pytest
-
 from chatlas import ChatGoogle
 
 from .conftest import (
     assert_data_extraction,
     assert_images_inline,
     assert_images_remote_error,
-    assert_pdf_local,
     assert_tools_parallel,
     assert_tools_sequential,
     assert_tools_simple,
+    assert_tools_simple_stream_content,
     assert_turns_existing,
     assert_turns_system,
 )
@@ -59,6 +58,8 @@ def test_google_tool_variations():
     time.sleep(3)
     assert_tools_simple(chat_fun)
     time.sleep(3)
+    assert_tools_simple_stream_content(chat_fun)
+    time.sleep(3)
     assert_tools_parallel(chat_fun)
     time.sleep(3)
     assert_tools_sequential(
@@ -88,8 +89,9 @@ def test_google_images():
     assert_images_remote_error(chat_fun)
 
 
-def test_google_pdfs():
-    chat_fun = ChatGoogle
-
-    time.sleep(20)
-    assert_pdf_local(chat_fun)
+# TODO: figure out a way to workaround the rate limits for this test
+# def test_google_pdfs():
+#    chat_fun = ChatGoogle
+#
+#    time.sleep(20)
+#    assert_pdf_local(chat_fun)

--- a/tests/test_provider_openai.py
+++ b/tests/test_provider_openai.py
@@ -1,5 +1,4 @@
 import pytest
-
 from chatlas import ChatOpenAI
 
 from .conftest import (
@@ -11,6 +10,7 @@ from .conftest import (
     assert_tools_parallel,
     assert_tools_sequential,
     assert_tools_simple,
+    assert_tools_simple_stream_content,
     assert_turns_existing,
     assert_turns_system,
 )
@@ -53,6 +53,7 @@ def test_openai_respects_turns_interface():
 def test_openai_tool_variations():
     chat_fun = ChatOpenAI
     assert_tools_simple(chat_fun)
+    assert_tools_simple_stream_content(chat_fun)
     assert_tools_parallel(chat_fun)
     assert_tools_sequential(chat_fun, total_calls=6)
 


### PR DESCRIPTION
This PR does 3 things:

1. Adds a `content` argument to `.stream()`. For now, it defaults to `"text"`, but when `"all"`,  `ContentToolRequest()`/`ContentToolResult()` are yielded in the stream when tool request/results occur.
2. Adds a `.tagify()` method to `ContentToolRequest()`/`ContentToolResult()` so they automatically display themselves sensibly in shiny
    * The latest (dev) version of Shiny is required for this to work
3. Allow an instance of `ContentToolResult` to be returned by a tool call.
    * This way, developers can subclass `ContentToolResult` and provide their own `.tagify()` method to customize the tool call UI.
