### PR TITLE
feat: Add extra field to `ToolAnnotations` (for custom annotation info)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `ChatAuto()`'s new `provider_model` takes both provider and model in a single string in the format `"{provider}/{model}"`, e.g. `"openai/gpt-5"`. If not provided, `ChatAuto()` looks for the `CHATLAS_CHAT_PROVIDER_MODEL` environment variable, defaulting to `"openai"` if neither are provided. Unlike previous versions of `ChatAuto()`, the environment variables are now used *only if function arguments are not provided*. In other words, if `provider_model` is given, the `CHATLAS_CHAT_PROVIDER_MODEL` environment variable is ignored. Similarly, `CHATLAS_CHAT_ARGS` are only used if no `kwargs` are provided. This improves interactive use cases, makes it easier to introduce application-specific environment variables, and puts more control in the hands of the developer. (#159)
 * The `.register_tool()` method now accepts a `Tool` instance as input. This is primarily useful for binding things like `annotations` to the `Tool` in one place, and registering it in another. (#172)
+* The `ToolAnnotations` type gains an `extra` key field -- providing a place for providing additional information that other consumers of tool annotations (e.g., [shinychat](https://posit-dev.github.io/shinychat/)) may make use of.
 
 ### Bug fixes
 

--- a/chatlas/_content.py
+++ b/chatlas/_content.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Literal, Optional, Union
 import orjson
 from pydantic import BaseModel, ConfigDict
 
-from ._typing_extensions import NotRequired, TypedDict
+from ._typing_extensions import TypedDict
 
 if TYPE_CHECKING:
     from ._tools import Tool
@@ -24,16 +24,16 @@ class ToolAnnotations(TypedDict, total=False):
     received from untrusted servers.
     """
 
-    title: NotRequired[str]
+    title: str
     """A human-readable title for the tool."""
 
-    readOnlyHint: NotRequired[bool]
+    readOnlyHint: bool
     """
     If true, the tool does not modify its environment.
     Default: false
     """
 
-    destructiveHint: NotRequired[bool]
+    destructiveHint: bool
     """
     If true, the tool may perform destructive updates to its environment.
     If false, the tool performs only additive updates.
@@ -41,7 +41,7 @@ class ToolAnnotations(TypedDict, total=False):
     Default: true
     """
 
-    idempotentHint: NotRequired[bool]
+    idempotentHint: bool
     """
     If true, calling the tool repeatedly with the same arguments
     will have no additional effect on the its environment.
@@ -49,13 +49,18 @@ class ToolAnnotations(TypedDict, total=False):
     Default: false
     """
 
-    openWorldHint: NotRequired[bool]
+    openWorldHint: bool
     """
     If true, this tool may interact with an "open world" of external
     entities. If false, the tool's domain of interaction is closed.
     For example, the world of a web search tool is open, whereas that
     of a memory tool is not.
     Default: true
+    """
+
+    extra: dict[str, Any]
+    """
+    Additional metadata about the tool.
     """
 
 


### PR DESCRIPTION
Adds an `extra` key field to `ToolAnnotations`. This way, we can have type hints for "official" MCP annotations, and also a place to provide additional info for 3rd party integrations (like `shinychat`'s tool display feature).