### PR TITLE
fix(docs): Fix incorrect function name in evals documentation

### DIFF
--- a/docs/misc/evals.qmd
+++ b/docs/misc/evals.qmd
@@ -160,7 +160,7 @@ Since our data is now is in JSONL format, before running the eval, we'll want to
 ```python
 from inspect_ai.dataset import json_dataset
 
-Task(dataset=jsonl_dataset("my_eval_dataset.jsonl"), ...)
+Task(dataset=json_dataset("my_eval_dataset.jsonl"), ...)
 ```
 
 Now that you have the basics of collecting eval datasets, let's dive deeper into the other components of an eval: **solvers** and **scorers**.


### PR DESCRIPTION
Replaces a reference to `jsonl_dataset` with the correct `json_dataset` function in the example code, ensuring accuracy in the documentation.