### PR TITLE
feat(Chat): Add new `.current_display` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `ContentToolRequest` and `ContentToolResponse` are now exported to `chatlas` namespace. (#75)
 * `ContentToolRequest` and `ContentToolResponse` now have `.tagify()` methods, making it so they can render automatically in a Shiny chatbot. (#75)
 * `ContentToolResult` instances can be returned from tools. This allows for custom rendering of the tool result. (#75)
+* `Chat` gains a new `.current_display` property. When a `.chat()` or `.stream()` is currently active, this property returns an object with a `.append()` method (to add new content). This is primarily useful for displaying custom content during a tool call. (#79)
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `ContentToolRequest` and `ContentToolResponse` are now exported to `chatlas` namespace. (#75)
 * `ContentToolRequest` and `ContentToolResponse` now have `.tagify()` methods, making it so they can render automatically in a Shiny chatbot. (#75)
 * `ContentToolResult` instances can be returned from tools. This allows for custom rendering of the tool result. (#75)
-* `Chat` gains a new `.current_display` property. When a `.chat()` or `.stream()` is currently active, this property returns an object with a `.append()` method (to add new content). This is primarily useful for displaying custom content during a tool call. (#79)
+* `Chat` gains a new `.current_display` property. When a `.chat()` or `.stream()` is currently active, this property returns an object with a `.echo()` method (to echo new content to the display). This is primarily useful for displaying custom content during a tool call. (#79)
 
 ### Changes
 

--- a/chatlas/_chat.py
+++ b/chatlas/_chat.py
@@ -1006,7 +1006,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         """
         return self._current_display
 
-    def _update_display(self, x: str):
+    def _echo_content(self, x: str):
         if self.current_display is None:
             return
         self.current_display.append(x)
@@ -1180,12 +1180,12 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
             for x in turn.contents:
                 if isinstance(x, ContentToolRequest):
                     if echo == "output":
-                        self._update_display(f"\n\n{x}\n\n")
+                        self._echo_content(f"\n\n{x}\n\n")
                     if content == "all":
                         yield x
                     res = self._invoke_tool(x)
                     if echo == "output":
-                        self._update_display(f"\n\n{res}\n\n")
+                        self._echo_content(f"\n\n{res}\n\n")
                     if content == "all":
                         yield res
                     results.append(res)
@@ -1239,12 +1239,12 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
             for x in turn.contents:
                 if isinstance(x, ContentToolRequest):
                     if echo == "output":
-                        self._update_display(f"\n\n{x}\n\n")
+                        self._echo_content(f"\n\n{x}\n\n")
                     if content == "all":
                         yield x
                     res = await self._invoke_tool_async(x)
                     if echo == "output":
-                        self._update_display(f"\n\n{res}\n\n")
+                        self._echo_content(f"\n\n{res}\n\n")
                     if content == "all":
                         yield res
                     else:
@@ -1266,7 +1266,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
             raise ValueError("Cannot use async tools in a synchronous chat")
 
         def emit(text: str | Content):
-            self._update_display(str(text))
+            self._echo_content(str(text))
 
         emit("<br>\n\n")
 
@@ -1328,7 +1328,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         kwargs: Optional[SubmitInputArgsT] = None,
     ) -> AsyncGenerator[str, None]:
         def emit(text: str | Content):
-            self._update_display(str(text))
+            self._echo_content(str(text))
 
         emit("<br>\n\n")
 
@@ -1404,7 +1404,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
             return result
         except Exception as e:
             log_tool_error(x.name, str(args), e)
-            self._update_display(f"\n\n{e}\n\n")
+            self._echo_content(f"\n\n{e}\n\n")
             return ContentToolResult(value=None, error=e, request=x)
 
     async def _invoke_tool_async(self, x: ContentToolRequest) -> ContentToolResult:

--- a/chatlas/_chat.py
+++ b/chatlas/_chat.py
@@ -1034,9 +1034,8 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         return self._current_display
 
     def _echo_content(self, x: str):
-        if self.current_display is None:
-            return
-        self.current_display.echo(x)
+        if self._current_display:
+            self._current_display.echo(x)
 
     def export(
         self,

--- a/chatlas/_chat.py
+++ b/chatlas/_chat.py
@@ -1008,7 +1008,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
 
     def _update_display(self, x: str):
         if self.current_display is None:
-            raise ValueError("No display context is active. Please report this issue.")
+            return
         self.current_display.append(x)
 
     def export(

--- a/chatlas/_chat.py
+++ b/chatlas/_chat.py
@@ -1009,7 +1009,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
     def _echo_content(self, x: str):
         if self.current_display is None:
             return
-        self.current_display.append(x)
+        self.current_display.echo(x)
 
     def export(
         self,
@@ -1672,4 +1672,4 @@ class ChatMarkdownDisplay:
         return result
 
     def append(self, content):
-        return self._display.append(content)
+        return self._display.echo(content)

--- a/chatlas/_chat.py
+++ b/chatlas/_chat.py
@@ -1009,7 +1009,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
     def _update_display(self, x: str):
         if self.current_display is None:
             raise ValueError("No display context is active. Please report this issue.")
-        self.current_display.update(x)
+        self.current_display.append(x)
 
     def export(
         self,
@@ -1671,5 +1671,5 @@ class ChatMarkdownDisplay:
         self._chat._current_display = None
         return result
 
-    def update(self, content):
-        return self._display.update(content)
+    def append(self, content):
+        return self._display.append(content)

--- a/chatlas/_chat.py
+++ b/chatlas/_chat.py
@@ -999,6 +999,33 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         display while the chat is running, but currently blocked by something
         like a tool call.
 
+        Example
+        -------
+        ```python
+        import requests
+        from chatlas import ChatOpenAI
+
+        chat = ChatOpenAI()
+
+
+        def get_current_weather(latitude: float, longitude: float):
+            "Get the current weather given a latitude and longitude."
+
+            lat_lng = f"latitude={latitude}&longitude={longitude}"
+            url = f"https://api.open-meteo.com/v1/forecast?{lat_lng}&current=temperature_2m,wind_speed_10m&hourly=temperature_2m,relative_humidity_2m,wind_speed_10m"
+            response = requests.get(url)
+            json = response.json()
+            if chat.current_display:
+                chat.current_display.echo("My custom tool display!!!")
+            return json["current"]
+
+
+        chat.register_tool(get_current_weather)
+
+        chat.chat("What's the current temperature in Duluth, MN?", echo="text")
+        ```
+
+
         Returns
         -------
         Optional[MarkdownDisplay]

--- a/chatlas/_display.py
+++ b/chatlas/_display.py
@@ -13,7 +13,7 @@ from ._typing_extensions import TypedDict
 
 class MarkdownDisplay(ABC):
     @abstractmethod
-    def update(self, content: str):
+    def append(self, content: str):
         pass
 
     @abstractmethod
@@ -26,7 +26,7 @@ class MarkdownDisplay(ABC):
 
 
 class MockMarkdownDisplay(MarkdownDisplay):
-    def update(self, content: str):
+    def append(self, content: str):
         pass
 
     def __enter__(self):
@@ -63,7 +63,7 @@ class LiveMarkdownDisplay(MarkdownDisplay):
 
         self._markdown_options = echo_options["rich_markdown"]
 
-    def update(self, content: str):
+    def append(self, content: str):
         from rich.markdown import Markdown
 
         self.content += content
@@ -102,7 +102,7 @@ class IPyMarkdownDisplay(MarkdownDisplay):
         self.content: str = ""
         self._css_styles = echo_options["css_styles"]
 
-    def update(self, content: str):
+    def append(self, content: str):
         from IPython.display import Markdown, update_display
 
         self.content += content

--- a/chatlas/_display.py
+++ b/chatlas/_display.py
@@ -12,8 +12,14 @@ from ._typing_extensions import TypedDict
 
 
 class MarkdownDisplay(ABC):
+    """Base class for displaying markdown content in different environments."""
+
     @abstractmethod
-    def append(self, content: str):
+    def echo(self, content: str):
+        """
+        Display the provided markdown string. This will append the content
+        to the current display.
+        """
         pass
 
     @abstractmethod
@@ -26,7 +32,7 @@ class MarkdownDisplay(ABC):
 
 
 class MockMarkdownDisplay(MarkdownDisplay):
-    def append(self, content: str):
+    def echo(self, content: str):
         pass
 
     def __enter__(self):
@@ -63,7 +69,7 @@ class LiveMarkdownDisplay(MarkdownDisplay):
 
         self._markdown_options = echo_options["rich_markdown"]
 
-    def append(self, content: str):
+    def echo(self, content: str):
         from rich.markdown import Markdown
 
         self.content += content
@@ -102,7 +108,7 @@ class IPyMarkdownDisplay(MarkdownDisplay):
         self.content: str = ""
         self._css_styles = echo_options["css_styles"]
 
-    def append(self, content: str):
+    def echo(self, content: str):
         from IPython.display import Markdown, update_display
 
         self.content += content


### PR DESCRIPTION
This new property makes it possible to echo ephemeral content to the current display (i.e., the live rich console or IPython display). This is primarily useful for displaying content (that doesn't need to be stored in the message history) to the user during tool calls. 

For example:

```python
import requests
from chatlas import ChatOpenAI

chat = ChatOpenAI()

def get_current_weather(latitude: float, longitude: float):
    """Get the current weather given a latitude and longitude."""

    lat_lng = f"latitude={latitude}&longitude={longitude}"
    url = f"https://api.open-meteo.com/v1/forecast?{lat_lng}&current=temperature_2m,wind_speed_10m&hourly=temperature_2m,relative_humidity_2m,wind_speed_10m"
    response = requests.get(url)
    json = response.json()
    if chat.current_display:
        chat.current_display.echo("My custom tool display!!!")
    return json["current"]

chat.register_tool(get_current_weather)

chat.chat("What's the current temperature in Duluth, MN?", echo="text")
```

```
My custom tool display!!!                                                                                         

The current temperature in Duluth, MN is 3.7°C.    
```