### PR TITLE
fix: make `ContentToolResult`'s `extra` aware of shinychat's `display` feature (for bookmarking)

### DIFF
--- a/chatlas/_content.py
+++ b/chatlas/_content.py
@@ -740,10 +740,11 @@ def restore_html(x: dict[str, Any]):
     for d in x["dependencies"]:
         if not isinstance(d, dict):
             continue
-        name = d.pop("name")
-        version = d.pop("version")
+        name = d["name"]
+        version = d["version"]
+        other = {k: v for k, v in d.items() if k not in ("name", "version")}
         # TODO: warn if the source is a tempdir?
-        deps.append(HTMLDependency(name=name, version=version, **d))
+        deps.append(HTMLDependency(name=name, version=version, **other))
 
     res = TagList(HTML(x["html"]), *deps)
     if not deps:

--- a/chatlas/types/anthropic/_submit.py
+++ b/chatlas/types/anthropic/_submit.py
@@ -3,7 +3,7 @@
 # ---------------------------------------------------------
 
 
-from typing import Iterable, Literal, Mapping, Optional, TypedDict, Union
+from typing import Iterable, Literal, Mapping, Optional, Sequence, TypedDict, Union
 
 import anthropic
 import anthropic.types.message_param
@@ -48,7 +48,7 @@ class SubmitInputArgs(TypedDict, total=False):
         str,
     ]
     service_tier: Union[Literal["auto", "standard_only"], anthropic.NotGiven]
-    stop_sequences: Union[list[str], anthropic.NotGiven]
+    stop_sequences: Union[Sequence[str], anthropic.NotGiven]
     stream: Union[Literal[False], Literal[True], anthropic.NotGiven]
     system: Union[
         str,

--- a/chatlas/types/openai/_submit.py
+++ b/chatlas/types/openai/_submit.py
@@ -3,7 +3,7 @@
 # ---------------------------------------------------------
 
 
-from typing import Iterable, Literal, Mapping, Optional, TypedDict, Union
+from typing import Iterable, Literal, Mapping, Optional, Sequence, TypedDict, Union
 
 import openai
 import openai.types.chat.chat_completion_allowed_tool_choice_param
@@ -148,7 +148,7 @@ class SubmitInputArgs(TypedDict, total=False):
     service_tier: Union[
         Literal["auto", "default", "flex", "scale", "priority"], None, openai.NotGiven
     ]
-    stop: Union[str, None, list[str], openai.NotGiven]
+    stop: Union[str, None, Sequence[str], openai.NotGiven]
     store: Union[bool, None, openai.NotGiven]
     stream: Union[Literal[False], None, Literal[True], openai.NotGiven]
     stream_options: Union[


### PR DESCRIPTION
https://github.com/posit-dev/shinychat/pull/107 will be encouraging a pattern like this for Custom tool display UI:

```python
import faicons
from chatlas import ChatOpenAI, ContentToolResult

from shinychat.express import Chat

chat_client = ChatOpenAI(model="gpt-4.1-nano")

def list_files(path: str, _intent: str):
    return ContentToolResult(
        value=["app.py", "data.csv"],
        extra={
            "display": {"icon": faicons.icon_svg("folder-open")},
        },
    )

chat_client.register_tool(list_files)

chat = Chat(id="chat")
chat.ui(
    messages=[
        '<p class="suggestion submit">In three separate tool calls list the files in apps, data, docs</p>',
    ],
)


@chat.on_user_submit
async def handle_user_input(user_input: str):
    response = await chat_client.stream_async(user_input, content="all")
    await chat.append_message_stream(response)
```


However, this is a problem for bookmarking (i.e., serializable `ContentToolResult`, `Turn`, etc) since `htmltools` classes currently aren't serializable (https://github.com/posit-dev/py-htmltools/issues/100). 

This PR adds a bit of a hacky workaround to serialize/restore the `extra` field properly when it contains Tag-like objects. Ideally, htmltools could handle this for us, but that's a larger problem for another day.