### PR TITLE
Add openai as a hard dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 -->
 
+## [UNRELEASED]
+
+* Added `openai` as a hard dependency, making installation easier for a wide range of use cases. (#91) 
+
 ## [0.7.0] - 2025-04-22
 
 ### New features

--- a/chatlas/_databricks.py
+++ b/chatlas/_databricks.py
@@ -111,17 +111,11 @@ class DatabricksProvider(OpenAIProvider):
         except ImportError:
             raise ImportError(
                 "`ChatDatabricks()` requires the `databricks-sdk` package. "
-                "Install it with `pip install databricks-sdk[openai]`."
+                "Install it with `pip install databricks-sdk`."
             )
 
-        try:
-            import httpx
-            from openai import AsyncOpenAI
-        except ImportError:
-            raise ImportError(
-                "`ChatDatabricks()` requires the `openai` package. "
-                "Install it with `pip install openai`."
-            )
+        import httpx
+        from openai import AsyncOpenAI
 
         self._model = model
         self._seed = None

--- a/chatlas/_github.py
+++ b/chatlas/_github.py
@@ -40,12 +40,6 @@ def ChatGithub(
     You may need to apply for and be accepted into a beta access program.
     :::
 
-    ::: {.callout-note}
-    ## Python requirements
-
-    `ChatGithub` requires the `openai` package: `pip install "chatlas[github]"`.
-    :::
-
 
     Examples
     --------

--- a/chatlas/_google.py
+++ b/chatlas/_google.py
@@ -291,7 +291,8 @@ class GoogleProvider(
                 GoogleTool(
                     function_declarations=[
                         FunctionDeclaration.from_callable(
-                            client=self._client, callable=tool.func
+                            client=self._client._api_client,
+                            callable=tool.func,
                         )
                         for tool in tools.values()
                     ]

--- a/chatlas/_groq.py
+++ b/chatlas/_groq.py
@@ -38,12 +38,6 @@ def ChatGroq(
     Sign up at <https://groq.com> to get an API key.
     :::
 
-    ::: {.callout-note}
-    ## Python requirements
-
-    `ChatGroq` requires the `openai` package: `pip install "chatlas[groq]"`.
-    :::
-
     Examples
     --------
 

--- a/chatlas/_ollama.py
+++ b/chatlas/_ollama.py
@@ -49,12 +49,6 @@ def ChatOllama(
     (e.g. `ollama pull llama3.2`).
     :::
 
-    ::: {.callout-note}
-    ## Python requirements
-
-    `ChatOllama` requires the `openai` package: `pip install "chatlas[ollama]"`.
-    :::
-
 
     Examples
     --------

--- a/chatlas/_openai.py
+++ b/chatlas/_openai.py
@@ -78,12 +78,6 @@ def ChatOpenAI(
     account that will give you an API key that you can use with this package.
     :::
 
-    ::: {.callout-note}
-    ## Python requirements
-
-    `ChatOpenAI` requires the `openai` package: `pip install "chatlas[openai]"`.
-    :::
-
     Examples
     --------
     ```python
@@ -194,13 +188,7 @@ class OpenAIProvider(Provider[ChatCompletion, ChatCompletionChunk, ChatCompletio
         seed: Optional[int] = None,
         kwargs: Optional["ChatClientArgs"] = None,
     ):
-        try:
-            from openai import AsyncOpenAI, OpenAI
-        except ImportError:
-            raise ImportError(
-                "`ChatOpenAI()` requires the `openai` package. "
-                "Install it with `pip install openai`."
-            )
+        from openai import AsyncOpenAI, OpenAI
 
         self._model = model
         self._seed = seed
@@ -433,7 +421,9 @@ class OpenAIProvider(Provider[ChatCompletion, ChatCompletionChunk, ChatCompletio
                                 "id": x.id,
                                 "function": {
                                     "name": x.name,
-                                    "arguments": orjson.dumps(x.arguments).decode("utf-8"),
+                                    "arguments": orjson.dumps(x.arguments).decode(
+                                        "utf-8"
+                                    ),
                                 },
                                 "type": "function",
                             }
@@ -602,16 +592,6 @@ def ChatAzureOpenAI(
     hosts a number of open source models as well as proprietary models
     from OpenAI.
 
-    Prerequisites
-    -------------
-
-    ::: {.callout-note}
-    ## Python requirements
-
-    `ChatAzureOpenAI` requires the `openai` package:
-    `pip install "chatlas[azure-openai]"`.
-    :::
-
     Examples
     --------
     ```python
@@ -693,13 +673,7 @@ class OpenAIAzureProvider(OpenAIProvider):
         seed: int | None = None,
         kwargs: Optional["ChatAzureClientArgs"] = None,
     ):
-        try:
-            from openai import AsyncAzureOpenAI, AzureOpenAI
-        except ImportError:
-            raise ImportError(
-                "`ChatAzureOpenAI()` requires the `openai` package. "
-                "Install it with `pip install openai`."
-            )
+        from openai import AsyncAzureOpenAI, AzureOpenAI
 
         self._model = deployment_id
         self._seed = seed

--- a/chatlas/_perplexity.py
+++ b/chatlas/_perplexity.py
@@ -40,12 +40,6 @@ def ChatPerplexity(
     Sign up at <https://www.perplexity.ai> to get an API key.
     :::
 
-    ::: {.callout-note}
-    ## Python requirements
-
-    `ChatPerplexity` requires the `openai` package: `pip install "chatlas[perplexity]"`.
-    :::
-
 
     Examples
     --------

--- a/chatlas/types/anthropic/_submit.py
+++ b/chatlas/types/anthropic/_submit.py
@@ -17,6 +17,7 @@ import anthropic.types.tool_choice_none_param
 import anthropic.types.tool_choice_tool_param
 import anthropic.types.tool_param
 import anthropic.types.tool_text_editor_20250124_param
+import anthropic.types.web_search_tool_20250305_param
 
 
 class SubmitInputArgs(TypedDict, total=False):
@@ -66,6 +67,7 @@ class SubmitInputArgs(TypedDict, total=False):
                 anthropic.types.tool_param.ToolParam,
                 anthropic.types.tool_bash_20250124_param.ToolBash20250124Param,
                 anthropic.types.tool_text_editor_20250124_param.ToolTextEditor20250124Param,
+                anthropic.types.web_search_tool_20250305_param.WebSearchTool20250305Param,
             ]
         ],
         anthropic.NotGiven,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,8 @@ docs = [
 anthropic = ["anthropic"]
 bedrock-anthropic = ["anthropic[bedrock]"]
 databricks = ["databricks-sdk"]
+# Intentionally empty since these providers used to require 
+# an additional openai install, but that's now included 
 github = []
 google = ["google-genai"]
 groq = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
   "jinja2",
   "orjson",
   "rich",
+  "openai"
 ]
 classifiers = [
   "Development Status :: 4 - Beta",
@@ -76,14 +77,14 @@ docs = [
 # Provider extras ----
 anthropic = ["anthropic"]
 bedrock-anthropic = ["anthropic[bedrock]"]
-databricks = ["databricks-sdk[openai]"]
-github = ["openai"]
+databricks = ["databricks-sdk"]
+github = []
 google = ["google-genai"]
-groq = ["openai"]
-ollama = ["openai"]
-openai = ["openai"]
-azure-openai = ["openai"]
-perplexity = ["openai"]
+groq = []
+ollama = []
+openai = []
+azure-openai = []
+perplexity = []
 snowflake = ["snowflake-ml-python"]
 vertex = ["google-genai"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dev = [
     "shiny",
     "openai",
     "anthropic[bedrock]",
-    "google-genai>=1.2.0",
+    "google-genai>=1.14.0",
     "numpy>1.24.4",
     "tiktoken",
     "databricks-sdk",
@@ -81,14 +81,14 @@ databricks = ["databricks-sdk"]
 # Intentionally empty since these providers used to require 
 # an additional openai install, but that's now included 
 github = []
-google = ["google-genai"]
+google = ["google-genai>=1.14.0"]
 groq = []
 ollama = []
 openai = []
 azure-openai = []
 perplexity = []
 snowflake = ["snowflake-ml-python"]
-vertex = ["google-genai"]
+vertex = ["google-genai>=1.14.0"]
 
 [tool.uv]
 dev-dependencies = [

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -30,11 +30,12 @@ def test_simple_streaming_chat():
     chunks = [chunk for chunk in res]
     assert len(chunks) > 2
     result = "".join(chunks)
-    rainbow_re = "^red *\norange *\nyellow *\ngreen *\nblue *\nindigo *\nviolet *\n?$"
-    assert re.match(rainbow_re, result.lower())
+    res = re.sub(r"\s+", "", result).lower()
+    assert res == "redorangeyellowgreenblueindigoviolet"
     turn = chat.get_last_turn()
     assert turn is not None
-    assert re.match(rainbow_re, turn.text.lower())
+    res = re.sub(r"\s+", "", turn.text).lower()
+    assert res == "redorangeyellowgreenblueindigoviolet"
 
 
 @pytest.mark.asyncio

--- a/tests/test_provider_databricks.py
+++ b/tests/test_provider_databricks.py
@@ -3,6 +3,11 @@ from chatlas import ChatDatabricks
 
 from .conftest import assert_data_extraction, assert_turns_existing, assert_turns_system
 
+pytest.skip(
+    "(Temporarily) skipping Databricks tests (access has been revoked for some reason)",
+    allow_module_level=True,
+)
+
 
 def test_openai_simple_request():
     chat = ChatDatabricks(


### PR DESCRIPTION
Adds `openai` as a hard dependency so that a handful of chat providers can be used without an additional install. This also helps avoid a confusing install error when tools are used.

Closes #22