### PR TITLE
Don't throw needless warnings/errors about missing pricing info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Fixed an issue where `.chat()` wasn't streaming output properly in (the latest build of) Positron's Jupyter notebook. (#131)
 
+* Needless warnings and errors are no longer thrown when model pricing info is unavailable. (#132)
+
 ## [0.9.0] - 2025-07-02
 
 ### New features

--- a/chatlas/_chat.py
+++ b/chatlas/_chat.py
@@ -44,7 +44,7 @@ from ._display import (
 from ._logging import log_tool_error
 from ._mcp_manager import MCPSessionManager
 from ._provider import Provider, StandardModelParams, SubmitInputArgsT
-from ._tokens import get_token_pricing
+from ._tokens import compute_cost, get_token_pricing
 from ._tools import Tool, ToolRejectError
 from ._turn import Turn, user_turn
 from ._typing_extensions import TypedDict, TypeGuard
@@ -2222,11 +2222,22 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
     def __repr__(self):
         turns = self.get_turns(include_system_prompt=True)
         tokens = self.get_tokens()
-        cost = self.get_cost()
         tokens_asst = sum(u["tokens_total"] for u in tokens if u["role"] == "assistant")
         tokens_user = sum(u["tokens_total"] for u in tokens if u["role"] == "user")
 
-        res = f"<Chat {self.provider.name}/{self.provider.model} turns={len(turns)} tokens={tokens_user}/{tokens_asst} ${round(cost, ndigits=2)}>"
+        res = f"<Chat {self.provider.name}/{self.provider.model} turns={len(turns)} tokens={tokens_user}/{tokens_asst}"
+
+        # Add cost info only if we can compute it
+        cost = compute_cost(
+            self.provider.name,
+            self.provider.model,
+            tokens_user,
+            tokens_asst,
+        )
+        if cost is not None:
+            res += f"${round(cost, ndigits=2)}"
+
+        res += ">"
         for turn in turns:
             res += "\n" + turn.__repr__(indent=2)
         return res + "\n"

--- a/chatlas/_chat.py
+++ b/chatlas/_chat.py
@@ -2235,7 +2235,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
             tokens_asst,
         )
         if cost is not None:
-            res += f"${round(cost, ndigits=2)}"
+            res += f" ${round(cost, ndigits=2)}"
 
         res += ">"
         for turn in turns:

--- a/chatlas/_tokens.py
+++ b/chatlas/_tokens.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import copy
 import importlib.resources as resources
-import warnings
 from threading import Lock
 from typing import TYPE_CHECKING
 
@@ -47,12 +46,12 @@ class ThreadSafeTokenCounter:
                     "model": model,
                     "input": input_tokens,
                     "output": output_tokens,
-                    "cost": compute_price(name, model, input_tokens, output_tokens),
+                    "cost": compute_cost(name, model, input_tokens, output_tokens),
                 }
             else:
                 self._tokens[name]["input"] += input_tokens
                 self._tokens[name]["output"] += output_tokens
-                price = compute_price(name, model, input_tokens, output_tokens)
+                price = compute_cost(name, model, input_tokens, output_tokens)
                 if price is not None:
                     cost = self._tokens[name]["cost"]
                     if cost is None:
@@ -122,7 +121,7 @@ def get_token_pricing(name: str, model: str) -> TokenPrice | None:
     -------
     TokenPrice | None
     """
-    result = next(
+    return next(
         (
             item
             for item in pricing_list
@@ -130,16 +129,9 @@ def get_token_pricing(name: str, model: str) -> TokenPrice | None:
         ),
         None,
     )
-    if result is None:
-        warnings.warn(
-            f"Token pricing for the provider '{name}' and model '{model}' you selected is not available. "
-            "Please check the provider's documentation."
-        )
-
-    return result
 
 
-def compute_price(
+def compute_cost(
     name: str, model: str, input_tokens: int, output_tokens: int
 ) -> float | None:
     """

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -310,7 +310,7 @@ def test_get_cost():
             "Expected `options` to be one of 'all' or 'last', not 'bad_option'"
         ),
     ):
-        chat.get_cost(options="bad_option")
+        chat.get_cost(options="bad_option")  # type: ignore
 
     # Checking that these have the right form vs. the actual calculation because the price may change
     cost = chat.get_cost(options="all")

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -2,7 +2,7 @@ import pytest
 from chatlas import ChatAnthropic, ChatGoogle, ChatOpenAI, Turn
 from chatlas._openai import OpenAIAzureProvider, OpenAIProvider
 from chatlas._tokens import (
-    compute_price,
+    compute_cost,
     get_token_pricing,
     token_usage,
     tokens_log,
@@ -59,29 +59,22 @@ def test_token_count_method():
 def test_get_token_prices():
     chat = ChatOpenAI(model="o1-mini")
     pricing = get_token_pricing(chat.provider.name, chat.provider.model)
+    assert pricing is not None
     assert pricing["provider"] == "OpenAI"
     assert pricing["model"] == "o1-mini"
     assert isinstance(pricing["cached_input"], float)
     assert isinstance(pricing["input"], float)
     assert isinstance(pricing["output"], float)
 
-    with pytest.warns(
-        match="Token pricing for the provider 'OpenAI' and model 'ABCD' you selected is not available. "
-        "Please check the provider's documentation."
-    ):
-        chat = ChatOpenAI(model="ABCD")
-        pricing = get_token_pricing(chat.provider.name, chat.provider.model)
-        assert pricing is None
 
-
-def test_compute_price():
+def test_compute_cost():
     chat = ChatOpenAI(model="o1-mini")
-    price = compute_price(chat.provider.name, chat.provider.model, 10, 50)
+    price = compute_cost(chat.provider.name, chat.provider.model, 10, 50)
     assert isinstance(price, float)
     assert price > 0
 
     chat = ChatOpenAI(model="ABCD")
-    price = compute_price(chat.provider.name, chat.provider.model, 10, 50)
+    price = compute_cost(chat.provider.name, chat.provider.model, 10, 50)
     assert price is None
 
 


### PR DESCRIPTION
This PR fixes 2 issues:

1. Unnecessary warnings no longer occur when chatting with a model that doesn't have pricing info:

```python
import chatlas as ctl
chat = ctl.ChatAnthropic()
chat.chat("Foo")
```

```python
/Users/cpsievert/github/chatlas/chatlas/_tokens.py:134: UserWarning: Token pricing for the provider 'Anthropic' and model 
'claude-3-7-sonnet-latest' you selected is not available. Please check the provider's documentation.
  warnings.warn(
```

2. Printing a `chat` instance at the console (i.e., `repr()`) no longer errors when pricing info is unavailable

```python 
chat

KeyError: "We could not locate pricing information for model 'claude-3-7-sonnet-latest' from provider 'Anthropic'. If you know the pricing for this model, specify it in `token_price`."
```

Closes #129 