### PR TITLE
Rename `.stream()`/`.stream_async()`'s `content` parameter to `stream`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `ChatSnowflake()` now supports tool calling. (#98)
 * `Chat` instances can now be deep copied, which is useful for forking the chat session. (#96)
 
+### Breaking changes
+
+* The `.stream()`/`.stream_async()` method's `content` parameter was renamed to `stream`. Set `stream` to `"content"` to gain access to tool request/result content objects. ()
+
 ### Changes
 
 * `ChatDatabricks()`'s `model` now defaults to `databricks-claude-3-7-sonnet` instead of `databricks-dbrx-instruct`. (#95)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking changes
 
-* The `.stream()`/`.stream_async()` method's `content` parameter was renamed to `stream`. Set `stream` to `"content"` to gain access to tool request/result content objects. ()
+* The `.stream()`/`.stream_async()` method's `content` parameter was renamed to `stream`. Set `stream` to `"content"` to gain access to tool request/result content objects. (#102)
 
 ### Changes
 

--- a/chatlas/_chat.py
+++ b/chatlas/_chat.py
@@ -418,9 +418,12 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
             Whether to run the app in a background thread. If `None`, the app will
             run in a background thread if the current environment is a notebook.
         echo
-            Whether to echo text content, all content (i.e., tool calls), or no
-            content. Defaults to `"none"` when `stream=True` and `"text"` when
-            `stream=False`.
+            One of the following (defaults to `"none"` when `stream=True` and `"text"` when
+            `stream=False`):
+              - `"text"`: Echo just the text content of the response.
+              - `"output"`: Echo text and tool call content.
+              - `"all"`: Echo both the assistant and user turn.
+              - `"none"`: Do not echo any content.
         content
             Whether to display text content or all content (i.e., tool calls).
         kwargs
@@ -508,8 +511,11 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         Parameters
         ----------
         echo
-            Whether to echo text content, all content (i.e., tool calls), or no
-            content.
+            One of the following (default is "output"):
+              - `"text"`: Echo just the text content of the response.
+              - `"output"`: Echo text and tool call content.
+              - `"all"`: Echo both the assistant and user turn.
+              - `"none"`: Do not echo any content.
         stream
             Whether to stream the response (i.e., have the response appear in chunks).
         kwargs
@@ -546,8 +552,11 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         args
             The user input(s) to generate a response from.
         echo
-            Whether to echo text content, all content (i.e., tool calls), or no
-            content.
+            One of the following (default is "output"):
+              - `"text"`: Echo just the text content of the response.
+              - `"output"`: Echo text and tool call content.
+              - `"all"`: Echo both the assistant and user turn.
+              - `"none"`: Do not echo any content.
         stream
             Whether to stream the response (i.e., have the response appear in
             chunks).
@@ -596,8 +605,11 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         args
             The user input(s) to generate a response from.
         echo
-            Whether to echo text content, all content (i.e., tool calls, images,
-            etc), or no content.
+            One of the following (default is "output"):
+              - `"text"`: Echo just the text content of the response.
+              - `"output"`: Echo text and tool call content.
+              - `"all"`: Echo both the assistant and user turn.
+              - `"none"`: Do not echo any content.
         stream
             Whether to stream the response (i.e., have the response appear in
             chunks).
@@ -664,11 +676,14 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         args
             The user input(s) to generate a response from.
         echo
-            Whether to echo text content, all content (i.e., tool calls), or no
-            content.
-        content
-            Whether to yield just text content, or rich content objects (e.g., tool
-            calls) when relevant.
+            One of the following (default is "none"):
+              - `"text"`: Echo just the text content of the response.
+              - `"output"`: Echo text and tool call content.
+              - `"all"`: Echo both the assistant and user turn.
+              - `"none"`: Do not echo any content.
+        stream
+            Whether to yield just text content or include rich content objects
+            (e.g., tool calls) when relevant.
         kwargs
             Additional keyword arguments to pass to the method used for requesting
             the response.
@@ -733,10 +748,14 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         args
             The user input(s) to generate a response from.
         echo
-            Whether to echo text content, all content (i.e., tool calls), or no
-            content.
-        content
-            Whether to yield just text content, or all content (i.e., tool calls).
+            One of the following (default is "none"):
+              - `"text"`: Echo just the text content of the response.
+              - `"output"`: Echo text and tool call content.
+              - `"all"`: Echo both the assistant and user turn.
+              - `"none"`: Do not echo any content.
+        stream
+            Whether to yield just text content or include rich content objects
+            (e.g., tool calls) when relevant.
         kwargs
             Additional keyword arguments to pass to the method used for requesting
             the response.
@@ -783,7 +802,11 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         data_model
             A Pydantic model describing the structure of the data to extract.
         echo
-            Whether to echo text content, all content (i.e., tool calls), or no content.
+            One of the following (default is "none"):
+              - `"text"`: Echo just the text content of the response.
+              - `"output"`: Echo text and tool call content.
+              - `"all"`: Echo both the assistant and user turn.
+              - `"none"`: Do not echo any content.
         stream
             Whether to stream the response (i.e., have the response appear in chunks).
 
@@ -841,7 +864,11 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         data_model
             A Pydantic model describing the structure of the data to extract.
         echo
-            Whether to echo text content, all content (i.e., tool calls), or no content
+            One of the following (default is "none"):
+              - `"text"`: Echo just the text content of the response.
+              - `"output"`: Echo text and tool call content.
+              - `"all"`: Echo both the assistant and user turn.
+              - `"none"`: Do not echo any content.
         stream
             Whether to stream the response (i.e., have the response appear in chunks).
             Defaults to `True` if `echo` is not "none".

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,7 +93,7 @@ def assert_tools_simple_stream_content(chat_fun: ChatFun):
 
     chat.register_tool(get_date)
 
-    response = chat.stream("What's the current date in Y-M-D format?", stream="content",)
+    response = chat.stream("What's the current date in Y-M-D format?", stream="content")
     chunks = [chunk for chunk in response]
     request = [x for x in chunks if isinstance(x, ContentToolRequest)]
     assert len(request) == 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,7 +93,7 @@ def assert_tools_simple_stream_content(chat_fun: ChatFun):
 
     chat.register_tool(get_date)
 
-    response = chat.stream("What's the current date in Y-M-D format?", content="all")
+    response = chat.stream("What's the current date in Y-M-D format?", stream="content",)
     chunks = [chunk for chunk in response]
     request = [x for x in chunks if isinstance(x, ContentToolRequest)]
     assert len(request) == 1


### PR DESCRIPTION
Breaking change to align the API for streaming content objects with https://github.com/tidyverse/ellmer/pull/494.

Before this change, to access tool request/result objects in a stream, it was:

```python
chat.stream(content="all")
```

Now it's

```python
chat.stream(stream="content")
```

**UPDATE**: Now that I think through this naming change a bit more, I'm not convinced it's an improvement.  With `stream="content"`, it could make one wonder what `chat.stream()` is doing -- is it streaming something other than content? From that perspective, I like `content="all"` better -- it better implies that you're gaining access to _additional_ content, which is the main point of the parameter existing.

cc @gadenbuie 