### PR TITLE
fix(ChatSnowflake): pass session along to `complete()` call

### DIFF
--- a/chatlas/_snowflake.py
+++ b/chatlas/_snowflake.py
@@ -277,6 +277,7 @@ class SnowflakeProvider(Provider["Completion", "CompletionChunk", "CompletionChu
             "stream": stream,
             "prompt": self._as_prompt_input(turns),
             "model": self._model,
+            "session": self._session,
             **(kwargs or {}),
         }
 


### PR DESCRIPTION
This PR fixes an issue where submitting the input in this Shiny app:

```python
from shiny.express import ui

from chatlas import ChatSnowflake

chat_client = ChatSnowflake(
    connection_name="posit",
)

chat = ui.Chat(id="chat")
chat.ui()
chat.update_user_input(value="Tell me a story")

@chat.on_user_submit
async def handle_user_input(user_input: str):
    response = await chat_client.stream_async(user_input)
    await chat.append_message_stream(response)
```

Would result an error of:

```python
shiny.types.NotifyException: Error in Chat('chat'): (1409): More than one active session is detected. When you call function 'udf' or use decorator '@udf', you must specify the 'session' parameter if you created multiple sessions.Alternatively, you can use 'session.udf.register' to register UDFs
```
