### PR TITLE
Support `ContentToolResultImage`/`ContentToolResultResource` where we can

### DIFF
--- a/chatlas/__init__.py
+++ b/chatlas/__init__.py
@@ -2,7 +2,7 @@ from . import types
 from ._anthropic import ChatAnthropic, ChatBedrockAnthropic
 from ._auto import ChatAuto
 from ._chat import Chat
-from ._content import ContentToolRequest, ContentToolResult
+from ._content import ContentToolRequest, ContentToolResult, ContentToolResultImage
 from ._content_image import content_image_file, content_image_plot, content_image_url
 from ._content_pdf import content_pdf_file, content_pdf_url
 from ._databricks import ChatDatabricks
@@ -46,6 +46,7 @@ __all__ = (
     "content_pdf_url",
     "ContentToolRequest",
     "ContentToolResult",
+    "ContentToolResultImage",
     "interpolate",
     "interpolate_file",
     "Provider",

--- a/chatlas/_anthropic.py
+++ b/chatlas/_anthropic.py
@@ -17,6 +17,8 @@ from ._content import (
     ContentText,
     ContentToolRequest,
     ContentToolResult,
+    ContentToolResultImage,
+    ContentToolResultResource,
 )
 from ._logging import log_model_default
 from ._provider import Provider
@@ -496,8 +498,26 @@ class AnthropicProvider(Provider[Message, RawMessageStreamEvent, Message]):
                 "tool_use_id": content.id,
                 "is_error": content.error is not None,
             }
-            # Anthropic supports non-text contents like ImageBlockParam
-            res["content"] = content.get_model_value()  # type: ignore
+
+            if isinstance(content, ContentToolResultImage):
+                res["content"] = [
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": content.mime_type,
+                            "data": content.value,
+                        },
+                    }
+                ]
+            elif isinstance(content, ContentToolResultResource):
+                raise NotImplementedError(
+                    "ContentToolResultResource is not currently supported by Anthropic."
+                )
+            else:
+                # Anthropic supports non-text contents like ImageBlockParam
+                res["content"] = content.get_model_value()  # type: ignore
+
             return res
 
         raise ValueError(f"Unknown content type: {type(content)}")

--- a/chatlas/_content.py
+++ b/chatlas/_content.py
@@ -455,6 +455,12 @@ class ContentToolResultImage(ContentToolResult):
     def _repr_markdown_(self):
         return f"![](data:{self.mime_type};base64,{self.value})"
 
+    def get_model_value(self):
+        raise NotImplementedError(
+            "The value actually sent to the model depends on the model "
+            "provider used (e.g., OpenAI, Anthropic, etc.). "
+        )
+
 
 class ContentToolResultResource(ContentToolResult):
     """

--- a/chatlas/_google.py
+++ b/chatlas/_google.py
@@ -16,6 +16,8 @@ from ._content import (
     ContentText,
     ContentToolRequest,
     ContentToolResult,
+    ContentToolResultImage,
+    ContentToolResultResource,
 )
 from ._logging import log_model_default
 from ._merge import merge_dicts
@@ -430,6 +432,13 @@ class GoogleProvider(
                 )
             )
         elif isinstance(content, ContentToolResult):
+            if isinstance(
+                content.value, (ContentToolResultImage, ContentToolResultResource)
+            ):
+                raise NotImplementedError(
+                    "Tool results with images or resources aren't supported by Google (Gemini). "
+                )
+
             if content.error:
                 resp = {"error": content.error}
             else:

--- a/chatlas/_openai.py
+++ b/chatlas/_openai.py
@@ -17,6 +17,8 @@ from ._content import (
     ContentText,
     ContentToolRequest,
     ContentToolResult,
+    ContentToolResultImage,
+    ContentToolResultResource,
 )
 from ._logging import log_model_default
 from ._merge import merge_dicts
@@ -490,6 +492,12 @@ class OpenAIProvider(Provider[ChatCompletion, ChatCompletionChunk, ChatCompletio
                             }
                         )
                     elif isinstance(x, ContentToolResult):
+                        if isinstance(
+                            x, (ContentToolResultImage, ContentToolResultResource)
+                        ):
+                            raise NotImplementedError(
+                                "OpenAI does not support tool results with images or resources."
+                            )
                         tool_results.append(
                             ChatCompletionToolMessageParam(
                                 # Currently, OpenAI only allows for text content in tool results

--- a/tests/test_provider_anthropic.py
+++ b/tests/test_provider_anthropic.py
@@ -2,8 +2,7 @@ import base64
 
 import httpx
 import pytest
-
-from chatlas import ChatAnthropic, ContentToolResult
+from chatlas import ChatAnthropic, ContentToolResultImage
 
 from .conftest import (
     assert_data_extraction,
@@ -108,17 +107,10 @@ def test_anthropic_image_tool(test_images_dir):
         # Local copy of https://upload.wikimedia.org/wikipedia/commons/4/47/PNG_transparency_demonstration_1.png
         with open(test_images_dir / "dice.png", "rb") as image:
             bytez = image.read()
-        res = [
-            {
-                "type": "image",
-                "source": {
-                    "type": "base64",
-                    "media_type": "image/png",
-                    "data": base64.b64encode(bytez).decode("utf-8"),
-                },
-            }
-        ]
-        return ContentToolResult(value=res, model_format="as_is")
+        return ContentToolResultImage(
+            value=base64.b64encode(bytez).decode("utf-8"),
+            mime_type="image/png",
+        )
 
     chat = ChatAnthropic()
     chat.register_tool(get_picture)


### PR DESCRIPTION
These contents types were added in #39 (since MCP tools can return images and resources). However, it appears only Anthropic supports non-text tool results.

Perhaps there is some sort of trick we can apply to still get these to work with openai/google (e.g., use `role="user"` instead of `role="tool"`)?