### PR TITLE
Fix `ChatGitHub()` to actually use it's `base_url`

### DIFF
--- a/chatlas/_provider_github.py
+++ b/chatlas/_provider_github.py
@@ -141,7 +141,7 @@ def ChatGithub(
 
 class GitHubProvider(OpenAIProvider):
     def __init__(self, base_url: str, **kwargs):
-        super().__init__(**kwargs)
+        super().__init__(base_url=base_url, **kwargs)
         self._base_url = base_url
 
     def list_models(self) -> list[ModelInfo]:
@@ -190,7 +190,7 @@ def list_models_gh_azure(base_url: str = "https://models.inference.ai.azure.com"
     for m in models:
         info: ModelInfo = {
             "id": m["name"],
-            "provider": m["publisher"]
+            "provider": m["publisher"],
         }
         res.append(info)
 


### PR DESCRIPTION
Introduced by #155.

```python
import chatlas as ctl

chat = ctl.ChatGithub()
chat.chat("Hello")
```

```python
Traceback (most recent call last):
  File "/Users/cpsievert/github/chatlas/dev.py", line 4, in <module>
    chat.chat("Hello")
    ~~~~~~~~~^^^^^^^^^
  File "/Users/cpsievert/github/chatlas/chatlas/_chat.py", line 858, in chat
    for _ in response:
             ^^^^^^^^
  File "/Users/cpsievert/github/chatlas/chatlas/_chat.py", line 2549, in __next__
    chunk = next(self._generator)
  File "/Users/cpsievert/github/chatlas/chatlas/_chat.py", line 2063, in _chat_impl
    for chunk in self._submit_turns(
                 ~~~~~~~~~~~~~~~~~~^
        user_turn_result,
        ^^^^^^^^^^^^^^^^^
    ...<2 lines>...
        kwargs=kwargs,
        ^^^^^^^^^^^^^^
    ):
    ^
  File "/Users/cpsievert/github/chatlas/chatlas/_chat.py", line 2193, in _submit_turns
    response = self.provider.chat_perform(
        stream=True,
    ...<3 lines>...
        kwargs=all_kwargs,
    )
  File "/Users/cpsievert/github/chatlas/chatlas/_provider_openai.py", line 282, in chat_perform
    return self._client.chat.completions.create(**kwargs)  # type: ignore
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/Users/cpsievert/github/chatlas/.venv/lib/python3.13/site-packages/openai/_utils/_utils.py", line 286, in wrapper
    return func(*args, **kwargs)
  File "/Users/cpsievert/github/chatlas/.venv/lib/python3.13/site-packages/openai/resources/chat/completions/completions.py", line 1147, in create
    return self._post(
           ~~~~~~~~~~^
        "/chat/completions",
        ^^^^^^^^^^^^^^^^^^^^
    ...<46 lines>...
        stream_cls=Stream[ChatCompletionChunk],
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/cpsievert/github/chatlas/.venv/lib/python3.13/site-packages/openai/_base_client.py", line 1259, in post
    return cast(ResponseT, self.request(cast_to, opts, stream=stream, stream_cls=stream_cls))
                           ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/cpsievert/github/chatlas/.venv/lib/python3.13/site-packages/openai/_base_client.py", line 1047, in request
    raise self._make_status_error_from_response(err.response) from None
openai.AuthenticationError: Error code: 401 - {'error': {'message': 'Incorrect API key provided: ghp_vqnW****************************KjDv. You can find your API key at https://platform.openai.com/account/api-keys.', 'type': 'invalid_request_error', 'param': None, 'code': 'invalid_api_key'}}
```