### PR TITLE
Filtering lower-level warnings in pytest

### DIFF
--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -293,6 +293,7 @@ def test_chat_tool_request_reject2(capsys):
     assert "Joe denied the request." in capsys.readouterr().out
 
 
+@pytest.mark.filterwarnings("ignore", category=UserWarning)
 def test_get_cost():
     chat = ChatOpenAI(api_key="fake_key")
     chat.set_turns(

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -74,6 +74,7 @@ def test_get_token_prices():
         assert pricing is None
 
 
+@pytest.mark.filterwarnings("ignore", category=UserWarning)
 def test_compute_price():
     chat = ChatOpenAI(model="o1-mini")
     price = compute_price(chat.provider.name, chat.provider.model, 10, 50)
@@ -90,6 +91,7 @@ def test_usage_is_none():
     assert token_usage() is None
 
 
+@pytest.mark.filterwarnings("ignore", category=UserWarning)
 def test_can_retrieve_and_log_tokens():
     tokens_reset()
 


### PR DESCRIPTION
Filtering out warnings for particular tests where we are purposefully provoking the warning-based behavior. Ex. We are testing a bad input and it is surfacing a warning from an inner function that we test elsewhere.