### PR TITLE
fix: preserve OpenAI streaming result on unexpected post-completion events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* Fixed OpenAI streaming crash (`AttributeError: 'NoneType' object has no attribute 'output'`) caused by a new `response.rate_limits.updated` event emitted after `response.completed`. (#282)
 * Fixed tool calling with Google thinking models (e.g., `gemini-3-flash-preview`) failing with a 400 `INVALID_ARGUMENT` error about a missing `thought_signature`. The signature is now preserved and forwarded in subsequent turns. (#274)
 * OpenAI's `web_search_call` no longer errors on non-search action types like `open_page` and `find_in_page`. (#277)
 

--- a/chatlas/_provider.py
+++ b/chatlas/_provider.py
@@ -243,7 +243,7 @@ class Provider(
         self,
         completion: Optional[ChatCompletionDictT],
         chunk: ChatCompletionChunkT,
-    ) -> ChatCompletionDictT: ...
+    ) -> Optional[ChatCompletionDictT]: ...
 
     @abstractmethod
     def stream_turn(

--- a/chatlas/_provider_openai.py
+++ b/chatlas/_provider_openai.py
@@ -318,8 +318,7 @@ class OpenAIProvider(
         elif chunk.type == "error":
             raise RuntimeError(f"Request errored: {chunk.message}")
 
-        # Since this value won't actually be used, we can lie about the type
-        return cast(Response, None)
+        return completion
 
     def stream_turn(self, completion, has_data_model):
         return self._response_as_turn(completion, has_data_model)

--- a/chatlas/types/anthropic/_submit.py
+++ b/chatlas/types/anthropic/_submit.py
@@ -40,6 +40,8 @@ class SubmitInputArgs(TypedDict, total=False):
     messages: Iterable[anthropic.types.message_param.MessageParam]
     model: Union[
         Literal[
+            "claude-opus-4-7",
+            "claude-mythos-preview",
             "claude-opus-4-6",
             "claude-sonnet-4-6",
             "claude-haiku-4-5",

--- a/chatlas/types/openai/_client.py
+++ b/chatlas/types/openai/_client.py
@@ -7,10 +7,12 @@ from typing import Awaitable, Callable, Mapping, Optional, TypedDict, Union
 
 import httpx
 import openai
+import openai.auth._workload
 
 
 class ChatClientArgs(TypedDict, total=False):
-    api_key: Union[str, Callable[[], Awaitable[str]], None]
+    api_key: Union[str, None, Callable[[], Awaitable[str]]]
+    workload_identity: openai.auth._workload.WorkloadIdentity | None
     organization: str | None
     project: str | None
     webhook_secret: str | None

--- a/chatlas/types/openai/_client_azure.py
+++ b/chatlas/types/openai/_client_azure.py
@@ -6,6 +6,7 @@ from typing import Awaitable, Callable, Mapping, Optional, TypedDict, Union
 
 import httpx
 import openai
+import openai.auth._workload
 
 
 class ChatAzureClientArgs(TypedDict, total=False):
@@ -13,6 +14,7 @@ class ChatAzureClientArgs(TypedDict, total=False):
     azure_deployment: str | None
     api_version: str | None
     api_key: Union[str, Callable[[], Awaitable[str]], None]
+    workload_identity: openai.auth._workload.WorkloadIdentity | None
     azure_ad_token: str | None
     organization: str | None
     project: str | None

--- a/tests/_vcr/test_provider_openai/test_data_extraction.yaml
+++ b/tests/_vcr/test_provider_openai/test_data_extraction.yaml
@@ -12,7 +12,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -29,21 +29,21 @@ interactions:
     uri: https://api.openai.com/v1/responses
   response:
     body:
-      string: "{\n  \"id\": \"resp_0de1f7fdb56d45370169558a6b3bd88191805466907e85d55a\",\n
-        \ \"object\": \"response\",\n  \"created_at\": 1767213675,\n  \"status\":
+      string: "{\n  \"id\": \"resp_0ae0c3e911b851180169e136988380819ea1c6409c8dc864f6\",\n
+        \ \"object\": \"response\",\n  \"created_at\": 1776367256,\n  \"status\":
         \"completed\",\n  \"background\": false,\n  \"billing\": {\n    \"payer\":
-        \"developer\"\n  },\n  \"completed_at\": 1767213675,\n  \"error\": null,\n
-        \ \"incomplete_details\": null,\n  \"instructions\": null,\n  \"max_output_tokens\":
-        null,\n  \"max_tool_calls\": null,\n  \"model\": \"gpt-4.1-2025-04-14\",\n
-        \ \"output\": [\n    {\n      \"id\": \"msg_0de1f7fdb56d45370169558a6b8ab0819197ee3cebfa1d54a2\",\n
+        \"developer\"\n  },\n  \"completed_at\": 1776367257,\n  \"error\": null,\n
+        \ \"frequency_penalty\": 0.0,\n  \"incomplete_details\": null,\n  \"instructions\":
+        null,\n  \"max_output_tokens\": null,\n  \"max_tool_calls\": null,\n  \"model\":
+        \"gpt-4.1-2025-04-14\",\n  \"output\": [\n    {\n      \"id\": \"msg_0ae0c3e911b851180169e13698d298819eb4d25fcd851bcfd0\",\n
         \     \"type\": \"message\",\n      \"status\": \"completed\",\n      \"content\":
         [\n        {\n          \"type\": \"output_text\",\n          \"annotations\":
         [],\n          \"logprobs\": [],\n          \"text\": \"{\\n  \\\"title\\\":
         \\\"Apples are tasty\\\",\\n  \\\"author\\\": \\\"Hadley Wickham\\\"\\n}\"\n
         \       }\n      ],\n      \"role\": \"assistant\"\n    }\n  ],\n  \"parallel_tool_calls\":
-        true,\n  \"previous_response_id\": null,\n  \"prompt_cache_key\": null,\n
-        \ \"prompt_cache_retention\": null,\n  \"reasoning\": {\n    \"effort\": null,\n
-        \   \"summary\": null\n  },\n  \"safety_identifier\": null,\n  \"service_tier\":
+        true,\n  \"presence_penalty\": 0.0,\n  \"previous_response_id\": null,\n  \"prompt_cache_key\":
+        null,\n  \"prompt_cache_retention\": null,\n  \"reasoning\": {\n    \"effort\":
+        null,\n    \"summary\": null\n  },\n  \"safety_identifier\": null,\n  \"service_tier\":
         \"default\",\n  \"store\": false,\n  \"temperature\": 1.0,\n  \"text\": {\n
         \   \"format\": {\n      \"type\": \"json_schema\",\n      \"description\":
         null,\n      \"name\": \"structured_data\",\n      \"schema\": {\n        \"description\":
@@ -60,13 +60,13 @@ interactions:
         \ \"user\": null,\n  \"metadata\": {}\n}"
     headers:
       CF-RAY:
-      - 9b6c98bdfa9adb04-ORD
+      - 9ed58cd8e8c0f861-ORD
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Wed, 31 Dec 2025 20:41:15 GMT
+      - Thu, 16 Apr 2026 19:20:57 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -80,13 +80,11 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       content-length:
-      - '2006'
+      - '2061'
       openai-processing-ms:
-      - '500'
+      - '540'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '503'
       x-ratelimit-limit-requests:
       - '10000'
       x-ratelimit-limit-tokens:
@@ -120,7 +118,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -128,8 +126,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - __cf_bm=daLjsRYl4e1swzRhMGi7txja5RcE.6l0BHHvKDYAKm8-1767213675-1.0.1.1-H8SNmRbdbetKI2d0i_b36DAsIKJq21VrDLGEJmWnJT3cP4VMOhpV163OUoNUwq4SvTR5gcT.UiOB6M6EyugTC5BY6.6978BE1oCQNRhrF_8;
-        _cfuvid=G80JVON9JDKas3rhhmkj2._hkOStYcgp8eMmmgSFUIA-1767213675745-0.0.1.1-604800000
+      - __cf_bm=DoxQho_Y_QxFirwPxhIrBs2DHWJ29HATA6B.FhagfIA-1776367256.465088-1.0.1.1-viET.LdhPAnU6ziur0OCuYdk.CotiTT._ef5kCnSPs0vK0s3saonprEpcGLN0AKsxUwIHEMfXeOybKWeUkleeypHG7Vf0OPRcOAY3jp9ePgcrPKmP30WDbcFaQNRezNZ
       Host:
       - api.openai.com
       X-Stainless-Async:
@@ -140,44 +137,44 @@ interactions:
     uri: https://api.openai.com/v1/responses
   response:
     body:
-      string: "{\n  \"id\": \"resp_0c83445941e524b70169558a6bfa10819d992abd619b92f762\",\n
-        \ \"object\": \"response\",\n  \"created_at\": 1767213676,\n  \"status\":
+      string: "{\n  \"id\": \"resp_03f5f6d80136ee230169e136995adc81978c25adedd59fda25\",\n
+        \ \"object\": \"response\",\n  \"created_at\": 1776367257,\n  \"status\":
         \"completed\",\n  \"background\": false,\n  \"billing\": {\n    \"payer\":
-        \"developer\"\n  },\n  \"completed_at\": 1767213676,\n  \"error\": null,\n
-        \ \"incomplete_details\": null,\n  \"instructions\": null,\n  \"max_output_tokens\":
-        null,\n  \"max_tool_calls\": null,\n  \"model\": \"gpt-4.1-2025-04-14\",\n
-        \ \"output\": [\n    {\n      \"id\": \"msg_0c83445941e524b70169558a6c38d0819da082e7e7b12b6ba3\",\n
+        \"developer\"\n  },\n  \"completed_at\": 1776367257,\n  \"error\": null,\n
+        \ \"frequency_penalty\": 0.0,\n  \"incomplete_details\": null,\n  \"instructions\":
+        null,\n  \"max_output_tokens\": null,\n  \"max_tool_calls\": null,\n  \"model\":
+        \"gpt-4.1-2025-04-14\",\n  \"output\": [\n    {\n      \"id\": \"msg_03f5f6d80136ee230169e136998fac81979d8402f81f8d0f15\",\n
         \     \"type\": \"message\",\n      \"status\": \"completed\",\n      \"content\":
         [\n        {\n          \"type\": \"output_text\",\n          \"annotations\":
         [],\n          \"logprobs\": [],\n          \"text\": \"{\\\"title\\\":\\\"Apples
         are tasty\\\",\\\"author\\\":\\\"Hadley Wickham\\\"}\"\n        }\n      ],\n
         \     \"role\": \"assistant\"\n    }\n  ],\n  \"parallel_tool_calls\": true,\n
-        \ \"previous_response_id\": null,\n  \"prompt_cache_key\": null,\n  \"prompt_cache_retention\":
-        null,\n  \"reasoning\": {\n    \"effort\": null,\n    \"summary\": null\n
-        \ },\n  \"safety_identifier\": null,\n  \"service_tier\": \"default\",\n  \"store\":
-        false,\n  \"temperature\": 1.0,\n  \"text\": {\n    \"format\": {\n      \"type\":
-        \"json_schema\",\n      \"description\": null,\n      \"name\": \"structured_data\",\n
-        \     \"schema\": {\n        \"description\": \"Summary of the article\",\n
-        \       \"properties\": {\n          \"title\": {\n            \"type\": \"string\"\n
-        \         },\n          \"author\": {\n            \"type\": \"string\"\n
-        \         }\n        },\n        \"required\": [\n          \"title\",\n          \"author\"\n
-        \       ],\n        \"type\": \"object\",\n        \"additionalProperties\":
-        false\n      },\n      \"strict\": true\n    },\n    \"verbosity\": \"medium\"\n
-        \ },\n  \"tool_choice\": \"auto\",\n  \"tools\": [],\n  \"top_logprobs\":
-        0,\n  \"top_p\": 1.0,\n  \"truncation\": \"disabled\",\n  \"usage\": {\n    \"input_tokens\":
-        143,\n    \"input_tokens_details\": {\n      \"cached_tokens\": 0\n    },\n
-        \   \"output_tokens\": 16,\n    \"output_tokens_details\": {\n      \"reasoning_tokens\":
-        0\n    },\n    \"total_tokens\": 159\n  },\n  \"user\": null,\n  \"metadata\":
-        {}\n}"
+        \ \"presence_penalty\": 0.0,\n  \"previous_response_id\": null,\n  \"prompt_cache_key\":
+        null,\n  \"prompt_cache_retention\": null,\n  \"reasoning\": {\n    \"effort\":
+        null,\n    \"summary\": null\n  },\n  \"safety_identifier\": null,\n  \"service_tier\":
+        \"default\",\n  \"store\": false,\n  \"temperature\": 1.0,\n  \"text\": {\n
+        \   \"format\": {\n      \"type\": \"json_schema\",\n      \"description\":
+        null,\n      \"name\": \"structured_data\",\n      \"schema\": {\n        \"description\":
+        \"Summary of the article\",\n        \"properties\": {\n          \"title\":
+        {\n            \"type\": \"string\"\n          },\n          \"author\": {\n
+        \           \"type\": \"string\"\n          }\n        },\n        \"required\":
+        [\n          \"title\",\n          \"author\"\n        ],\n        \"type\":
+        \"object\",\n        \"additionalProperties\": false\n      },\n      \"strict\":
+        true\n    },\n    \"verbosity\": \"medium\"\n  },\n  \"tool_choice\": \"auto\",\n
+        \ \"tools\": [],\n  \"top_logprobs\": 0,\n  \"top_p\": 1.0,\n  \"truncation\":
+        \"disabled\",\n  \"usage\": {\n    \"input_tokens\": 143,\n    \"input_tokens_details\":
+        {\n      \"cached_tokens\": 0\n    },\n    \"output_tokens\": 16,\n    \"output_tokens_details\":
+        {\n      \"reasoning_tokens\": 0\n    },\n    \"total_tokens\": 159\n  },\n
+        \ \"user\": null,\n  \"metadata\": {}\n}"
     headers:
       CF-RAY:
-      - 9b6c98c29cbecefa-ORD
+      - 9ed58cde3ada218b-ORD
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Wed, 31 Dec 2025 20:41:16 GMT
+      - Thu, 16 Apr 2026 19:20:57 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -191,13 +188,11 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       content-length:
-      - '1995'
+      - '2050'
       openai-processing-ms:
-      - '397'
+      - '395'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '400'
       x-ratelimit-limit-requests:
       - '10000'
       x-ratelimit-limit-tokens:
@@ -235,7 +230,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -243,8 +238,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - __cf_bm=daLjsRYl4e1swzRhMGi7txja5RcE.6l0BHHvKDYAKm8-1767213675-1.0.1.1-H8SNmRbdbetKI2d0i_b36DAsIKJq21VrDLGEJmWnJT3cP4VMOhpV163OUoNUwq4SvTR5gcT.UiOB6M6EyugTC5BY6.6978BE1oCQNRhrF_8;
-        _cfuvid=G80JVON9JDKas3rhhmkj2._hkOStYcgp8eMmmgSFUIA-1767213675745-0.0.1.1-604800000
+      - __cf_bm=DoxQho_Y_QxFirwPxhIrBs2DHWJ29HATA6B.FhagfIA-1776367256.465088-1.0.1.1-viET.LdhPAnU6ziur0OCuYdk.CotiTT._ef5kCnSPs0vK0s3saonprEpcGLN0AKsxUwIHEMfXeOybKWeUkleeypHG7Vf0OPRcOAY3jp9ePgcrPKmP30WDbcFaQNRezNZ
       Host:
       - api.openai.com
       X-Stainless-Async:
@@ -255,24 +249,24 @@ interactions:
     uri: https://api.openai.com/v1/responses
   response:
     body:
-      string: "{\n  \"id\": \"resp_07ad3cacaa68c2e80169558a6ca248819ea81489088a94adff\",\n
-        \ \"object\": \"response\",\n  \"created_at\": 1767213676,\n  \"status\":
+      string: "{\n  \"id\": \"resp_0d8f4de8dd1c786a0169e13699f76881908e220194309386ba\",\n
+        \ \"object\": \"response\",\n  \"created_at\": 1776367257,\n  \"status\":
         \"completed\",\n  \"background\": false,\n  \"billing\": {\n    \"payer\":
-        \"developer\"\n  },\n  \"completed_at\": 1767213677,\n  \"error\": null,\n
-        \ \"incomplete_details\": null,\n  \"instructions\": null,\n  \"max_output_tokens\":
-        null,\n  \"max_tool_calls\": null,\n  \"model\": \"gpt-4.1-2025-04-14\",\n
-        \ \"output\": [\n    {\n      \"id\": \"msg_07ad3cacaa68c2e80169558a6d3b88819ea9fc2c9f21e29818\",\n
+        \"developer\"\n  },\n  \"completed_at\": 1776367258,\n  \"error\": null,\n
+        \ \"frequency_penalty\": 0.0,\n  \"incomplete_details\": null,\n  \"instructions\":
+        null,\n  \"max_output_tokens\": null,\n  \"max_tool_calls\": null,\n  \"model\":
+        \"gpt-4.1-2025-04-14\",\n  \"output\": [\n    {\n      \"id\": \"msg_0d8f4de8dd1c786a0169e1369a4ba48190982de1ced50e80f9\",\n
         \     \"type\": \"message\",\n      \"status\": \"completed\",\n      \"content\":
         [\n        {\n          \"type\": \"output_text\",\n          \"annotations\":
-        [],\n          \"logprobs\": [],\n          \"text\": \"{\\\"name\\\":\\\"Sophia
-        Johnson\\\",\\\"age\\\":34}\"\n        }\n      ],\n      \"role\": \"assistant\"\n
-        \   }\n  ],\n  \"parallel_tool_calls\": true,\n  \"previous_response_id\":
-        null,\n  \"prompt_cache_key\": null,\n  \"prompt_cache_retention\": null,\n
-        \ \"reasoning\": {\n    \"effort\": null,\n    \"summary\": null\n  },\n  \"safety_identifier\":
-        null,\n  \"service_tier\": \"default\",\n  \"store\": false,\n  \"temperature\":
-        1.0,\n  \"text\": {\n    \"format\": {\n      \"type\": \"json_schema\",\n
-        \     \"description\": null,\n      \"name\": \"structured_data\",\n      \"schema\":
-        {\n        \"properties\": {\n          \"name\": {\n            \"type\":
+        [],\n          \"logprobs\": [],\n          \"text\": \"{\\\"name\\\":\\\"Sophie
+        Ramirez\\\",\\\"age\\\":32}\"\n        }\n      ],\n      \"role\": \"assistant\"\n
+        \   }\n  ],\n  \"parallel_tool_calls\": true,\n  \"presence_penalty\": 0.0,\n
+        \ \"previous_response_id\": null,\n  \"prompt_cache_key\": null,\n  \"prompt_cache_retention\":
+        null,\n  \"reasoning\": {\n    \"effort\": null,\n    \"summary\": null\n
+        \ },\n  \"safety_identifier\": null,\n  \"service_tier\": \"default\",\n  \"store\":
+        false,\n  \"temperature\": 1.0,\n  \"text\": {\n    \"format\": {\n      \"type\":
+        \"json_schema\",\n      \"description\": null,\n      \"name\": \"structured_data\",\n
+        \     \"schema\": {\n        \"properties\": {\n          \"name\": {\n            \"type\":
         \"string\"\n          },\n          \"age\": {\n            \"type\": \"integer\"\n
         \         }\n        },\n        \"required\": [\n          \"name\",\n          \"age\"\n
         \       ],\n        \"type\": \"object\",\n        \"additionalProperties\":
@@ -285,13 +279,13 @@ interactions:
         {}\n}"
     headers:
       CF-RAY:
-      - 9b6c98c6bb90eac4-ORD
+      - 9ed58ce20c3f61c7-ORD
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Wed, 31 Dec 2025 20:41:17 GMT
+      - Thu, 16 Apr 2026 19:20:58 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -305,13 +299,11 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       content-length:
-      - '1917'
+      - '1972'
       openai-processing-ms:
-      - '819'
+      - '467'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '822'
       x-ratelimit-limit-requests:
       - '10000'
       x-ratelimit-limit-tokens:
@@ -341,7 +333,7 @@ interactions:
       Wickham\"}", "annotations": []}], "status": "completed", "type": "message",
       "id": "msg_missing_id"}, {"role": "user", "content": [{"type": "input_text",
       "text": "Generate the name and age of a random person."}]}, {"role": "assistant",
-      "content": [{"type": "output_text", "text": "{\"name\":\"Sophia Johnson\",\"age\":34}",
+      "content": [{"type": "output_text", "text": "{\"name\":\"Sophie Ramirez\",\"age\":32}",
       "annotations": []}], "status": "completed", "type": "message", "id": "msg_missing_id"},
       {"role": "user", "content": [{"type": "input_text", "text": "What is the name
       of the person?"}]}], "model": "gpt-4.1", "store": false, "stream": true}'
@@ -349,7 +341,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -357,8 +349,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - __cf_bm=daLjsRYl4e1swzRhMGi7txja5RcE.6l0BHHvKDYAKm8-1767213675-1.0.1.1-H8SNmRbdbetKI2d0i_b36DAsIKJq21VrDLGEJmWnJT3cP4VMOhpV163OUoNUwq4SvTR5gcT.UiOB6M6EyugTC5BY6.6978BE1oCQNRhrF_8;
-        _cfuvid=G80JVON9JDKas3rhhmkj2._hkOStYcgp8eMmmgSFUIA-1767213675745-0.0.1.1-604800000
+      - __cf_bm=DoxQho_Y_QxFirwPxhIrBs2DHWJ29HATA6B.FhagfIA-1776367256.465088-1.0.1.1-viET.LdhPAnU6ziur0OCuYdk.CotiTT._ef5kCnSPs0vK0s3saonprEpcGLN0AKsxUwIHEMfXeOybKWeUkleeypHG7Vf0OPRcOAY3jp9ePgcrPKmP30WDbcFaQNRezNZ
       Host:
       - api.openai.com
       X-Stainless-Async:
@@ -371,125 +362,123 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0a418a38cbd95bcd0169558a6db6a4819fa22a82fc183ad602","object":"response","created_at":1767213677,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.created","response":{"id":"resp_0e37f865145d094c0169e1369ac3188196ace6b279067fba48","object":"response","created_at":1776367258,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0a418a38cbd95bcd0169558a6db6a4819fa22a82fc183ad602","object":"response","created_at":1767213677,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.in_progress","response":{"id":"resp_0e37f865145d094c0169e1369ac3188196ace6b279067fba48","object":"response","created_at":1776367258,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0a418a38cbd95bcd0169558a6de524819fa12a2cbcdf2850b6","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","item":{"id":"msg_0e37f865145d094c0169e1369b1b088196831db6ecd7a23295","type":"message","status":"in_progress","content":[],"role":"assistant"},"output_index":0,"sequence_number":2}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0a418a38cbd95bcd0169558a6de524819fa12a2cbcdf2850b6","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","content_index":0,"item_id":"msg_0e37f865145d094c0169e1369b1b088196831db6ecd7a23295","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":3}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_0a418a38cbd95bcd0169558a6de524819fa12a2cbcdf2850b6","output_index":0,"content_index":0,"delta":"The","logprobs":[],"obfuscation":"vI5P6PQcB0mYG"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"The","item_id":"msg_0e37f865145d094c0169e1369b1b088196831db6ecd7a23295","logprobs":[],"obfuscation":"npZprAA4056BL","output_index":0,"sequence_number":4}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_0a418a38cbd95bcd0169558a6de524819fa12a2cbcdf2850b6","output_index":0,"content_index":0,"delta":"
-        name","logprobs":[],"obfuscation":"cejTxGBrJU6"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" name","item_id":"msg_0e37f865145d094c0169e1369b1b088196831db6ecd7a23295","logprobs":[],"obfuscation":"NvojtJlOXai","output_index":0,"sequence_number":5}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_0a418a38cbd95bcd0169558a6de524819fa12a2cbcdf2850b6","output_index":0,"content_index":0,"delta":"
-        of","logprobs":[],"obfuscation":"gPh3VFno8jQaJ"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" of","item_id":"msg_0e37f865145d094c0169e1369b1b088196831db6ecd7a23295","logprobs":[],"obfuscation":"QGJpygQnFYId1","output_index":0,"sequence_number":6}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_0a418a38cbd95bcd0169558a6de524819fa12a2cbcdf2850b6","output_index":0,"content_index":0,"delta":"
-        the","logprobs":[],"obfuscation":"p5Lcn1GmEd9N"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" the","item_id":"msg_0e37f865145d094c0169e1369b1b088196831db6ecd7a23295","logprobs":[],"obfuscation":"oNpjlL5mhw4v","output_index":0,"sequence_number":7}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_0a418a38cbd95bcd0169558a6de524819fa12a2cbcdf2850b6","output_index":0,"content_index":0,"delta":"
-        person","logprobs":[],"obfuscation":"vrmiJjh6Z"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" person","item_id":"msg_0e37f865145d094c0169e1369b1b088196831db6ecd7a23295","logprobs":[],"obfuscation":"uuxWn6MPY","output_index":0,"sequence_number":8}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_0a418a38cbd95bcd0169558a6de524819fa12a2cbcdf2850b6","output_index":0,"content_index":0,"delta":"
-        is","logprobs":[],"obfuscation":"WCrWXp26DU0TT"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" is","item_id":"msg_0e37f865145d094c0169e1369b1b088196831db6ecd7a23295","logprobs":[],"obfuscation":"oMfcN9rYE37xv","output_index":0,"sequence_number":9}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_0a418a38cbd95bcd0169558a6de524819fa12a2cbcdf2850b6","output_index":0,"content_index":0,"delta":"
-        **","logprobs":[],"obfuscation":"VLwD2QHN3xfZb"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" **","item_id":"msg_0e37f865145d094c0169e1369b1b088196831db6ecd7a23295","logprobs":[],"obfuscation":"ip9PDOnh7qqgx","output_index":0,"sequence_number":10}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_0a418a38cbd95bcd0169558a6de524819fa12a2cbcdf2850b6","output_index":0,"content_index":0,"delta":"Soph","logprobs":[],"obfuscation":"GQG5XK9gimCV"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"S","item_id":"msg_0e37f865145d094c0169e1369b1b088196831db6ecd7a23295","logprobs":[],"obfuscation":"drpY3tdOKohq5nW","output_index":0,"sequence_number":11}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_0a418a38cbd95bcd0169558a6de524819fa12a2cbcdf2850b6","output_index":0,"content_index":0,"delta":"ia","logprobs":[],"obfuscation":"WnNZb003njzWwh"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"ophie","item_id":"msg_0e37f865145d094c0169e1369b1b088196831db6ecd7a23295","logprobs":[],"obfuscation":"Y9o1VDYEard","output_index":0,"sequence_number":12}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_0a418a38cbd95bcd0169558a6de524819fa12a2cbcdf2850b6","output_index":0,"content_index":0,"delta":"
-        Johnson","logprobs":[],"obfuscation":"7HIpxiIW"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" Ramirez","item_id":"msg_0e37f865145d094c0169e1369b1b088196831db6ecd7a23295","logprobs":[],"obfuscation":"lPd29JmT","output_index":0,"sequence_number":13}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_0a418a38cbd95bcd0169558a6de524819fa12a2cbcdf2850b6","output_index":0,"content_index":0,"delta":"**","logprobs":[],"obfuscation":"J2PYacztHNoR5t"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"**","item_id":"msg_0e37f865145d094c0169e1369b1b088196831db6ecd7a23295","logprobs":[],"obfuscation":"u6ZosHdkFqyo70","output_index":0,"sequence_number":14}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_0a418a38cbd95bcd0169558a6de524819fa12a2cbcdf2850b6","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"uN0ZvKJkkNAaK5P"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_0e37f865145d094c0169e1369b1b088196831db6ecd7a23295","logprobs":[],"obfuscation":"rXUN3K4ah91g1k1","output_index":0,"sequence_number":15}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":16,"item_id":"msg_0a418a38cbd95bcd0169558a6de524819fa12a2cbcdf2850b6","output_index":0,"content_index":0,"text":"The
-        name of the person is **Sophia Johnson**.","logprobs":[]}
+        data: {"type":"response.output_text.done","content_index":0,"item_id":"msg_0e37f865145d094c0169e1369b1b088196831db6ecd7a23295","logprobs":[],"output_index":0,"sequence_number":16,"text":"The
+        name of the person is **Sophie Ramirez**."}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":17,"item_id":"msg_0a418a38cbd95bcd0169558a6de524819fa12a2cbcdf2850b6","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"The
-        name of the person is **Sophia Johnson**."}}
+        data: {"type":"response.content_part.done","content_index":0,"item_id":"msg_0e37f865145d094c0169e1369b1b088196831db6ecd7a23295","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"The
+        name of the person is **Sophie Ramirez**."},"sequence_number":17}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":18,"output_index":0,"item":{"id":"msg_0a418a38cbd95bcd0169558a6de524819fa12a2cbcdf2850b6","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"The
-        name of the person is **Sophia Johnson**."}],"role":"assistant"}}
+        data: {"type":"response.output_item.done","item":{"id":"msg_0e37f865145d094c0169e1369b1b088196831db6ecd7a23295","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"The
+        name of the person is **Sophie Ramirez**."}],"role":"assistant"},"output_index":0,"sequence_number":18}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":19,"response":{"id":"resp_0a418a38cbd95bcd0169558a6db6a4819fa22a82fc183ad602","object":"response","created_at":1767213677,"status":"completed","background":false,"completed_at":1767213677,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"msg_0a418a38cbd95bcd0169558a6de524819fa12a2cbcdf2850b6","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"The
-        name of the person is **Sophia Johnson**."}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":166,"input_tokens_details":{"cached_tokens":0},"output_tokens":13,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":179},"user":null,"metadata":{}}}
+        data: {"type":"response.completed","response":{"id":"resp_0e37f865145d094c0169e1369ac3188196ace6b279067fba48","object":"response","created_at":1776367258,"status":"completed","background":false,"completed_at":1776367259,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"msg_0e37f865145d094c0169e1369b1b088196831db6ecd7a23295","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"The
+        name of the person is **Sophie Ramirez**."}],"role":"assistant"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":166,"input_tokens_details":{"cached_tokens":0},"output_tokens":13,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":179},"user":null,"metadata":{}},"sequence_number":19}
+
+
+        event: response.rate_limits.updated
+
+        data: {"type":"response.rate_limits.updated","rate_limits":{"limit_requests":"10000","limit_tokens":"30000000","remaining_requests":"9999","remaining_tokens":"30000000","reset_requests_ms":6,"reset_tokens_ms":0},"sequence_number":20}
 
 
         '
     headers:
       CF-RAY:
-      - 9b6c98cd7fabda16-ORD
+      - 9ed58ce6e82e3bdc-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:17 GMT
+      - Thu, 16 Apr 2026 19:20:58 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -503,11 +492,21 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       openai-processing-ms:
-      - '67'
+      - '91'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '70'
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '30000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '29999815'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
     status:
       code: 200
       message: OK

--- a/tests/_vcr/test_provider_openai/test_openai_images.yaml
+++ b/tests/_vcr/test_provider_openai/test_openai_images.yaml
@@ -8,7 +8,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -27,194 +27,197 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0582841f432da9070169558a6e40c08192990ea53a4598b0cf","object":"response","created_at":1767213678,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.created","response":{"id":"resp_03ec059f93e27d870169e1369fdbb48193bca19a8d756ee74b","object":"response","created_at":1776367263,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0582841f432da9070169558a6e40c08192990ea53a4598b0cf","object":"response","created_at":1767213678,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.in_progress","response":{"id":"resp_03ec059f93e27d870169e1369fdbb48193bca19a8d756ee74b","object":"response","created_at":1776367263,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0582841f432da9070169558a6e8c8881928a268084c5c573ea","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","item":{"id":"msg_03ec059f93e27d870169e136a07dfc81938589a20bc34b8954","type":"message","status":"in_progress","content":[],"role":"assistant"},"output_index":0,"sequence_number":2}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0582841f432da9070169558a6e8c8881928a268084c5c573ea","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","content_index":0,"item_id":"msg_03ec059f93e27d870169e136a07dfc81938589a20bc34b8954","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":3}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_0582841f432da9070169558a6e8c8881928a268084c5c573ea","output_index":0,"content_index":0,"delta":"This","logprobs":[],"obfuscation":"uHQTw8Irk1HO"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"This","item_id":"msg_03ec059f93e27d870169e136a07dfc81938589a20bc34b8954","logprobs":[],"obfuscation":"nsZdS2nwpez8","output_index":0,"sequence_number":4}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_0582841f432da9070169558a6e8c8881928a268084c5c573ea","output_index":0,"content_index":0,"delta":"
-        image","logprobs":[],"obfuscation":"Q3goKI9szs"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" image","item_id":"msg_03ec059f93e27d870169e136a07dfc81938589a20bc34b8954","logprobs":[],"obfuscation":"NrSdd2DsuP","output_index":0,"sequence_number":5}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_0582841f432da9070169558a6e8c8881928a268084c5c573ea","output_index":0,"content_index":0,"delta":"
-        consists","logprobs":[],"obfuscation":"6i97X2G"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" is","item_id":"msg_03ec059f93e27d870169e136a07dfc81938589a20bc34b8954","logprobs":[],"obfuscation":"9Ih98f87ihYkV","output_index":0,"sequence_number":6}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_0582841f432da9070169558a6e8c8881928a268084c5c573ea","output_index":0,"content_index":0,"delta":"
-        entirely","logprobs":[],"obfuscation":"AoMuy0c"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" a","item_id":"msg_03ec059f93e27d870169e136a07dfc81938589a20bc34b8954","logprobs":[],"obfuscation":"DXClgIM7N1yasb","output_index":0,"sequence_number":7}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_0582841f432da9070169558a6e8c8881928a268084c5c573ea","output_index":0,"content_index":0,"delta":"
-        of","logprobs":[],"obfuscation":"bitD24WgfeUYv"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" solid","item_id":"msg_03ec059f93e27d870169e136a07dfc81938589a20bc34b8954","logprobs":[],"obfuscation":"dlzXAj1IFo","output_index":0,"sequence_number":8}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_0582841f432da9070169558a6e8c8881928a268084c5c573ea","output_index":0,"content_index":0,"delta":"
-        a","logprobs":[],"obfuscation":"26gYaTlEapEXq9"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" block","item_id":"msg_03ec059f93e27d870169e136a07dfc81938589a20bc34b8954","logprobs":[],"obfuscation":"1YqZ7AQz3h","output_index":0,"sequence_number":9}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_0582841f432da9070169558a6e8c8881928a268084c5c573ea","output_index":0,"content_index":0,"delta":"
-        solid","logprobs":[],"obfuscation":"oE2nw0vCKt"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" of","item_id":"msg_03ec059f93e27d870169e136a07dfc81938589a20bc34b8954","logprobs":[],"obfuscation":"3TuDqOpV1MMtR","output_index":0,"sequence_number":10}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_0582841f432da9070169558a6e8c8881928a268084c5c573ea","output_index":0,"content_index":0,"delta":"
-        red","logprobs":[],"obfuscation":"uk46qNeaRaLK"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" red","item_id":"msg_03ec059f93e27d870169e136a07dfc81938589a20bc34b8954","logprobs":[],"obfuscation":"NsqsqAXgpfl2","output_index":0,"sequence_number":11}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_0582841f432da9070169558a6e8c8881928a268084c5c573ea","output_index":0,"content_index":0,"delta":"
-        color","logprobs":[],"obfuscation":"ltpngsNghs"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" color","item_id":"msg_03ec059f93e27d870169e136a07dfc81938589a20bc34b8954","logprobs":[],"obfuscation":"BlQiiu2A7T","output_index":0,"sequence_number":12}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_0582841f432da9070169558a6e8c8881928a268084c5c573ea","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"XmMuafs7yeBhHaK"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_03ec059f93e27d870169e136a07dfc81938589a20bc34b8954","logprobs":[],"obfuscation":"jffYELs4d0HwFce","output_index":0,"sequence_number":13}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_0582841f432da9070169558a6e8c8881928a268084c5c573ea","output_index":0,"content_index":0,"delta":"
-        There","logprobs":[],"obfuscation":"anD0poKB9n"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" There","item_id":"msg_03ec059f93e27d870169e136a07dfc81938589a20bc34b8954","logprobs":[],"obfuscation":"a1hTvUbxgB","output_index":0,"sequence_number":14}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_0582841f432da9070169558a6e8c8881928a268084c5c573ea","output_index":0,"content_index":0,"delta":"
-        are","logprobs":[],"obfuscation":"IvC70ZQt17Fd"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" are","item_id":"msg_03ec059f93e27d870169e136a07dfc81938589a20bc34b8954","logprobs":[],"obfuscation":"4UpyPx08j51q","output_index":0,"sequence_number":15}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_0582841f432da9070169558a6e8c8881928a268084c5c573ea","output_index":0,"content_index":0,"delta":"
-        no","logprobs":[],"obfuscation":"3Cf9QtWrpdrjW"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" no","item_id":"msg_03ec059f93e27d870169e136a07dfc81938589a20bc34b8954","logprobs":[],"obfuscation":"Oye9AXSXAlWib","output_index":0,"sequence_number":16}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_0582841f432da9070169558a6e8c8881928a268084c5c573ea","output_index":0,"content_index":0,"delta":"
-        discern","logprobs":[],"obfuscation":"ywQuUBnt"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" discern","item_id":"msg_03ec059f93e27d870169e136a07dfc81938589a20bc34b8954","logprobs":[],"obfuscation":"4bkrtWBb","output_index":0,"sequence_number":17}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_0582841f432da9070169558a6e8c8881928a268084c5c573ea","output_index":0,"content_index":0,"delta":"ible","logprobs":[],"obfuscation":"bQsIQe8T9Qsq"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"ible","item_id":"msg_03ec059f93e27d870169e136a07dfc81938589a20bc34b8954","logprobs":[],"obfuscation":"psHSbKNPTxAY","output_index":0,"sequence_number":18}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_0582841f432da9070169558a6e8c8881928a268084c5c573ea","output_index":0,"content_index":0,"delta":"
-        objects","logprobs":[],"obfuscation":"6FCyCxn0"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" objects","item_id":"msg_03ec059f93e27d870169e136a07dfc81938589a20bc34b8954","logprobs":[],"obfuscation":"jdVEisMJ","output_index":0,"sequence_number":19}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_0582841f432da9070169558a6e8c8881928a268084c5c573ea","output_index":0,"content_index":0,"delta":",","logprobs":[],"obfuscation":"fCdH6Jpnid1hi7P"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":",","item_id":"msg_03ec059f93e27d870169e136a07dfc81938589a20bc34b8954","logprobs":[],"obfuscation":"8i9S4XM8t9MfjyT","output_index":0,"sequence_number":20}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_0582841f432da9070169558a6e8c8881928a268084c5c573ea","output_index":0,"content_index":0,"delta":"
-        text","logprobs":[],"obfuscation":"vHXVH8VA3Rb"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" text","item_id":"msg_03ec059f93e27d870169e136a07dfc81938589a20bc34b8954","logprobs":[],"obfuscation":"5iC0RdtrKBy","output_index":0,"sequence_number":21}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_0582841f432da9070169558a6e8c8881928a268084c5c573ea","output_index":0,"content_index":0,"delta":",","logprobs":[],"obfuscation":"dyWOP5ANxnufY0h"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":",","item_id":"msg_03ec059f93e27d870169e136a07dfc81938589a20bc34b8954","logprobs":[],"obfuscation":"JBp49uHabWZI806","output_index":0,"sequence_number":22}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_0582841f432da9070169558a6e8c8881928a268084c5c573ea","output_index":0,"content_index":0,"delta":"
-        or","logprobs":[],"obfuscation":"hVBVFLWnNXvU2"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" or","item_id":"msg_03ec059f93e27d870169e136a07dfc81938589a20bc34b8954","logprobs":[],"obfuscation":"fMFyFIJOMs9hT","output_index":0,"sequence_number":23}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_0582841f432da9070169558a6e8c8881928a268084c5c573ea","output_index":0,"content_index":0,"delta":"
-        patterns","logprobs":[],"obfuscation":"KbY5gwA"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" patterns","item_id":"msg_03ec059f93e27d870169e136a07dfc81938589a20bc34b8954","logprobs":[],"obfuscation":"0RlMEAB","output_index":0,"sequence_number":24}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_0582841f432da9070169558a6e8c8881928a268084c5c573ea","output_index":0,"content_index":0,"delta":"
-        present","logprobs":[],"obfuscation":"Edromx2q"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" visible","item_id":"msg_03ec059f93e27d870169e136a07dfc81938589a20bc34b8954","logprobs":[],"obfuscation":"QD22Txvn","output_index":0,"sequence_number":25}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_0582841f432da9070169558a6e8c8881928a268084c5c573ea","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"9uR64VzbY3InoqK"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" in","item_id":"msg_03ec059f93e27d870169e136a07dfc81938589a20bc34b8954","logprobs":[],"obfuscation":"hQdPbHSaSyJEB","output_index":0,"sequence_number":26}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" the","item_id":"msg_03ec059f93e27d870169e136a07dfc81938589a20bc34b8954","logprobs":[],"obfuscation":"tCp6QzH0evn2","output_index":0,"sequence_number":27}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" image","item_id":"msg_03ec059f93e27d870169e136a07dfc81938589a20bc34b8954","logprobs":[],"obfuscation":"MCJYoFpKVD","output_index":0,"sequence_number":28}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_03ec059f93e27d870169e136a07dfc81938589a20bc34b8954","logprobs":[],"obfuscation":"AEDu3Rfq7jgIs1H","output_index":0,"sequence_number":29}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":27,"item_id":"msg_0582841f432da9070169558a6e8c8881928a268084c5c573ea","output_index":0,"content_index":0,"text":"This
-        image consists entirely of a solid red color. There are no discernible objects,
-        text, or patterns present.","logprobs":[]}
+        data: {"type":"response.output_text.done","content_index":0,"item_id":"msg_03ec059f93e27d870169e136a07dfc81938589a20bc34b8954","logprobs":[],"output_index":0,"sequence_number":30,"text":"This
+        image is a solid block of red color. There are no discernible objects, text,
+        or patterns visible in the image."}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":28,"item_id":"msg_0582841f432da9070169558a6e8c8881928a268084c5c573ea","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"This
-        image consists entirely of a solid red color. There are no discernible objects,
-        text, or patterns present."}}
+        data: {"type":"response.content_part.done","content_index":0,"item_id":"msg_03ec059f93e27d870169e136a07dfc81938589a20bc34b8954","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"This
+        image is a solid block of red color. There are no discernible objects, text,
+        or patterns visible in the image."},"sequence_number":31}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":29,"output_index":0,"item":{"id":"msg_0582841f432da9070169558a6e8c8881928a268084c5c573ea","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"This
-        image consists entirely of a solid red color. There are no discernible objects,
-        text, or patterns present."}],"role":"assistant"}}
+        data: {"type":"response.output_item.done","item":{"id":"msg_03ec059f93e27d870169e136a07dfc81938589a20bc34b8954","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"This
+        image is a solid block of red color. There are no discernible objects, text,
+        or patterns visible in the image."}],"role":"assistant"},"output_index":0,"sequence_number":32}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":30,"response":{"id":"resp_0582841f432da9070169558a6e40c08192990ea53a4598b0cf","object":"response","created_at":1767213678,"status":"completed","background":false,"completed_at":1767213679,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"msg_0582841f432da9070169558a6e8c8881928a268084c5c573ea","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"This
-        image consists entirely of a solid red color. There are no discernible objects,
-        text, or patterns present."}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":272,"input_tokens_details":{"cached_tokens":0},"output_tokens":24,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":296},"user":null,"metadata":{}}}
+        data: {"type":"response.completed","response":{"id":"resp_03ec059f93e27d870169e1369fdbb48193bca19a8d756ee74b","object":"response","created_at":1776367263,"status":"completed","background":false,"completed_at":1776367264,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"msg_03ec059f93e27d870169e136a07dfc81938589a20bc34b8954","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"This
+        image is a solid block of red color. There are no discernible objects, text,
+        or patterns visible in the image."}],"role":"assistant"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":272,"input_tokens_details":{"cached_tokens":0},"output_tokens":27,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":299},"user":null,"metadata":{}},"sequence_number":33}
+
+
+        event: response.rate_limits.updated
+
+        data: {"type":"response.rate_limits.updated","rate_limits":{"limit_requests":"10000","limit_tokens":"30000000","remaining_requests":"9999","remaining_tokens":"30000000","reset_requests_ms":6,"reset_tokens_ms":0},"sequence_number":34}
 
 
         '
     headers:
       CF-RAY:
-      - 9b6c98d0bda289ed-ORD
+      - 9ed58d06b813844d-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:18 GMT
+      - Thu, 16 Apr 2026 19:21:03 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -228,11 +231,21 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       openai-processing-ms:
-      - '54'
+      - '102'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '58'
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '30000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '29999542'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
     status:
       code: 200
       message: OK
@@ -245,7 +258,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -264,594 +277,494 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_04f2367676577f240169558a6f6230819daae9b493b5a2a662","object":"response","created_at":1767213679,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.created","response":{"id":"resp_00573790b85ebf870169e136a0dbec8195907935cd4e09ed18","object":"response","created_at":1776367265,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_04f2367676577f240169558a6f6230819daae9b493b5a2a662","object":"response","created_at":1767213679,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.in_progress","response":{"id":"resp_00573790b85ebf870169e136a0dbec8195907935cd4e09ed18","object":"response","created_at":1776367265,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","item":{"id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","type":"message","status":"in_progress","content":[],"role":"assistant"},"output_index":0,"sequence_number":2}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","content_index":0,"item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":3}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"This","logprobs":[],"obfuscation":"kk2o2dFmxk1v"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"This","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"1IeNkt6nzrnG","output_index":0,"sequence_number":4}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        image","logprobs":[],"obfuscation":"b0YLbFg4RC"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" image","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"pyfCe3vJFd","output_index":0,"sequence_number":5}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        is","logprobs":[],"obfuscation":"HYMT6n7SwjXTE"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" is","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"IrnA35ZgVgGzi","output_index":0,"sequence_number":6}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        in","logprobs":[],"obfuscation":"Zga5yuNlNOlHc"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" contained","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"y8CpHH","output_index":0,"sequence_number":7}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        the","logprobs":[],"obfuscation":"zbPO1wSUJsCB"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" within","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"ALcG4Ww6I","output_index":0,"sequence_number":8}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        shape","logprobs":[],"obfuscation":"o4vqacPcaz"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" a","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"lieBJc5OB9c2Vu","output_index":0,"sequence_number":9}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        of","logprobs":[],"obfuscation":"SrHOEC0JKAhm8"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" hex","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"Oyc6o369Oo3g","output_index":0,"sequence_number":10}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        a","logprobs":[],"obfuscation":"uvipZCYGRrccl9"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"agon","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"6FayxDCTqB52","output_index":0,"sequence_number":11}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        hex","logprobs":[],"obfuscation":"PIKe7ARCQ0u8"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" shape","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"fGgS4Q8IJ6","output_index":0,"sequence_number":12}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"agon","logprobs":[],"obfuscation":"A4p7PJmW4LIB"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"xLjIHq3LVMeyMtz","output_index":0,"sequence_number":13}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"NzxPyNW4517OhXP"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" Inside","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"w3FfM4bF0","output_index":0,"sequence_number":14}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        Inside","logprobs":[],"obfuscation":"vnVDmpvwP"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" the","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"UJAvLVb2VYWW","output_index":0,"sequence_number":15}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        the","logprobs":[],"obfuscation":"rtOcIEgi7TES"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" hex","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"LbL6reVNcd9G","output_index":0,"sequence_number":16}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        hex","logprobs":[],"obfuscation":"OT97mvE6ED55"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"agon","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"im48UUDFz4K6","output_index":0,"sequence_number":17}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"agon","logprobs":[],"obfuscation":"oLIAJqBNPFAG"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":",","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"UCHc9StRzVXUbpU","output_index":0,"sequence_number":18}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":",","logprobs":[],"obfuscation":"d3wksCsrnLkUMQw"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" there","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"FvLUp88PqI","output_index":0,"sequence_number":19}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        there","logprobs":[],"obfuscation":"nmbnzXYMvD"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" is","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"EvpTy6TorJLn6","output_index":0,"sequence_number":20}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        is","logprobs":[],"obfuscation":"Vd1Yyz5y5OJqo"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" an","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"HGqcPKE1mYnSQ","output_index":0,"sequence_number":21}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        a","logprobs":[],"obfuscation":"5x9uN9RSmnkkgG"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" illustration","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"LfS","output_index":0,"sequence_number":22}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        drawing","logprobs":[],"obfuscation":"LEkSB4ZB"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" of","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"tYcnRH5Xm3Uej","output_index":0,"sequence_number":23}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        of","logprobs":[],"obfuscation":"UN4olszf8pjDt"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" a","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"8isLkW9U4yYhn1","output_index":0,"sequence_number":24}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        a","logprobs":[],"obfuscation":"Evu7CWwPY8PNB5"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" baseball","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"9H4B8aY","output_index":0,"sequence_number":25}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        baseball","logprobs":[],"obfuscation":"ImzUZkV"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" player","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"eCrokbPqC","output_index":0,"sequence_number":26}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        player","logprobs":[],"obfuscation":"kyhJfsWiX"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" in","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"XjUbx1cCcaIXV","output_index":0,"sequence_number":27}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        in","logprobs":[],"obfuscation":"3Q9QMBH8hPTsK"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" a","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"JpSdtW0Lu06sV4","output_index":0,"sequence_number":28}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        red","logprobs":[],"obfuscation":"1GZt7wpHyFwH"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" red","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"TYKjvL7Sx5DC","output_index":0,"sequence_number":29}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        swinging","logprobs":[],"obfuscation":"7JBMc0t"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" color","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"ifr5DGPufO","output_index":0,"sequence_number":30}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":31,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        a","logprobs":[],"obfuscation":"ysX8veiXochsJN"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":",","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"SKKUlOwdY56MzU1","output_index":0,"sequence_number":31}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":32,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        bat","logprobs":[],"obfuscation":"WcDOfKTpwVdV"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" swinging","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"s1P2prc","output_index":0,"sequence_number":32}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":33,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"yHydfE8dOkX9UTe"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" a","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"rtE4HFYJfPGZlR","output_index":0,"sequence_number":33}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":34,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        Above","logprobs":[],"obfuscation":"MXN7xH1X3O"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" bat","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"8F7t8Pc2ZfPo","output_index":0,"sequence_number":34}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":35,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        the","logprobs":[],"obfuscation":"EbLIoXAy8d67"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"OttkbSNVqvlykYn","output_index":0,"sequence_number":35}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":36,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        player","logprobs":[],"obfuscation":"XxhrhprOJ"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" Above","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"C1dwpen6Hi","output_index":0,"sequence_number":36}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":37,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":",","logprobs":[],"obfuscation":"L6TDCKxS26tJyQE"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" the","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"nKSLIKryG7Q3","output_index":0,"sequence_number":37}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":38,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        there","logprobs":[],"obfuscation":"5cf47A13Nf"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" player","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"ruOOpWqpb","output_index":0,"sequence_number":38}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":39,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        is","logprobs":[],"obfuscation":"IoHnwKg90PPtb"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" is","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"eVV7x8FMsLQbW","output_index":0,"sequence_number":39}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":40,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        the","logprobs":[],"obfuscation":"27BXbizmkm2e"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" the","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"xcTEjda25qXI","output_index":0,"sequence_number":40}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":41,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        styl","logprobs":[],"obfuscation":"szk1zbDsYWa"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" styl","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"EyTvuosGRo6","output_index":0,"sequence_number":41}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":42,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"ized","logprobs":[],"obfuscation":"66AXzPUiWw8c"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"ized","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"6UM6C60HLTf1","output_index":0,"sequence_number":42}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":43,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        text","logprobs":[],"obfuscation":"ckPeVL9Cbea"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" text","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"5nC3yYqvpid","output_index":0,"sequence_number":43}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":44,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"v6bNHJReKWg0Dv"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" \"","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"73s7DIkNTznh0A","output_index":0,"sequence_number":44}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":45,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"ht","logprobs":[],"obfuscation":"6T4bQESNneY9Sd"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"ht","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"79NwaMTvZHRz5g","output_index":0,"sequence_number":45}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":46,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"tr","logprobs":[],"obfuscation":"9Oi6s0A5yPsY9B"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"tr","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"XRDvkjxfkDsOmN","output_index":0,"sequence_number":46}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":47,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"2","logprobs":[],"obfuscation":"k6PBlW3WRiUDb8j"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"2","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"5cxjnZWJk8VFh75","output_index":0,"sequence_number":47}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":48,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"\"","logprobs":[],"obfuscation":"L5U1u6kXskuNouS"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"\"","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"P7u8Oib1cRSJpcH","output_index":0,"sequence_number":48}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":49,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        in","logprobs":[],"obfuscation":"c6bfjd0rlS5Oe"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" in","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"8YoyNK8F1Ye3H","output_index":0,"sequence_number":49}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":50,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        white","logprobs":[],"obfuscation":"zmkzWKbcUb"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" a","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"32b7FMDk2qPB3z","output_index":0,"sequence_number":50}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":51,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":",","logprobs":[],"obfuscation":"OrbFuDHaTUeQQ8A"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" script","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"zWoyAUtBB","output_index":0,"sequence_number":51}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":52,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        with","logprobs":[],"obfuscation":"P2HkH8X2elF"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" font","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"yr2EFAqQZ8w","output_index":0,"sequence_number":52}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":53,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        a","logprobs":[],"obfuscation":"Pzoi5xInjpf5UR"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":",","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"Pyc7wGsldPKAe4H","output_index":0,"sequence_number":53}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":54,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        swo","logprobs":[],"obfuscation":"2vCGJ8pt89ew"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" with","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"5afWYDb9Qm8","output_index":0,"sequence_number":54}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":55,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"osh","logprobs":[],"obfuscation":"dZ4xwhGb46QeI"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" a","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"SXVZ37KczMaRoo","output_index":0,"sequence_number":55}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":56,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        graphic","logprobs":[],"obfuscation":"QDEnyoEl"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" swo","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"adz1ldbtvrzW","output_index":0,"sequence_number":56}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":57,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        beneath","logprobs":[],"obfuscation":"GRB7i5AI"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"osh","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"Lm7rlarmI0RdS","output_index":0,"sequence_number":57}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":58,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        it","logprobs":[],"obfuscation":"biuaAd5blNEYH"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" underline","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"gmOjMd","output_index":0,"sequence_number":58}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":59,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":",","logprobs":[],"obfuscation":"VWDgSPy7c9uuUUA"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" reminiscent","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"NbaV","output_index":0,"sequence_number":59}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":60,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        resembling","logprobs":[],"obfuscation":"LWAQI"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" of","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"f5ecN5rqAFxZd","output_index":0,"sequence_number":60}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":61,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        a","logprobs":[],"obfuscation":"ovRIL1YDFTUite"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" sports","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"UKQ3MuEAJ","output_index":0,"sequence_number":61}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":62,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        baseball","logprobs":[],"obfuscation":"549PwQg"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" logos","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"HtGM92BU6N","output_index":0,"sequence_number":62}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":63,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        logo","logprobs":[],"obfuscation":"tLuWyLXayGj"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"A8dpFsWGea4ZpzM","output_index":0,"sequence_number":63}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":64,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"yp9ZkabfQcj1uxK"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" There","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"4UkBXVcIFw","output_index":0,"sequence_number":64}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":65,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        There","logprobs":[],"obfuscation":"Q5BgDVhz5O"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" is","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"EiaieRRoRDas3","output_index":0,"sequence_number":65}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":66,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        is","logprobs":[],"obfuscation":"Vkde1HCXy2eDj"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" also","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"HoIOgIvIOMV","output_index":0,"sequence_number":66}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":67,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        also","logprobs":[],"obfuscation":"N2iYjZ8iBrl"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" a","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"xU0T3rRqIzqxNN","output_index":0,"sequence_number":67}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":68,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        a","logprobs":[],"obfuscation":"BNRCQOi5DUpi1y"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" small","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"EE6IyG9IOK","output_index":0,"sequence_number":68}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":69,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        small","logprobs":[],"obfuscation":"qSW2j5mMsQ"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" red","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"4RMKVESbn89p","output_index":0,"sequence_number":69}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":70,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        red","logprobs":[],"obfuscation":"wQj2mWwqtdhG"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" baseball","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"MwxXSX5","output_index":0,"sequence_number":70}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":71,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        circle","logprobs":[],"obfuscation":"1bzf632mq"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" with","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"BWtudz036t5","output_index":0,"sequence_number":71}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":72,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        with","logprobs":[],"obfuscation":"vG8kDiIhlq5"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" \"","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"tqyyclgrMNEmZU","output_index":0,"sequence_number":72}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":73,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"jSUcFCehasrovk"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"www","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"gLTbqRv1aXqVp","output_index":0,"sequence_number":73}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":74,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"www","logprobs":[],"obfuscation":"92xIYFBU7XkuS"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"\"","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"G4BOcF9DBpb7c51","output_index":0,"sequence_number":74}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":75,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"\"","logprobs":[],"obfuscation":"3vFNzF0uEfQWERI"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" written","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"t68Ao8qL","output_index":0,"sequence_number":75}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":76,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        written","logprobs":[],"obfuscation":"ruh5d6eq"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" on","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"IBYkcjWeM6zBP","output_index":0,"sequence_number":76}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":77,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        on","logprobs":[],"obfuscation":"BRSa6Fs3CO2dH"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" it","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"XFzAfQxtbXTq3","output_index":0,"sequence_number":77}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":78,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        it","logprobs":[],"obfuscation":"F2xLyo9jZAI48"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"3R7lqlI6215LBM3","output_index":0,"sequence_number":78}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":79,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        to","logprobs":[],"obfuscation":"JhD8zLHpS6Vav"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" The","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"kCzRXfR6RGV2","output_index":0,"sequence_number":79}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":80,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        the","logprobs":[],"obfuscation":"8tOnpXUfzm3r"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" background","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"FItTx","output_index":0,"sequence_number":80}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":81,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        left","logprobs":[],"obfuscation":"D7tfQof0AhP"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" is","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"BbvA0nCT4bbia","output_index":0,"sequence_number":81}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":82,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        of","logprobs":[],"obfuscation":"54zRhBwZzu1gY"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" a","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"TmrcqgboOvPNTD","output_index":0,"sequence_number":82}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":83,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        the","logprobs":[],"obfuscation":"mN6EurIHb44N"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" dark","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"Yt7z2gkKGaI","output_index":0,"sequence_number":83}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":84,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        player","logprobs":[],"obfuscation":"wYl761RDH"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" blue","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"wwPL4Z5AlKB","output_index":0,"sequence_number":84}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":85,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"iGgn9csZikfofVz"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" color","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"rTYeV8IqXn","output_index":0,"sequence_number":85}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":86,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        The","logprobs":[],"obfuscation":"0ClurK870q5F"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":87,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        background","logprobs":[],"obfuscation":"jSUMG"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":88,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        color","logprobs":[],"obfuscation":"ZwpGhRjc7G"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":89,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        is","logprobs":[],"obfuscation":"rvxtuVuLLJJTT"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":90,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        a","logprobs":[],"obfuscation":"yxQCqYPwSF3BHI"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":91,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        dark","logprobs":[],"obfuscation":"c1O7KfxcaHZ"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":92,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":"
-        blue","logprobs":[],"obfuscation":"8cIxD2wbfYS"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":93,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"dlZw52z6foYAEns"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"obfuscation":"NVnbtPjzBe1d6l3","output_index":0,"sequence_number":86}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":94,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"text":"This
-        image is in the shape of a hexagon. Inside the hexagon, there is a drawing
-        of a baseball player in red swinging a bat. Above the player, there is the
-        stylized text \"httr2\" in white, with a swoosh graphic beneath it, resembling
-        a baseball logo. There is also a small red circle with \"www\" written on
-        it to the left of the player. The background color is a dark blue.","logprobs":[]}
+        data: {"type":"response.output_text.done","content_index":0,"item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","logprobs":[],"output_index":0,"sequence_number":87,"text":"This
+        image is contained within a hexagon shape. Inside the hexagon, there is an
+        illustration of a baseball player in a red color, swinging a bat. Above the
+        player is the stylized text \"httr2\" in a script font, with a swoosh underline
+        reminiscent of sports logos. There is also a small red baseball with \"www\"
+        written on it. The background is a dark blue color."}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":95,"item_id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"This
-        image is in the shape of a hexagon. Inside the hexagon, there is a drawing
-        of a baseball player in red swinging a bat. Above the player, there is the
-        stylized text \"httr2\" in white, with a swoosh graphic beneath it, resembling
-        a baseball logo. There is also a small red circle with \"www\" written on
-        it to the left of the player. The background color is a dark blue."}}
+        data: {"type":"response.content_part.done","content_index":0,"item_id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"This
+        image is contained within a hexagon shape. Inside the hexagon, there is an
+        illustration of a baseball player in a red color, swinging a bat. Above the
+        player is the stylized text \"httr2\" in a script font, with a swoosh underline
+        reminiscent of sports logos. There is also a small red baseball with \"www\"
+        written on it. The background is a dark blue color."},"sequence_number":88}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":96,"output_index":0,"item":{"id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"This
-        image is in the shape of a hexagon. Inside the hexagon, there is a drawing
-        of a baseball player in red swinging a bat. Above the player, there is the
-        stylized text \"httr2\" in white, with a swoosh graphic beneath it, resembling
-        a baseball logo. There is also a small red circle with \"www\" written on
-        it to the left of the player. The background color is a dark blue."}],"role":"assistant"}}
+        data: {"type":"response.output_item.done","item":{"id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"This
+        image is contained within a hexagon shape. Inside the hexagon, there is an
+        illustration of a baseball player in a red color, swinging a bat. Above the
+        player is the stylized text \"httr2\" in a script font, with a swoosh underline
+        reminiscent of sports logos. There is also a small red baseball with \"www\"
+        written on it. The background is a dark blue color."}],"role":"assistant"},"output_index":0,"sequence_number":89}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":97,"response":{"id":"resp_04f2367676577f240169558a6f6230819daae9b493b5a2a662","object":"response","created_at":1767213679,"status":"completed","background":false,"completed_at":1767213683,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"msg_04f2367676577f240169558a708e00819d847b41c859c340bc","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"This
-        image is in the shape of a hexagon. Inside the hexagon, there is a drawing
-        of a baseball player in red swinging a bat. Above the player, there is the
-        stylized text \"httr2\" in white, with a swoosh graphic beneath it, resembling
-        a baseball logo. There is also a small red circle with \"www\" written on
-        it to the left of the player. The background color is a dark blue."}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":281,"input_tokens_details":{"cached_tokens":0},"output_tokens":91,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":372},"user":null,"metadata":{}}}
+        data: {"type":"response.completed","response":{"id":"resp_00573790b85ebf870169e136a0dbec8195907935cd4e09ed18","object":"response","created_at":1776367265,"status":"completed","background":false,"completed_at":1776367267,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"msg_00573790b85ebf870169e136a1b560819595e7158418c2a9e2","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"This
+        image is contained within a hexagon shape. Inside the hexagon, there is an
+        illustration of a baseball player in a red color, swinging a bat. Above the
+        player is the stylized text \"httr2\" in a script font, with a swoosh underline
+        reminiscent of sports logos. There is also a small red baseball with \"www\"
+        written on it. The background is a dark blue color."}],"role":"assistant"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":281,"input_tokens_details":{"cached_tokens":0},"output_tokens":84,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":365},"user":null,"metadata":{}},"sequence_number":90}
+
+
+        event: response.rate_limits.updated
+
+        data: {"type":"response.rate_limits.updated","rate_limits":{"limit_requests":"10000","limit_tokens":"30000000","remaining_requests":"9999","remaining_tokens":"30000000","reset_requests_ms":6,"reset_tokens_ms":0},"sequence_number":91}
 
 
         '
     headers:
       CF-RAY:
-      - 9b6c98d7df2ce1a9-ORD
+      - 9ed58d0d1adab648-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:19 GMT
+      - Thu, 16 Apr 2026 19:21:05 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -865,11 +778,21 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       openai-processing-ms:
-      - '497'
+      - '360'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '501'
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '30000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '29999533'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
     status:
       code: 200
       message: OK

--- a/tests/_vcr/test_provider_openai/test_openai_list_models.yaml
+++ b/tests/_vcr/test_provider_openai/test_openai_list_models.yaml
@@ -5,7 +5,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Host:
@@ -24,30 +24,27 @@ interactions:
         \     \"created\": 1687882411,\n      \"owned_by\": \"openai\"\n    },\n    {\n
         \     \"id\": \"gpt-3.5-turbo\",\n      \"object\": \"model\",\n      \"created\":
         1677610602,\n      \"owned_by\": \"openai\"\n    },\n    {\n      \"id\":
-        \"chatgpt-image-latest\",\n      \"object\": \"model\",\n      \"created\":
-        1765925279,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"gpt-4o-mini-tts-2025-03-20\",\n      \"object\": \"model\",\n      \"created\":
-        1765610731,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"gpt-4o-mini-tts-2025-12-15\",\n      \"object\": \"model\",\n      \"created\":
-        1765610837,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"gpt-realtime-mini-2025-12-15\",\n      \"object\": \"model\",\n      \"created\":
-        1765612007,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"gpt-audio-mini-2025-12-15\",\n      \"object\": \"model\",\n      \"created\":
-        1765760008,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"davinci-002\",\n      \"object\": \"model\",\n      \"created\": 1692634301,\n
-        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"babbage-002\",\n
-        \     \"object\": \"model\",\n      \"created\": 1692634615,\n      \"owned_by\":
-        \"system\"\n    },\n    {\n      \"id\": \"gpt-3.5-turbo-instruct\",\n      \"object\":
-        \"model\",\n      \"created\": 1692901427,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"gpt-3.5-turbo-instruct-0914\",\n      \"object\":
-        \"model\",\n      \"created\": 1694122472,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"dall-e-3\",\n      \"object\": \"model\",\n
-        \     \"created\": 1698785189,\n      \"owned_by\": \"system\"\n    },\n    {\n
-        \     \"id\": \"dall-e-2\",\n      \"object\": \"model\",\n      \"created\":
-        1698798177,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"gpt-4-1106-preview\",\n      \"object\": \"model\",\n      \"created\":
-        1698957206,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"gpt-3.5-turbo-1106\",\n      \"object\": \"model\",\n      \"created\":
+        \"gpt-5.4-mini\",\n      \"object\": \"model\",\n      \"created\": 1773451123,\n
+        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"gpt-5.4\",\n
+        \     \"object\": \"model\",\n      \"created\": 1772691852,\n      \"owned_by\":
+        \"system\"\n    },\n    {\n      \"id\": \"gpt-5.4-nano-2026-03-17\",\n      \"object\":
+        \"model\",\n      \"created\": 1773450837,\n      \"owned_by\": \"system\"\n
+        \   },\n    {\n      \"id\": \"gpt-5.4-nano\",\n      \"object\": \"model\",\n
+        \     \"created\": 1773450870,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"gpt-5.4-mini-2026-03-17\",\n      \"object\": \"model\",\n
+        \     \"created\": 1773451076,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"davinci-002\",\n      \"object\": \"model\",\n      \"created\":
+        1692634301,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"babbage-002\",\n      \"object\": \"model\",\n      \"created\": 1692634615,\n
+        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"gpt-3.5-turbo-instruct\",\n
+        \     \"object\": \"model\",\n      \"created\": 1692901427,\n      \"owned_by\":
+        \"system\"\n    },\n    {\n      \"id\": \"gpt-3.5-turbo-instruct-0914\",\n
+        \     \"object\": \"model\",\n      \"created\": 1694122472,\n      \"owned_by\":
+        \"system\"\n    },\n    {\n      \"id\": \"dall-e-3\",\n      \"object\":
+        \"model\",\n      \"created\": 1698785189,\n      \"owned_by\": \"system\"\n
+        \   },\n    {\n      \"id\": \"dall-e-2\",\n      \"object\": \"model\",\n
+        \     \"created\": 1698798177,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"gpt-3.5-turbo-1106\",\n      \"object\": \"model\",\n      \"created\":
         1698959748,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
         \"tts-1-hd\",\n      \"object\": \"model\",\n      \"created\": 1699046015,\n
         \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"tts-1-1106\",\n
@@ -58,64 +55,54 @@ interactions:
         \"model\",\n      \"created\": 1705948997,\n      \"owned_by\": \"system\"\n
         \   },\n    {\n      \"id\": \"text-embedding-3-large\",\n      \"object\":
         \"model\",\n      \"created\": 1705953180,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"gpt-4-0125-preview\",\n      \"object\": \"model\",\n
-        \     \"created\": 1706037612,\n      \"owned_by\": \"system\"\n    },\n    {\n
-        \     \"id\": \"gpt-4-turbo-preview\",\n      \"object\": \"model\",\n      \"created\":
-        1706037777,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"gpt-3.5-turbo-0125\",\n      \"object\": \"model\",\n      \"created\":
-        1706048358,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"gpt-4-turbo\",\n      \"object\": \"model\",\n      \"created\": 1712361441,\n
-        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"gpt-4-turbo-2024-04-09\",\n
-        \     \"object\": \"model\",\n      \"created\": 1712601677,\n      \"owned_by\":
-        \"system\"\n    },\n    {\n      \"id\": \"gpt-4o\",\n      \"object\": \"model\",\n
-        \     \"created\": 1715367049,\n      \"owned_by\": \"system\"\n    },\n    {\n
-        \     \"id\": \"gpt-4o-2024-05-13\",\n      \"object\": \"model\",\n      \"created\":
-        1715368132,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"gpt-4o-mini-2024-07-18\",\n      \"object\": \"model\",\n      \"created\":
-        1721172717,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"gpt-4o-mini\",\n      \"object\": \"model\",\n      \"created\": 1721172741,\n
-        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"gpt-4o-2024-08-06\",\n
-        \     \"object\": \"model\",\n      \"created\": 1722814719,\n      \"owned_by\":
-        \"system\"\n    },\n    {\n      \"id\": \"chatgpt-4o-latest\",\n      \"object\":
-        \"model\",\n      \"created\": 1723515131,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"gpt-4o-audio-preview\",\n      \"object\":
-        \"model\",\n      \"created\": 1727460443,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"gpt-4o-realtime-preview\",\n      \"object\":
-        \"model\",\n      \"created\": 1727659998,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"omni-moderation-latest\",\n      \"object\":
-        \"model\",\n      \"created\": 1731689265,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"omni-moderation-2024-09-26\",\n      \"object\":
-        \"model\",\n      \"created\": 1732734466,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"gpt-4o-realtime-preview-2024-12-17\",\n      \"object\":
-        \"model\",\n      \"created\": 1733945430,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"gpt-4o-audio-preview-2024-12-17\",\n      \"object\":
-        \"model\",\n      \"created\": 1734034239,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"gpt-4o-mini-realtime-preview-2024-12-17\",\n
-        \     \"object\": \"model\",\n      \"created\": 1734112601,\n      \"owned_by\":
-        \"system\"\n    },\n    {\n      \"id\": \"gpt-4o-mini-audio-preview-2024-12-17\",\n
-        \     \"object\": \"model\",\n      \"created\": 1734115920,\n      \"owned_by\":
-        \"system\"\n    },\n    {\n      \"id\": \"o1-2024-12-17\",\n      \"object\":
-        \"model\",\n      \"created\": 1734326976,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"o1\",\n      \"object\": \"model\",\n      \"created\":
-        1734375816,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"gpt-4o-mini-realtime-preview\",\n      \"object\": \"model\",\n      \"created\":
-        1734387380,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"gpt-4o-mini-audio-preview\",\n      \"object\": \"model\",\n      \"created\":
-        1734387424,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"computer-use-preview\",\n      \"object\": \"model\",\n      \"created\":
-        1734655677,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"o3-mini\",\n      \"object\": \"model\",\n      \"created\": 1737146383,\n
-        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"o3-mini-2025-01-31\",\n
-        \     \"object\": \"model\",\n      \"created\": 1738010200,\n      \"owned_by\":
-        \"system\"\n    },\n    {\n      \"id\": \"gpt-4o-2024-11-20\",\n      \"object\":
-        \"model\",\n      \"created\": 1739331543,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"computer-use-preview-2025-03-11\",\n      \"object\":
-        \"model\",\n      \"created\": 1741377021,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"gpt-4o-search-preview-2025-03-11\",\n      \"object\":
-        \"model\",\n      \"created\": 1741388170,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"gpt-4o-search-preview\",\n      \"object\":
-        \"model\",\n      \"created\": 1741388720,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"gpt-4o-mini-search-preview-2025-03-11\",\n
+        \   },\n    {\n      \"id\": \"gpt-3.5-turbo-0125\",\n      \"object\": \"model\",\n
+        \     \"created\": 1706048358,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"gpt-4-turbo\",\n      \"object\": \"model\",\n      \"created\":
+        1712361441,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-4-turbo-2024-04-09\",\n      \"object\": \"model\",\n      \"created\":
+        1712601677,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-4o\",\n      \"object\": \"model\",\n      \"created\": 1715367049,\n
+        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"gpt-4o-2024-05-13\",\n
+        \     \"object\": \"model\",\n      \"created\": 1715368132,\n      \"owned_by\":
+        \"system\"\n    },\n    {\n      \"id\": \"gpt-4o-mini-2024-07-18\",\n      \"object\":
+        \"model\",\n      \"created\": 1721172717,\n      \"owned_by\": \"system\"\n
+        \   },\n    {\n      \"id\": \"gpt-4o-mini\",\n      \"object\": \"model\",\n
+        \     \"created\": 1721172741,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"gpt-4o-2024-08-06\",\n      \"object\": \"model\",\n      \"created\":
+        1722814719,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-4o-audio-preview\",\n      \"object\": \"model\",\n      \"created\":
+        1727460443,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-4o-realtime-preview\",\n      \"object\": \"model\",\n      \"created\":
+        1727659998,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"omni-moderation-latest\",\n      \"object\": \"model\",\n      \"created\":
+        1731689265,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"omni-moderation-2024-09-26\",\n      \"object\": \"model\",\n      \"created\":
+        1732734466,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-4o-realtime-preview-2024-12-17\",\n      \"object\": \"model\",\n      \"created\":
+        1733945430,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-4o-audio-preview-2024-12-17\",\n      \"object\": \"model\",\n      \"created\":
+        1734034239,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-4o-mini-realtime-preview-2024-12-17\",\n      \"object\": \"model\",\n
+        \     \"created\": 1734112601,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"gpt-4o-mini-audio-preview-2024-12-17\",\n      \"object\":
+        \"model\",\n      \"created\": 1734115920,\n      \"owned_by\": \"system\"\n
+        \   },\n    {\n      \"id\": \"o1-2024-12-17\",\n      \"object\": \"model\",\n
+        \     \"created\": 1734326976,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"o1\",\n      \"object\": \"model\",\n      \"created\": 1734375816,\n
+        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"gpt-4o-mini-realtime-preview\",\n
+        \     \"object\": \"model\",\n      \"created\": 1734387380,\n      \"owned_by\":
+        \"system\"\n    },\n    {\n      \"id\": \"gpt-4o-mini-audio-preview\",\n
+        \     \"object\": \"model\",\n      \"created\": 1734387424,\n      \"owned_by\":
+        \"system\"\n    },\n    {\n      \"id\": \"computer-use-preview\",\n      \"object\":
+        \"model\",\n      \"created\": 1734655677,\n      \"owned_by\": \"system\"\n
+        \   },\n    {\n      \"id\": \"o3-mini\",\n      \"object\": \"model\",\n
+        \     \"created\": 1737146383,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"o3-mini-2025-01-31\",\n      \"object\": \"model\",\n      \"created\":
+        1738010200,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-4o-2024-11-20\",\n      \"object\": \"model\",\n      \"created\": 1739331543,\n
+        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"computer-use-preview-2025-03-11\",\n
+        \     \"object\": \"model\",\n      \"created\": 1741377021,\n      \"owned_by\":
+        \"system\"\n    },\n    {\n      \"id\": \"gpt-4o-mini-search-preview-2025-03-11\",\n
         \     \"object\": \"model\",\n      \"created\": 1741390858,\n      \"owned_by\":
         \"system\"\n    },\n    {\n      \"id\": \"gpt-4o-mini-search-preview\",\n
         \     \"object\": \"model\",\n      \"created\": 1741391161,\n      \"owned_by\":
@@ -148,81 +135,80 @@ interactions:
         \"gpt-4.1-nano\",\n      \"object\": \"model\",\n      \"created\": 1744321707,\n
         \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"gpt-image-1\",\n
         \     \"object\": \"model\",\n      \"created\": 1745517030,\n      \"owned_by\":
-        \"system\"\n    },\n    {\n      \"id\": \"codex-mini-latest\",\n      \"object\":
-        \"model\",\n      \"created\": 1746673257,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"o3-pro\",\n      \"object\": \"model\",\n      \"created\":
-        1748475349,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"gpt-4o-realtime-preview-2025-06-03\",\n      \"object\": \"model\",\n      \"created\":
-        1748907838,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"gpt-4o-audio-preview-2025-06-03\",\n      \"object\": \"model\",\n      \"created\":
-        1748908498,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"o3-pro-2025-06-10\",\n      \"object\": \"model\",\n      \"created\": 1749166761,\n
-        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"o4-mini-deep-research\",\n
-        \     \"object\": \"model\",\n      \"created\": 1749685485,\n      \"owned_by\":
-        \"system\"\n    },\n    {\n      \"id\": \"o3-deep-research\",\n      \"object\":
-        \"model\",\n      \"created\": 1749840121,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"gpt-4o-transcribe-diarize\",\n      \"object\":
-        \"model\",\n      \"created\": 1750798887,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"o3-deep-research-2025-06-26\",\n      \"object\":
-        \"model\",\n      \"created\": 1750865219,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"o4-mini-deep-research-2025-06-26\",\n      \"object\":
-        \"model\",\n      \"created\": 1750866121,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"gpt-5-chat-latest\",\n      \"object\": \"model\",\n
-        \     \"created\": 1754073306,\n      \"owned_by\": \"system\"\n    },\n    {\n
-        \     \"id\": \"gpt-5-2025-08-07\",\n      \"object\": \"model\",\n      \"created\":
-        1754075360,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"gpt-5\",\n      \"object\": \"model\",\n      \"created\": 1754425777,\n
-        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"gpt-5-mini-2025-08-07\",\n
-        \     \"object\": \"model\",\n      \"created\": 1754425867,\n      \"owned_by\":
-        \"system\"\n    },\n    {\n      \"id\": \"gpt-5-mini\",\n      \"object\":
-        \"model\",\n      \"created\": 1754425928,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"gpt-5-nano-2025-08-07\",\n      \"object\":
-        \"model\",\n      \"created\": 1754426303,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"gpt-5-nano\",\n      \"object\": \"model\",\n
-        \     \"created\": 1754426384,\n      \"owned_by\": \"system\"\n    },\n    {\n
-        \     \"id\": \"gpt-audio-2025-08-28\",\n      \"object\": \"model\",\n      \"created\":
-        1756256146,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"gpt-realtime\",\n      \"object\": \"model\",\n      \"created\": 1756271701,\n
-        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"gpt-realtime-2025-08-28\",\n
-        \     \"object\": \"model\",\n      \"created\": 1756271773,\n      \"owned_by\":
-        \"system\"\n    },\n    {\n      \"id\": \"gpt-audio\",\n      \"object\":
-        \"model\",\n      \"created\": 1756339249,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"gpt-5-codex\",\n      \"object\": \"model\",\n
-        \     \"created\": 1757527818,\n      \"owned_by\": \"system\"\n    },\n    {\n
-        \     \"id\": \"gpt-image-1-mini\",\n      \"object\": \"model\",\n      \"created\":
-        1758845821,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"gpt-5-pro-2025-10-06\",\n      \"object\": \"model\",\n      \"created\":
-        1759469707,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"gpt-5-pro\",\n      \"object\": \"model\",\n      \"created\": 1759469822,\n
-        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"gpt-audio-mini\",\n
-        \     \"object\": \"model\",\n      \"created\": 1759512027,\n      \"owned_by\":
-        \"system\"\n    },\n    {\n      \"id\": \"gpt-audio-mini-2025-10-06\",\n
-        \     \"object\": \"model\",\n      \"created\": 1759512137,\n      \"owned_by\":
-        \"system\"\n    },\n    {\n      \"id\": \"gpt-5-search-api\",\n      \"object\":
-        \"model\",\n      \"created\": 1759514629,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"gpt-realtime-mini\",\n      \"object\": \"model\",\n
-        \     \"created\": 1759517133,\n      \"owned_by\": \"system\"\n    },\n    {\n
-        \     \"id\": \"gpt-realtime-mini-2025-10-06\",\n      \"object\": \"model\",\n
-        \     \"created\": 1759517175,\n      \"owned_by\": \"system\"\n    },\n    {\n
-        \     \"id\": \"sora-2\",\n      \"object\": \"model\",\n      \"created\":
-        1759708615,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"sora-2-pro\",\n      \"object\": \"model\",\n      \"created\": 1759708663,\n
-        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"gpt-5-search-api-2025-10-14\",\n
-        \     \"object\": \"model\",\n      \"created\": 1760043960,\n      \"owned_by\":
-        \"system\"\n    },\n    {\n      \"id\": \"gpt-5.1-chat-latest\",\n      \"object\":
-        \"model\",\n      \"created\": 1762547951,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"gpt-5.1-2025-11-13\",\n      \"object\": \"model\",\n
-        \     \"created\": 1762800353,\n      \"owned_by\": \"system\"\n    },\n    {\n
-        \     \"id\": \"gpt-5.1\",\n      \"object\": \"model\",\n      \"created\":
-        1762800673,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"gpt-5.1-codex\",\n      \"object\": \"model\",\n      \"created\": 1762988221,\n
-        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"gpt-5.1-codex-mini\",\n
-        \     \"object\": \"model\",\n      \"created\": 1763007109,\n      \"owned_by\":
-        \"system\"\n    },\n    {\n      \"id\": \"gpt-5.1-codex-max\",\n      \"object\":
-        \"model\",\n      \"created\": 1763671532,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"gpt-image-1.5\",\n      \"object\": \"model\",\n
-        \     \"created\": 1764030620,\n      \"owned_by\": \"system\"\n    },\n    {\n
-        \     \"id\": \"gpt-5.2-2025-12-11\",\n      \"object\": \"model\",\n      \"created\":
+        \"system\"\n    },\n    {\n      \"id\": \"o3-pro\",\n      \"object\": \"model\",\n
+        \     \"created\": 1748475349,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"gpt-4o-realtime-preview-2025-06-03\",\n      \"object\": \"model\",\n
+        \     \"created\": 1748907838,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"gpt-4o-audio-preview-2025-06-03\",\n      \"object\": \"model\",\n
+        \     \"created\": 1748908498,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"o3-pro-2025-06-10\",\n      \"object\": \"model\",\n      \"created\":
+        1749166761,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"o4-mini-deep-research\",\n      \"object\": \"model\",\n      \"created\":
+        1749685485,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"o3-deep-research\",\n      \"object\": \"model\",\n      \"created\": 1749840121,\n
+        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"gpt-4o-transcribe-diarize\",\n
+        \     \"object\": \"model\",\n      \"created\": 1750798887,\n      \"owned_by\":
+        \"system\"\n    },\n    {\n      \"id\": \"o3-deep-research-2025-06-26\",\n
+        \     \"object\": \"model\",\n      \"created\": 1750865219,\n      \"owned_by\":
+        \"system\"\n    },\n    {\n      \"id\": \"o4-mini-deep-research-2025-06-26\",\n
+        \     \"object\": \"model\",\n      \"created\": 1750866121,\n      \"owned_by\":
+        \"system\"\n    },\n    {\n      \"id\": \"gpt-5-chat-latest\",\n      \"object\":
+        \"model\",\n      \"created\": 1754073306,\n      \"owned_by\": \"system\"\n
+        \   },\n    {\n      \"id\": \"gpt-5-2025-08-07\",\n      \"object\": \"model\",\n
+        \     \"created\": 1754075360,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"gpt-5\",\n      \"object\": \"model\",\n      \"created\":
+        1754425777,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-5-mini-2025-08-07\",\n      \"object\": \"model\",\n      \"created\":
+        1754425867,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-5-mini\",\n      \"object\": \"model\",\n      \"created\": 1754425928,\n
+        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"gpt-5-nano-2025-08-07\",\n
+        \     \"object\": \"model\",\n      \"created\": 1754426303,\n      \"owned_by\":
+        \"system\"\n    },\n    {\n      \"id\": \"gpt-5-nano\",\n      \"object\":
+        \"model\",\n      \"created\": 1754426384,\n      \"owned_by\": \"system\"\n
+        \   },\n    {\n      \"id\": \"gpt-audio-2025-08-28\",\n      \"object\":
+        \"model\",\n      \"created\": 1756256146,\n      \"owned_by\": \"system\"\n
+        \   },\n    {\n      \"id\": \"gpt-realtime\",\n      \"object\": \"model\",\n
+        \     \"created\": 1756271701,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"gpt-realtime-2025-08-28\",\n      \"object\": \"model\",\n
+        \     \"created\": 1756271773,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"gpt-audio\",\n      \"object\": \"model\",\n      \"created\":
+        1756339249,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-5-codex\",\n      \"object\": \"model\",\n      \"created\": 1757527818,\n
+        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"gpt-image-1-mini\",\n
+        \     \"object\": \"model\",\n      \"created\": 1758845821,\n      \"owned_by\":
+        \"system\"\n    },\n    {\n      \"id\": \"gpt-5-pro-2025-10-06\",\n      \"object\":
+        \"model\",\n      \"created\": 1759469707,\n      \"owned_by\": \"system\"\n
+        \   },\n    {\n      \"id\": \"gpt-5-pro\",\n      \"object\": \"model\",\n
+        \     \"created\": 1759469822,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"gpt-audio-mini\",\n      \"object\": \"model\",\n      \"created\":
+        1759512027,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-audio-mini-2025-10-06\",\n      \"object\": \"model\",\n      \"created\":
+        1759512137,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-5-search-api\",\n      \"object\": \"model\",\n      \"created\": 1759514629,\n
+        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"gpt-realtime-mini\",\n
+        \     \"object\": \"model\",\n      \"created\": 1759517133,\n      \"owned_by\":
+        \"system\"\n    },\n    {\n      \"id\": \"gpt-realtime-mini-2025-10-06\",\n
+        \     \"object\": \"model\",\n      \"created\": 1759517175,\n      \"owned_by\":
+        \"system\"\n    },\n    {\n      \"id\": \"sora-2\",\n      \"object\": \"model\",\n
+        \     \"created\": 1759708615,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"sora-2-pro\",\n      \"object\": \"model\",\n      \"created\":
+        1759708663,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-5-search-api-2025-10-14\",\n      \"object\": \"model\",\n      \"created\":
+        1760043960,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-5.1-chat-latest\",\n      \"object\": \"model\",\n      \"created\":
+        1762547951,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-5.1-2025-11-13\",\n      \"object\": \"model\",\n      \"created\":
+        1762800353,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-5.1\",\n      \"object\": \"model\",\n      \"created\": 1762800673,\n
+        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"gpt-5.1-codex\",\n
+        \     \"object\": \"model\",\n      \"created\": 1762988221,\n      \"owned_by\":
+        \"system\"\n    },\n    {\n      \"id\": \"gpt-5.1-codex-mini\",\n      \"object\":
+        \"model\",\n      \"created\": 1763007109,\n      \"owned_by\": \"system\"\n
+        \   },\n    {\n      \"id\": \"gpt-5.1-codex-max\",\n      \"object\": \"model\",\n
+        \     \"created\": 1763671532,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"gpt-image-1.5\",\n      \"object\": \"model\",\n      \"created\":
+        1764030620,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-5.2-2025-12-11\",\n      \"object\": \"model\",\n      \"created\":
         1765313028,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
         \"gpt-5.2\",\n      \"object\": \"model\",\n      \"created\": 1765313051,\n
         \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"gpt-5.2-pro-2025-12-11\",\n
@@ -235,25 +221,55 @@ interactions:
         \     \"created\": 1765610407,\n      \"owned_by\": \"system\"\n    },\n    {\n
         \     \"id\": \"gpt-4o-mini-transcribe-2025-03-20\",\n      \"object\": \"model\",\n
         \     \"created\": 1765610545,\n      \"owned_by\": \"system\"\n    },\n    {\n
-        \     \"id\": \"gpt-3.5-turbo-16k\",\n      \"object\": \"model\",\n      \"created\":
-        1683758102,\n      \"owned_by\": \"openai-internal\"\n    },\n    {\n      \"id\":
-        \"tts-1\",\n      \"object\": \"model\",\n      \"created\": 1681940951,\n
-        \     \"owned_by\": \"openai-internal\"\n    },\n    {\n      \"id\": \"whisper-1\",\n
-        \     \"object\": \"model\",\n      \"created\": 1677532384,\n      \"owned_by\":
-        \"openai-internal\"\n    },\n    {\n      \"id\": \"text-embedding-ada-002\",\n
+        \     \"id\": \"gpt-4o-mini-tts-2025-03-20\",\n      \"object\": \"model\",\n
+        \     \"created\": 1765610731,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"gpt-4o-mini-tts-2025-12-15\",\n      \"object\": \"model\",\n
+        \     \"created\": 1765610837,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"gpt-realtime-mini-2025-12-15\",\n      \"object\": \"model\",\n
+        \     \"created\": 1765612007,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"gpt-audio-mini-2025-12-15\",\n      \"object\": \"model\",\n
+        \     \"created\": 1765760008,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"chatgpt-image-latest\",\n      \"object\": \"model\",\n      \"created\":
+        1765925279,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-5.2-codex\",\n      \"object\": \"model\",\n      \"created\": 1766164985,\n
+        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"gpt-5.3-codex\",\n
+        \     \"object\": \"model\",\n      \"created\": 1770537915,\n      \"owned_by\":
+        \"system\"\n    },\n    {\n      \"id\": \"gpt-realtime-1.5\",\n      \"object\":
+        \"model\",\n      \"created\": 1771461469,\n      \"owned_by\": \"system\"\n
+        \   },\n    {\n      \"id\": \"gpt-audio-1.5\",\n      \"object\": \"model\",\n
+        \     \"created\": 1771550885,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"gpt-4o-search-preview\",\n      \"object\": \"model\",\n      \"created\":
+        1771905534,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-4o-search-preview-2025-03-11\",\n      \"object\": \"model\",\n      \"created\":
+        1771905621,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-5.3-chat-latest\",\n      \"object\": \"model\",\n      \"created\":
+        1772236571,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-5.4-2026-03-05\",\n      \"object\": \"model\",\n      \"created\":
+        1772654062,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-5.4-pro\",\n      \"object\": \"model\",\n      \"created\": 1772659601,\n
+        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"gpt-5.4-pro-2026-03-05\",\n
+        \     \"object\": \"model\",\n      \"created\": 1772659657,\n      \"owned_by\":
+        \"system\"\n    },\n    {\n      \"id\": \"gpt-3.5-turbo-16k\",\n      \"object\":
+        \"model\",\n      \"created\": 1683758102,\n      \"owned_by\": \"openai-internal\"\n
+        \   },\n    {\n      \"id\": \"tts-1\",\n      \"object\": \"model\",\n      \"created\":
+        1681940951,\n      \"owned_by\": \"openai-internal\"\n    },\n    {\n      \"id\":
+        \"whisper-1\",\n      \"object\": \"model\",\n      \"created\": 1677532384,\n
+        \     \"owned_by\": \"openai-internal\"\n    },\n    {\n      \"id\": \"text-embedding-ada-002\",\n
         \     \"object\": \"model\",\n      \"created\": 1671217299,\n      \"owned_by\":
         \"openai-internal\"\n    }\n  ]\n}"
     headers:
       CF-RAY:
-      - 9b6c990249d9e1eb-ORD
+      - 9ed58d33b851eac6-ORD
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Wed, 31 Dec 2025 20:41:26 GMT
+      - Thu, 16 Apr 2026 19:21:11 GMT
       Server:
       - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
       - chunked
       X-Content-Type-Options:
@@ -263,15 +279,11 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       content-length:
-      - '15424'
+      - '16417'
       openai-processing-ms:
-      - '396'
+      - '381'
       openai-version:
       - '2020-10-01'
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains; preload
-      x-envoy-upstream-service-time:
-      - '400'
       x-openai-proxy-wasm:
       - v0.1
     status:

--- a/tests/_vcr/test_provider_openai/test_openai_logprobs.yaml
+++ b/tests/_vcr/test_provider_openai/test_openai_logprobs.yaml
@@ -7,7 +7,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -24,71 +24,73 @@ interactions:
     uri: https://api.openai.com/v1/responses
   response:
     body:
-      string: "event: response.created\ndata: {\"type\":\"response.created\",\"sequence_number\":0,\"response\":{\"id\":\"resp_0e9a84adfd3a91420169558a73b274819d84766b8ff40045ae\",\"object\":\"response\",\"created_at\":1767213683,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4.1-2025-04-14\",\"output\":[],\"parallel_tool_calls\":true,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":false,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}}}\n\nevent:
-        response.in_progress\ndata: {\"type\":\"response.in_progress\",\"sequence_number\":1,\"response\":{\"id\":\"resp_0e9a84adfd3a91420169558a73b274819d84766b8ff40045ae\",\"object\":\"response\",\"created_at\":1767213683,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4.1-2025-04-14\",\"output\":[],\"parallel_tool_calls\":true,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":false,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}}}\n\nevent:
-        response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"sequence_number\":2,\"output_index\":0,\"item\":{\"id\":\"msg_0e9a84adfd3a91420169558a73e1a8819d9d6415825cd8f291\",\"type\":\"message\",\"status\":\"in_progress\",\"content\":[],\"role\":\"assistant\"}}\n\nevent:
-        response.content_part.added\ndata: {\"type\":\"response.content_part.added\",\"sequence_number\":3,\"item_id\":\"msg_0e9a84adfd3a91420169558a73e1a8819d9d6415825cd8f291\",\"output_index\":0,\"content_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"\"}}\n\nevent:
-        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":4,\"item_id\":\"msg_0e9a84adfd3a91420169558a73e1a8819d9d6415825cd8f291\",\"output_index\":0,\"content_index\":0,\"delta\":\"Hello\",\"logprobs\":[{\"bytes\":[72,101,108,108,111],\"logprob\":-0.0031777136027812958,\"token\":\"Hello\",\"top_logprobs\":[]}],\"obfuscation\":\"W7BFcYKpyC4\"}\n\nevent:
-        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":5,\"item_id\":\"msg_0e9a84adfd3a91420169558a73e1a8819d9d6415825cd8f291\",\"output_index\":0,\"content_index\":0,\"delta\":\"!\",\"logprobs\":[{\"bytes\":[33],\"logprob\":-4.320199877838604e-7,\"token\":\"!\",\"top_logprobs\":[]}],\"obfuscation\":\"RDL2AeEnSHOPRh1\"}\n\nevent:
-        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":6,\"item_id\":\"msg_0e9a84adfd3a91420169558a73e1a8819d9d6415825cd8f291\",\"output_index\":0,\"content_index\":0,\"delta\":\"
-        How\",\"logprobs\":[{\"bytes\":[32,72,111,119],\"logprob\":-0.024717185646295547,\"token\":\"
-        How\",\"top_logprobs\":[]}],\"obfuscation\":\"5qO1UFLLEwOS\"}\n\nevent: response.output_text.delta\ndata:
-        {\"type\":\"response.output_text.delta\",\"sequence_number\":7,\"item_id\":\"msg_0e9a84adfd3a91420169558a73e1a8819d9d6415825cd8f291\",\"output_index\":0,\"content_index\":0,\"delta\":\"
-        can\",\"logprobs\":[{\"bytes\":[32,99,97,110],\"logprob\":0.0,\"token\":\"
-        can\",\"top_logprobs\":[]}],\"obfuscation\":\"6w58bXdMvX80\"}\n\nevent: response.output_text.delta\ndata:
-        {\"type\":\"response.output_text.delta\",\"sequence_number\":8,\"item_id\":\"msg_0e9a84adfd3a91420169558a73e1a8819d9d6415825cd8f291\",\"output_index\":0,\"content_index\":0,\"delta\":\"
-        I\",\"logprobs\":[{\"bytes\":[32,73],\"logprob\":0.0,\"token\":\" I\",\"top_logprobs\":[]}],\"obfuscation\":\"hosbeKuSHCTt3N\"}\n\nevent:
-        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":9,\"item_id\":\"msg_0e9a84adfd3a91420169558a73e1a8819d9d6415825cd8f291\",\"output_index\":0,\"content_index\":0,\"delta\":\"
-        help\",\"logprobs\":[{\"bytes\":[32,104,101,108,112],\"logprob\":-0.02324547804892063,\"token\":\"
-        help\",\"top_logprobs\":[]}],\"obfuscation\":\"MN2G4VpIjzG\"}\n\nevent: response.output_text.delta\ndata:
-        {\"type\":\"response.output_text.delta\",\"sequence_number\":10,\"item_id\":\"msg_0e9a84adfd3a91420169558a73e1a8819d9d6415825cd8f291\",\"output_index\":0,\"content_index\":0,\"delta\":\"
-        you\",\"logprobs\":[{\"bytes\":[32,121,111,117],\"logprob\":0.0,\"token\":\"
-        you\",\"top_logprobs\":[]}],\"obfuscation\":\"NEy9XcF1OxJy\"}\n\nevent: response.output_text.delta\ndata:
-        {\"type\":\"response.output_text.delta\",\"sequence_number\":11,\"item_id\":\"msg_0e9a84adfd3a91420169558a73e1a8819d9d6415825cd8f291\",\"output_index\":0,\"content_index\":0,\"delta\":\"
-        today\",\"logprobs\":[{\"bytes\":[32,116,111,100,97,121],\"logprob\":0.0,\"token\":\"
-        today\",\"top_logprobs\":[]}],\"obfuscation\":\"oQXGfJmYpg\"}\n\nevent: response.output_text.delta\ndata:
-        {\"type\":\"response.output_text.delta\",\"sequence_number\":12,\"item_id\":\"msg_0e9a84adfd3a91420169558a73e1a8819d9d6415825cd8f291\",\"output_index\":0,\"content_index\":0,\"delta\":\"?\",\"logprobs\":[{\"bytes\":[63],\"logprob\":-5.512236498361744e-7,\"token\":\"?\",\"top_logprobs\":[]}],\"obfuscation\":\"pRzyoaxzimnyzwN\"}\n\nevent:
-        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":13,\"item_id\":\"msg_0e9a84adfd3a91420169558a73e1a8819d9d6415825cd8f291\",\"output_index\":0,\"content_index\":0,\"delta\":\"
-        \U0001F60A\",\"logprobs\":[{\"bytes\":[32,240,159,152,138],\"logprob\":-0.006733130197972059,\"token\":\"
-        \U0001F60A\",\"top_logprobs\":[]}],\"obfuscation\":\"oQI3roWhn6zfC5\"}\n\nevent:
-        response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\"sequence_number\":14,\"item_id\":\"msg_0e9a84adfd3a91420169558a73e1a8819d9d6415825cd8f291\",\"output_index\":0,\"content_index\":0,\"text\":\"Hello!
-        How can I help you today? \U0001F60A\",\"logprobs\":[{\"bytes\":[72,101,108,108,111],\"logprob\":-0.0031777136027812958,\"token\":\"Hello\",\"top_logprobs\":[]},{\"bytes\":[33],\"logprob\":-4.320199877838604e-7,\"token\":\"!\",\"top_logprobs\":[]},{\"bytes\":[32,72,111,119],\"logprob\":-0.024717185646295547,\"token\":\"
+      string: "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_039759604ee356b00169e136a365ac8197977726174a9258dc\",\"object\":\"response\",\"created_at\":1776367267,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4.1-2025-04-14\",\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":false,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":0}\n\nevent:
+        response.in_progress\ndata: {\"type\":\"response.in_progress\",\"response\":{\"id\":\"resp_039759604ee356b00169e136a365ac8197977726174a9258dc\",\"object\":\"response\",\"created_at\":1776367267,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4.1-2025-04-14\",\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":false,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":1}\n\nevent:
+        response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"msg_039759604ee356b00169e136a3be10819780a4794e317c1466\",\"type\":\"message\",\"status\":\"in_progress\",\"content\":[],\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":2}\n\nevent:
+        response.content_part.added\ndata: {\"type\":\"response.content_part.added\",\"content_index\":0,\"item_id\":\"msg_039759604ee356b00169e136a3be10819780a4794e317c1466\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"\"},\"sequence_number\":3}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Hello\",\"item_id\":\"msg_039759604ee356b00169e136a3be10819780a4794e317c1466\",\"logprobs\":[{\"bytes\":[72,101,108,108,111],\"logprob\":-0.000646433443762362,\"token\":\"Hello\",\"top_logprobs\":[]}],\"obfuscation\":\"AI0rkiQWTva\",\"output_index\":0,\"sequence_number\":4}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"!\",\"item_id\":\"msg_039759604ee356b00169e136a3be10819780a4794e317c1466\",\"logprobs\":[{\"bytes\":[33],\"logprob\":-3.128163257315464e-7,\"token\":\"!\",\"top_logprobs\":[]}],\"obfuscation\":\"SGo7rHndUVwaiqx\",\"output_index\":0,\"sequence_number\":5}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"
+        How\",\"item_id\":\"msg_039759604ee356b00169e136a3be10819780a4794e317c1466\",\"logprobs\":[{\"bytes\":[32,72,111,119],\"logprob\":-0.0018611650448292494,\"token\":\"
+        How\",\"top_logprobs\":[]}],\"obfuscation\":\"35u3iNWfogRj\",\"output_index\":0,\"sequence_number\":6}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"
+        can\",\"item_id\":\"msg_039759604ee356b00169e136a3be10819780a4794e317c1466\",\"logprobs\":[{\"bytes\":[32,99,97,110],\"logprob\":0.0,\"token\":\"
+        can\",\"top_logprobs\":[]}],\"obfuscation\":\"8oiiHJcaR96x\",\"output_index\":0,\"sequence_number\":7}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"
+        I\",\"item_id\":\"msg_039759604ee356b00169e136a3be10819780a4794e317c1466\",\"logprobs\":[{\"bytes\":[32,73],\"logprob\":0.0,\"token\":\"
+        I\",\"top_logprobs\":[]}],\"obfuscation\":\"hJsawJLlrgsw2B\",\"output_index\":0,\"sequence_number\":8}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"
+        help\",\"item_id\":\"msg_039759604ee356b00169e136a3be10819780a4794e317c1466\",\"logprobs\":[{\"bytes\":[32,104,101,108,112],\"logprob\":-0.03262728825211525,\"token\":\"
+        help\",\"top_logprobs\":[]}],\"obfuscation\":\"Ik2pTB8ri2q\",\"output_index\":0,\"sequence_number\":9}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"
+        you\",\"item_id\":\"msg_039759604ee356b00169e136a3be10819780a4794e317c1466\",\"logprobs\":[{\"bytes\":[32,121,111,117],\"logprob\":0.0,\"token\":\"
+        you\",\"top_logprobs\":[]}],\"obfuscation\":\"yJQjxI35deAF\",\"output_index\":0,\"sequence_number\":10}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"
+        today\",\"item_id\":\"msg_039759604ee356b00169e136a3be10819780a4794e317c1466\",\"logprobs\":[{\"bytes\":[32,116,111,100,97,121],\"logprob\":0.0,\"token\":\"
+        today\",\"top_logprobs\":[]}],\"obfuscation\":\"WCXp0NHwYM\",\"output_index\":0,\"sequence_number\":11}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"?\",\"item_id\":\"msg_039759604ee356b00169e136a3be10819780a4794e317c1466\",\"logprobs\":[{\"bytes\":[63],\"logprob\":-5.512236498361744e-7,\"token\":\"?\",\"top_logprobs\":[]}],\"obfuscation\":\"kIfLTwuQ2V7zQIu\",\"output_index\":0,\"sequence_number\":12}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"
+        \U0001F60A\",\"item_id\":\"msg_039759604ee356b00169e136a3be10819780a4794e317c1466\",\"logprobs\":[{\"bytes\":[32,240,159,152,138],\"logprob\":-0.10635676980018616,\"token\":\"
+        \U0001F60A\",\"top_logprobs\":[]}],\"obfuscation\":\"6kxEd0EunnCPw9\",\"output_index\":0,\"sequence_number\":13}\n\nevent:
+        response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\"content_index\":0,\"item_id\":\"msg_039759604ee356b00169e136a3be10819780a4794e317c1466\",\"logprobs\":[{\"bytes\":[72,101,108,108,111],\"logprob\":-0.000646433443762362,\"token\":\"Hello\",\"top_logprobs\":[]},{\"bytes\":[33],\"logprob\":-3.128163257315464e-7,\"token\":\"!\",\"top_logprobs\":[]},{\"bytes\":[32,72,111,119],\"logprob\":-0.0018611650448292494,\"token\":\"
         How\",\"top_logprobs\":[]},{\"bytes\":[32,99,97,110],\"logprob\":0.0,\"token\":\"
         can\",\"top_logprobs\":[]},{\"bytes\":[32,73],\"logprob\":0.0,\"token\":\"
-        I\",\"top_logprobs\":[]},{\"bytes\":[32,104,101,108,112],\"logprob\":-0.02324547804892063,\"token\":\"
+        I\",\"top_logprobs\":[]},{\"bytes\":[32,104,101,108,112],\"logprob\":-0.03262728825211525,\"token\":\"
         help\",\"top_logprobs\":[]},{\"bytes\":[32,121,111,117],\"logprob\":0.0,\"token\":\"
         you\",\"top_logprobs\":[]},{\"bytes\":[32,116,111,100,97,121],\"logprob\":0.0,\"token\":\"
-        today\",\"top_logprobs\":[]},{\"bytes\":[63],\"logprob\":-5.512236498361744e-7,\"token\":\"?\",\"top_logprobs\":[]},{\"bytes\":[32,240,159,152,138],\"logprob\":-0.006733130197972059,\"token\":\"
-        \U0001F60A\",\"top_logprobs\":[]}]}\n\nevent: response.content_part.done\ndata:
-        {\"type\":\"response.content_part.done\",\"sequence_number\":15,\"item_id\":\"msg_0e9a84adfd3a91420169558a73e1a8819d9d6415825cd8f291\",\"output_index\":0,\"content_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"Hello!
-        How can I help you today? \U0001F60A\"}}\n\nevent: response.output_item.done\ndata:
-        {\"type\":\"response.output_item.done\",\"sequence_number\":16,\"output_index\":0,\"item\":{\"id\":\"msg_0e9a84adfd3a91420169558a73e1a8819d9d6415825cd8f291\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[{\"bytes\":[72,101,108,108,111],\"logprob\":-0.003178,\"token\":\"Hello\",\"top_logprobs\":[]},{\"bytes\":[33],\"logprob\":-0.0,\"token\":\"!\",\"top_logprobs\":[]},{\"bytes\":[32,72,111,119],\"logprob\":-0.024717,\"token\":\"
+        today\",\"top_logprobs\":[]},{\"bytes\":[63],\"logprob\":-5.512236498361744e-7,\"token\":\"?\",\"top_logprobs\":[]},{\"bytes\":[32,240,159,152,138],\"logprob\":-0.10635676980018616,\"token\":\"
+        \U0001F60A\",\"top_logprobs\":[]}],\"output_index\":0,\"sequence_number\":14,\"text\":\"Hello!
+        How can I help you today? \U0001F60A\"}\n\nevent: response.content_part.done\ndata:
+        {\"type\":\"response.content_part.done\",\"content_index\":0,\"item_id\":\"msg_039759604ee356b00169e136a3be10819780a4794e317c1466\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"Hello!
+        How can I help you today? \U0001F60A\"},\"sequence_number\":15}\n\nevent:
+        response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"msg_039759604ee356b00169e136a3be10819780a4794e317c1466\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[{\"bytes\":[72,101,108,108,111],\"logprob\":-0.000646,\"token\":\"Hello\",\"top_logprobs\":[]},{\"bytes\":[33],\"logprob\":-0.0,\"token\":\"!\",\"top_logprobs\":[]},{\"bytes\":[32,72,111,119],\"logprob\":-0.001861,\"token\":\"
         How\",\"top_logprobs\":[]},{\"bytes\":[32,99,97,110],\"logprob\":0.0,\"token\":\"
         can\",\"top_logprobs\":[]},{\"bytes\":[32,73],\"logprob\":0.0,\"token\":\"
-        I\",\"top_logprobs\":[]},{\"bytes\":[32,104,101,108,112],\"logprob\":-0.023245,\"token\":\"
+        I\",\"top_logprobs\":[]},{\"bytes\":[32,104,101,108,112],\"logprob\":-0.032627,\"token\":\"
         help\",\"top_logprobs\":[]},{\"bytes\":[32,121,111,117],\"logprob\":0.0,\"token\":\"
         you\",\"top_logprobs\":[]},{\"bytes\":[32,116,111,100,97,121],\"logprob\":0.0,\"token\":\"
-        today\",\"top_logprobs\":[]},{\"bytes\":[63],\"logprob\":-1e-6,\"token\":\"?\",\"top_logprobs\":[]},{\"bytes\":[32,240,159,152,138],\"logprob\":-0.006733,\"token\":\"
+        today\",\"top_logprobs\":[]},{\"bytes\":[63],\"logprob\":-1e-6,\"token\":\"?\",\"top_logprobs\":[]},{\"bytes\":[32,240,159,152,138],\"logprob\":-0.106357,\"token\":\"
         \U0001F60A\",\"top_logprobs\":[]}],\"text\":\"Hello! How can I help you today?
-        \U0001F60A\"}],\"role\":\"assistant\"}}\n\nevent: response.completed\ndata:
-        {\"type\":\"response.completed\",\"sequence_number\":17,\"response\":{\"id\":\"resp_0e9a84adfd3a91420169558a73b274819d84766b8ff40045ae\",\"object\":\"response\",\"created_at\":1767213683,\"status\":\"completed\",\"background\":false,\"completed_at\":1767213684,\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4.1-2025-04-14\",\"output\":[{\"id\":\"msg_0e9a84adfd3a91420169558a73e1a8819d9d6415825cd8f291\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[{\"bytes\":[72,101,108,108,111],\"logprob\":-0.003178,\"token\":\"Hello\",\"top_logprobs\":[]},{\"bytes\":[33],\"logprob\":-0.0,\"token\":\"!\",\"top_logprobs\":[]},{\"bytes\":[32,72,111,119],\"logprob\":-0.024717,\"token\":\"
+        \U0001F60A\"}],\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":16}\n\nevent:
+        response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_039759604ee356b00169e136a365ac8197977726174a9258dc\",\"object\":\"response\",\"created_at\":1776367267,\"status\":\"completed\",\"background\":false,\"completed_at\":1776367267,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4.1-2025-04-14\",\"output\":[{\"id\":\"msg_039759604ee356b00169e136a3be10819780a4794e317c1466\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[{\"bytes\":[72,101,108,108,111],\"logprob\":-0.000646,\"token\":\"Hello\",\"top_logprobs\":[]},{\"bytes\":[33],\"logprob\":-0.0,\"token\":\"!\",\"top_logprobs\":[]},{\"bytes\":[32,72,111,119],\"logprob\":-0.001861,\"token\":\"
         How\",\"top_logprobs\":[]},{\"bytes\":[32,99,97,110],\"logprob\":0.0,\"token\":\"
         can\",\"top_logprobs\":[]},{\"bytes\":[32,73],\"logprob\":0.0,\"token\":\"
-        I\",\"top_logprobs\":[]},{\"bytes\":[32,104,101,108,112],\"logprob\":-0.023245,\"token\":\"
+        I\",\"top_logprobs\":[]},{\"bytes\":[32,104,101,108,112],\"logprob\":-0.032627,\"token\":\"
         help\",\"top_logprobs\":[]},{\"bytes\":[32,121,111,117],\"logprob\":0.0,\"token\":\"
         you\",\"top_logprobs\":[]},{\"bytes\":[32,116,111,100,97,121],\"logprob\":0.0,\"token\":\"
-        today\",\"top_logprobs\":[]},{\"bytes\":[63],\"logprob\":-1e-6,\"token\":\"?\",\"top_logprobs\":[]},{\"bytes\":[32,240,159,152,138],\"logprob\":-0.006733,\"token\":\"
+        today\",\"top_logprobs\":[]},{\"bytes\":[63],\"logprob\":-1e-6,\"token\":\"?\",\"top_logprobs\":[]},{\"bytes\":[32,240,159,152,138],\"logprob\":-0.106357,\"token\":\"
         \U0001F60A\",\"top_logprobs\":[]}],\"text\":\"Hello! How can I help you today?
-        \U0001F60A\"}],\"role\":\"assistant\"}],\"parallel_tool_calls\":true,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":false,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":8,\"input_tokens_details\":{\"cached_tokens\":0},\"output_tokens\":11,\"output_tokens_details\":{\"reasoning_tokens\":0},\"total_tokens\":19},\"user\":null,\"metadata\":{}}}\n\n"
+        \U0001F60A\"}],\"role\":\"assistant\"}],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":false,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":8,\"input_tokens_details\":{\"cached_tokens\":0},\"output_tokens\":11,\"output_tokens_details\":{\"reasoning_tokens\":0},\"total_tokens\":19},\"user\":null,\"metadata\":{}},\"sequence_number\":17}\n\nevent:
+        response.rate_limits.updated\ndata: {\"type\":\"response.rate_limits.updated\",\"rate_limits\":{\"limit_requests\":\"10000\",\"limit_tokens\":\"30000000\",\"remaining_requests\":\"9999\",\"remaining_tokens\":\"30000000\",\"reset_requests_ms\":6,\"reset_tokens_ms\":0},\"sequence_number\":18}\n\n"
     headers:
       CF-RAY:
-      - 9b6c98f2d81ce268-ORD
+      - 9ed58d1cc8829123-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:23 GMT
+      - Thu, 16 Apr 2026 19:21:07 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -102,11 +104,21 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       openai-processing-ms:
-      - '42'
+      - '121'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '45'
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '30000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '29999973'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
     status:
       code: 200
       message: OK

--- a/tests/_vcr/test_provider_openai/test_openai_pdf.yaml
+++ b/tests/_vcr/test_provider_openai/test_openai_pdf.yaml
@@ -8,7 +8,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -27,141 +27,133 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_05a9fa6ce51325a20169558a7460488190a79db17b680d8555","object":"response","created_at":1767213684,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.created","response":{"id":"resp_044d5aa8a739ddeb0169e136a4429c81a0bfc270b2b5031d6f","object":"response","created_at":1776367268,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_05a9fa6ce51325a20169558a7460488190a79db17b680d8555","object":"response","created_at":1767213684,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.in_progress","response":{"id":"resp_044d5aa8a739ddeb0169e136a4429c81a0bfc270b2b5031d6f","object":"response","created_at":1776367268,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_05a9fa6ce51325a20169558a74ff3881909236a1523c2359c3","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","item":{"id":"msg_044d5aa8a739ddeb0169e136a5324c81a0b47e2819acfc656e","type":"message","status":"in_progress","content":[],"role":"assistant"},"output_index":0,"sequence_number":2}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_05a9fa6ce51325a20169558a74ff3881909236a1523c2359c3","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","content_index":0,"item_id":"msg_044d5aa8a739ddeb0169e136a5324c81a0b47e2819acfc656e","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":3}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_05a9fa6ce51325a20169558a74ff3881909236a1523c2359c3","output_index":0,"content_index":0,"delta":"The","logprobs":[],"obfuscation":"74frVyI2kHXuU"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"The","item_id":"msg_044d5aa8a739ddeb0169e136a5324c81a0b47e2819acfc656e","logprobs":[],"obfuscation":"Wp3hnCb5GFTjR","output_index":0,"sequence_number":4}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_05a9fa6ce51325a20169558a74ff3881909236a1523c2359c3","output_index":0,"content_index":0,"delta":"
-        title","logprobs":[],"obfuscation":"22k7KJRLkX"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" title","item_id":"msg_044d5aa8a739ddeb0169e136a5324c81a0b47e2819acfc656e","logprobs":[],"obfuscation":"tC44BhWmal","output_index":0,"sequence_number":5}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_05a9fa6ce51325a20169558a74ff3881909236a1523c2359c3","output_index":0,"content_index":0,"delta":"
-        of","logprobs":[],"obfuscation":"32m3CEDiOVTBu"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" of","item_id":"msg_044d5aa8a739ddeb0169e136a5324c81a0b47e2819acfc656e","logprobs":[],"obfuscation":"whB6S5qvQSOzS","output_index":0,"sequence_number":6}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_05a9fa6ce51325a20169558a74ff3881909236a1523c2359c3","output_index":0,"content_index":0,"delta":"
-        the","logprobs":[],"obfuscation":"uFo7h5hWoG08"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" this","item_id":"msg_044d5aa8a739ddeb0169e136a5324c81a0b47e2819acfc656e","logprobs":[],"obfuscation":"PdQQFM5KjD1","output_index":0,"sequence_number":7}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_05a9fa6ce51325a20169558a74ff3881909236a1523c2359c3","output_index":0,"content_index":0,"delta":"
-        document","logprobs":[],"obfuscation":"CYYpmFs"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" document","item_id":"msg_044d5aa8a739ddeb0169e136a5324c81a0b47e2819acfc656e","logprobs":[],"obfuscation":"iWxImlk","output_index":0,"sequence_number":8}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_05a9fa6ce51325a20169558a74ff3881909236a1523c2359c3","output_index":0,"content_index":0,"delta":"
-        is","logprobs":[],"obfuscation":"RBVMH1CNWzOef"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" is","item_id":"msg_044d5aa8a739ddeb0169e136a5324c81a0b47e2819acfc656e","logprobs":[],"obfuscation":"jzYNXZGB1W9O0","output_index":0,"sequence_number":9}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_05a9fa6ce51325a20169558a74ff3881909236a1523c2359c3","output_index":0,"content_index":0,"delta":":","logprobs":[],"obfuscation":"IN5UFP0dKH6bloY"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":":","item_id":"msg_044d5aa8a739ddeb0169e136a5324c81a0b47e2819acfc656e","logprobs":[],"obfuscation":"x0YQvmCTJiZzZun","output_index":0,"sequence_number":10}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_05a9fa6ce51325a20169558a74ff3881909236a1523c2359c3","output_index":0,"content_index":0,"delta":"
-        **","logprobs":[],"obfuscation":"EUXOkgYJ7uLIf"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" **","item_id":"msg_044d5aa8a739ddeb0169e136a5324c81a0b47e2819acfc656e","logprobs":[],"obfuscation":"NEtQSauyLHOVI","output_index":0,"sequence_number":11}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_05a9fa6ce51325a20169558a74ff3881909236a1523c2359c3","output_index":0,"content_index":0,"delta":"\"","logprobs":[],"obfuscation":"FVJ6EwRBGqS8tC2"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"Ap","item_id":"msg_044d5aa8a739ddeb0169e136a5324c81a0b47e2819acfc656e","logprobs":[],"obfuscation":"IUZdlEoeEsrHOY","output_index":0,"sequence_number":12}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_05a9fa6ce51325a20169558a74ff3881909236a1523c2359c3","output_index":0,"content_index":0,"delta":"Ap","logprobs":[],"obfuscation":"igC4qVv6YVQ46z"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"ples","item_id":"msg_044d5aa8a739ddeb0169e136a5324c81a0b47e2819acfc656e","logprobs":[],"obfuscation":"JcEcUKS34FUz","output_index":0,"sequence_number":13}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_05a9fa6ce51325a20169558a74ff3881909236a1523c2359c3","output_index":0,"content_index":0,"delta":"ples","logprobs":[],"obfuscation":"XZe1AFdQZeuk"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" are","item_id":"msg_044d5aa8a739ddeb0169e136a5324c81a0b47e2819acfc656e","logprobs":[],"obfuscation":"BHNMglY4u7uT","output_index":0,"sequence_number":14}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_05a9fa6ce51325a20169558a74ff3881909236a1523c2359c3","output_index":0,"content_index":0,"delta":"
-        are","logprobs":[],"obfuscation":"55ICkzoiD0Dr"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" tasty","item_id":"msg_044d5aa8a739ddeb0169e136a5324c81a0b47e2819acfc656e","logprobs":[],"obfuscation":"2nigavwmwr","output_index":0,"sequence_number":15}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_05a9fa6ce51325a20169558a74ff3881909236a1523c2359c3","output_index":0,"content_index":0,"delta":"
-        tasty","logprobs":[],"obfuscation":"zaka4XrnJ8"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"**","item_id":"msg_044d5aa8a739ddeb0169e136a5324c81a0b47e2819acfc656e","logprobs":[],"obfuscation":"Wk2eErcAYUIt9x","output_index":0,"sequence_number":16}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_05a9fa6ce51325a20169558a74ff3881909236a1523c2359c3","output_index":0,"content_index":0,"delta":"\"","logprobs":[],"obfuscation":"WtlQBPKRUMycdY6"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_05a9fa6ce51325a20169558a74ff3881909236a1523c2359c3","output_index":0,"content_index":0,"delta":"**","logprobs":[],"obfuscation":"wwXStQ8VgwhfbR"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_044d5aa8a739ddeb0169e136a5324c81a0b47e2819acfc656e","logprobs":[],"obfuscation":"RgpN2hsWoox1lMe","output_index":0,"sequence_number":17}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":19,"item_id":"msg_05a9fa6ce51325a20169558a74ff3881909236a1523c2359c3","output_index":0,"content_index":0,"text":"The
-        title of the document is: **\"Apples are tasty\"**","logprobs":[]}
+        data: {"type":"response.output_text.done","content_index":0,"item_id":"msg_044d5aa8a739ddeb0169e136a5324c81a0b47e2819acfc656e","logprobs":[],"output_index":0,"sequence_number":18,"text":"The
+        title of this document is: **Apples are tasty**."}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":20,"item_id":"msg_05a9fa6ce51325a20169558a74ff3881909236a1523c2359c3","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"The
-        title of the document is: **\"Apples are tasty\"**"}}
+        data: {"type":"response.content_part.done","content_index":0,"item_id":"msg_044d5aa8a739ddeb0169e136a5324c81a0b47e2819acfc656e","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"The
+        title of this document is: **Apples are tasty**."},"sequence_number":19}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":21,"output_index":0,"item":{"id":"msg_05a9fa6ce51325a20169558a74ff3881909236a1523c2359c3","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"The
-        title of the document is: **\"Apples are tasty\"**"}],"role":"assistant"}}
+        data: {"type":"response.output_item.done","item":{"id":"msg_044d5aa8a739ddeb0169e136a5324c81a0b47e2819acfc656e","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"The
+        title of this document is: **Apples are tasty**."}],"role":"assistant"},"output_index":0,"sequence_number":20}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":22,"response":{"id":"resp_05a9fa6ce51325a20169558a7460488190a79db17b680d8555","object":"response","created_at":1767213684,"status":"completed","background":false,"completed_at":1767213685,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"msg_05a9fa6ce51325a20169558a74ff3881909236a1523c2359c3","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"The
-        title of the document is: **\"Apples are tasty\"**"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":56,"input_tokens_details":{"cached_tokens":0},"output_tokens":16,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":72},"user":null,"metadata":{}}}
+        data: {"type":"response.completed","response":{"id":"resp_044d5aa8a739ddeb0169e136a4429c81a0bfc270b2b5031d6f","object":"response","created_at":1776367268,"status":"completed","background":false,"completed_at":1776367269,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"msg_044d5aa8a739ddeb0169e136a5324c81a0b47e2819acfc656e","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"The
+        title of this document is: **Apples are tasty**."}],"role":"assistant"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":69,"input_tokens_details":{"cached_tokens":0},"output_tokens":15,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":84},"user":null,"metadata":{}},"sequence_number":21}
+
+
+        event: response.rate_limits.updated
+
+        data: {"type":"response.rate_limits.updated","rate_limits":{"limit_requests":"10000","limit_tokens":"30000000","remaining_requests":"9999","remaining_tokens":"30000000","reset_requests_ms":6,"reset_tokens_ms":0},"sequence_number":22}
 
 
         '
     headers:
       CF-RAY:
-      - 9b6c98f68850b46f-ORD
+      - 9ed58d21effac667-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:24 GMT
+      - Thu, 16 Apr 2026 19:21:09 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -175,11 +167,21 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       openai-processing-ms:
-      - '501'
+      - '749'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '505'
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '30000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '29999911'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
     status:
       code: 200
       message: OK
@@ -188,7 +190,7 @@ interactions:
       "What''s the title of this document?"}]}, {"role": "user", "content": [{"type":
       "input_file", "filename": "apples.pdf", "file_data": "data:application/pdf;base64,JVBERi0xLjMKJcTl8uXrp/Og0MTGCjMgMCBvYmoKPDwgL0ZpbHRlciAvRmxhdGVEZWNvZGUgL0xlbmd0aCA0MTggPj4Kc3RyZWFtCngBnZLdS8MwFMXf81cc31aQNGnXrIEhuDlQwY9hwAfxoXYZq2v31Qruv/e26zb3oUzJQwK5ueeXc+4cfcwhaCnpoaU9LCyeMYHbzSXiHLJaeUwV5W22qUurk0BavU7ZCEO4j2i34d51b67o2cUFOlfdSkD5XARaa7Q8NMOAhyFUoLhu7ssRCRMguTk1KLFk+URpwf1QEFCGjoFfXoj1ZjK4xpScZojG5WyW2tyBeUfPsD7cp1k0qagu4+IjSo39LNCAs6Y7TUeH3AsJbVeLulQy9MXeXfdEZCkUV95+rxc0ooUDGaJhHbzC3BI+9f0XPtu3SQYel5os+zv/YS8leOAf9CqivFjuGfJ9HDwynJXjsGt4y+cqWOcq68hX24rVq3N9W+I6GqR2ieckHo+izGHkPQXv1wVnu2F81/aPh93UtTajmfpFm7JZTRU2EWFg0yROph85oskAq8+XpxukydiimMJGBYqRzTgcVuV5GmvzOKvfOpm19xnbWYHhdIH1RA22vOcERWRJzmFG5CZ9iVVTh/sHsy3j9RD+DN3/ArZS/GcKZW5kc3RyZWFtCmVuZG9iagoxIDAgb2JqCjw8IC9UeXBlIC9QYWdlIC9QYXJlbnQgMiAwIFIgL1Jlc291cmNlcyA0IDAgUiAvQ29udGVudHMgMyAwIFIgL01lZGlhQm94IFswIDAgNjEyIDc5Ml0KPj4KZW5kb2JqCjQgMCBvYmoKPDwgL1Byb2NTZXQgWyAvUERGIC9UZXh0IF0gL0NvbG9yU3BhY2UgPDwgL0NzMSA1IDAgUiA+PiAvRm9udCA8PCAvVFQxIDYgMCBSCi9UVDIgNyAwIFIgL1RUMyA4IDAgUiA+PiA+PgplbmRvYmoKMTAgMCBvYmoKPDwgL04gMyAvQWx0ZXJuYXRlIC9EZXZpY2VSR0IgL0xlbmd0aCAyNjEyIC9GaWx0ZXIgL0ZsYXRlRGVjb2RlID4+CnN0cmVhbQp4AZ2Wd1RT2RaHz703vdASIiAl9Bp6CSDSO0gVBFGJSYBQAoaEJnZEBUYUESlWZFTAAUeHImNFFAuDgmLXCfIQUMbBUURF5d2MawnvrTXz3pr9x1nf2ee319ln733XugBQ/IIEwnRYAYA0oVgU7uvBXBITy8T3AhgQAQ5YAcDhZmYER/hEAtT8vT2ZmahIxrP27i6AZLvbLL9QJnPW/3+RIjdDJAYACkXVNjx+JhflApRTs8UZMv8EyvSVKTKGMTIWoQmirCLjxK9s9qfmK7vJmJcm5KEaWc4ZvDSejLtQ3pol4aOMBKFcmCXgZ6N8B2W9VEmaAOX3KNPT+JxMADAUmV/M5yahbIkyRRQZ7onyAgAIlMQ5vHIOi/k5aJ4AeKZn5IoEiUliphHXmGnl6Mhm+vGzU/liMSuUw03hiHhMz/S0DI4wF4Cvb5ZFASVZbZloke2tHO3tWdbmaPm/2d8eflP9Pch6+1XxJuzPnkGMnlnfbOysL70WAPYkWpsds76VVQC0bQZA5eGsT+8gAPIFALTenPMehmxeksTiDCcLi+zsbHMBn2suK+g3+5+Cb8q/hjn3mcvu+1Y7phc/gSNJFTNlReWmp6ZLRMzMDA6Xz2T99xD/48A5ac3Jwyycn8AX8YXoVVHolAmEiWi7hTyBWJAuZAqEf9Xhfxg2JwcZfp1rFGh1XwB9hTlQuEkHyG89AEMjAyRuP3oCfetbEDEKyL68aK2Rr3OPMnr+5/ofC1yKbuFMQSJT5vYMj2RyJaIsGaPfhGzBAhKQB3SgCjSBLjACLGANHIAzcAPeIACEgEgQA5YDLkgCaUAEskE+2AAKQTHYAXaDanAA1IF60AROgjZwBlwEV8ANcAsMgEdACobBSzAB3oFpCILwEBWiQaqQFqQPmULWEBtaCHlDQVA4FAPFQ4mQEJJA+dAmqBgqg6qhQ1A99CN0GroIXYP6oAfQIDQG/QF9hBGYAtNhDdgAtoDZsDscCEfCy+BEeBWcBxfA2+FKuBY+DrfCF+Eb8AAshV/CkwhAyAgD0UZYCBvxREKQWCQBESFrkSKkAqlFmpAOpBu5jUiRceQDBoehYZgYFsYZ44dZjOFiVmHWYkow1ZhjmFZMF+Y2ZhAzgfmCpWLVsaZYJ6w/dgk2EZuNLcRWYI9gW7CXsQPYYew7HA7HwBniHHB+uBhcMm41rgS3D9eMu4Drww3hJvF4vCreFO+CD8Fz8GJ8Ib4Kfxx/Ht+PH8a/J5AJWgRrgg8hliAkbCRUEBoI5wj9hBHCNFGBqE90IoYQecRcYimxjthBvEkcJk6TFEmGJBdSJCmZtIFUSWoiXSY9Jr0hk8k6ZEdyGFlAXk+uJJ8gXyUPkj9QlCgmFE9KHEVC2U45SrlAeUB5Q6VSDahu1FiqmLqdWk+9RH1KfS9HkzOX85fjya2Tq5FrleuXeyVPlNeXd5dfLp8nXyF/Sv6m/LgCUcFAwVOBo7BWoUbhtMI9hUlFmqKVYohimmKJYoPiNcVRJbySgZK3Ek+pQOmw0iWlIRpC06V50ri0TbQ62mXaMB1HN6T705PpxfQf6L30CWUlZVvlKOUc5Rrls8pSBsIwYPgzUhmljJOMu4yP8zTmuc/jz9s2r2le/7wplfkqbip8lSKVZpUBlY+qTFVv1RTVnaptqk/UMGomamFq2Wr71S6rjc+nz3eez51fNP/k/IfqsLqJerj6avXD6j3qkxqaGr4aGRpVGpc0xjUZmm6ayZrlmuc0x7RoWgu1BFrlWue1XjCVme7MVGYls4s5oa2u7act0T6k3as9rWOos1hno06zzhNdki5bN0G3XLdTd0JPSy9YL1+vUe+hPlGfrZ+kv0e/W3/KwNAg2mCLQZvBqKGKob9hnmGj4WMjqpGr0SqjWqM7xjhjtnGK8T7jWyawiZ1JkkmNyU1T2NTeVGC6z7TPDGvmaCY0qzW7x6Kw3FlZrEbWoDnDPMh8o3mb+SsLPYtYi50W3RZfLO0sUy3rLB9ZKVkFWG206rD6w9rEmmtdY33HhmrjY7POpt3mta2pLd92v+19O5pdsN0Wu067z/YO9iL7JvsxBz2HeIe9DvfYdHYou4R91RHr6OG4zvGM4wcneyex00mn351ZzinODc6jCwwX8BfULRhy0XHhuBxykS5kLoxfeHCh1FXbleNa6/rMTdeN53bEbcTd2D3Z/bj7Kw9LD5FHi8eUp5PnGs8LXoiXr1eRV6+3kvdi72rvpz46Pok+jT4Tvna+q30v+GH9Av12+t3z1/Dn+tf7TwQ4BKwJ6AqkBEYEVgc+CzIJEgV1BMPBAcG7gh8v0l8kXNQWAkL8Q3aFPAk1DF0V+nMYLiw0rCbsebhVeH54dwQtYkVEQ8S7SI/I0shHi40WSxZ3RslHxUXVR01Fe0WXRUuXWCxZs+RGjFqMIKY9Fh8bFXskdnKp99LdS4fj7OIK4+4uM1yWs+zacrXlqcvPrpBfwVlxKh4bHx3fEP+JE8Kp5Uyu9F+5d+UE15O7h/uS58Yr543xXfhl/JEEl4SyhNFEl8RdiWNJrkkVSeMCT0G14HWyX/KB5KmUkJSjKTOp0anNaYS0+LTTQiVhirArXTM9J70vwzSjMEO6ymnV7lUTokDRkUwoc1lmu5iO/kz1SIwkmyWDWQuzarLeZ0dln8pRzBHm9OSa5G7LHcnzyft+NWY1d3Vnvnb+hvzBNe5rDq2F1q5c27lOd13BuuH1vuuPbSBtSNnwy0bLjWUb326K3tRRoFGwvmBos+/mxkK5QlHhvS3OWw5sxWwVbO3dZrOtatuXIl7R9WLL4oriTyXckuvfWX1X+d3M9oTtvaX2pft34HYId9zd6brzWJliWV7Z0K7gXa3lzPKi8re7V+y+VmFbcWAPaY9kj7QyqLK9Sq9qR9Wn6qTqgRqPmua96nu37Z3ax9vXv99tf9MBjQPFBz4eFBy8f8j3UGutQW3FYdzhrMPP66Lqur9nf19/RO1I8ZHPR4VHpcfCj3XVO9TXN6g3lDbCjZLGseNxx2/94PVDexOr6VAzo7n4BDghOfHix/gf754MPNl5in2q6Sf9n/a20FqKWqHW3NaJtqQ2aXtMe9/pgNOdHc4dLT+b/3z0jPaZmrPKZ0vPkc4VnJs5n3d+8kLGhfGLiReHOld0Prq05NKdrrCu3suBl69e8blyqdu9+/xVl6tnrjldO32dfb3thv2N1h67npZf7H5p6bXvbb3pcLP9luOtjr4Ffef6Xfsv3va6feWO/50bA4sG+u4uvnv/Xtw96X3e/dEHqQ9eP8x6OP1o/WPs46InCk8qnqo/rf3V+Ndmqb307KDXYM+ziGePhrhDL/+V+a9PwwXPqc8rRrRG6ketR8+M+YzderH0xfDLjJfT44W/Kf6295XRq59+d/u9Z2LJxPBr0euZP0reqL45+tb2bedk6OTTd2nvpqeK3qu+P/aB/aH7Y/THkensT/hPlZ+NP3d8CfzyeCZtZubf94Tz+wplbmRzdHJlYW0KZW5kb2JqCjUgMCBvYmoKWyAvSUNDQmFzZWQgMTAgMCBSIF0KZW5kb2JqCjEyIDAgb2JqCjw8IC9UeXBlIC9TdHJ1Y3RUcmVlUm9vdCAvSyAxMSAwIFIgL1BhcmVudFRyZWUgMTMgMCBSIC9JRFRyZWUgMTQgMCBSPj4KZW5kb2JqCjExIDAgb2JqCjw8IC9UeXBlIC9TdHJ1Y3RFbGVtIC9TIC9Eb2N1bWVudCAvUCAxMiAwIFIgL0sgWyAxNSAwIFIgMTYgMCBSIDE3IDAgUiAxOCAwIFIKXSAgPj4KZW5kb2JqCjE1IDAgb2JqCjw8IC9UeXBlIC9TdHJ1Y3RFbGVtIC9TIC9IIC9QIDExIDAgUiAvUGcgMSAwIFIgL0sgMSAgPj4KZW5kb2JqCjE2IDAgb2JqCjw8IC9UeXBlIC9TdHJ1Y3RFbGVtIC9TIC9QIC9QIDExIDAgUiAvUGcgMSAwIFIgL0sgMiAgPj4KZW5kb2JqCjE3IDAgb2JqCjw8IC9UeXBlIC9TdHJ1Y3RFbGVtIC9TIC9QIC9QIDExIDAgUiAvUGcgMSAwIFIgL0sgMyAgPj4KZW5kb2JqCjE4IDAgb2JqCjw8IC9UeXBlIC9TdHJ1Y3RFbGVtIC9TIC9QIC9QIDExIDAgUiAvUGcgMSAwIFIgL0sgNCAgPj4KZW5kb2JqCjIgMCBvYmoKPDwgL1R5cGUgL1BhZ2VzIC9NZWRpYUJveCBbMCAwIDYxMiA3OTJdIC9Db3VudCAxIC9LaWRzIFsgMSAwIFIgXSA+PgplbmRvYmoKMTkgMCBvYmoKPDwgL1R5cGUgL0NhdGFsb2cgL1BhZ2VzIDIgMCBSIC9NYXJrSW5mbyA8PCAvTWFya2VkIHRydWUgPj4gL1N0cnVjdFRyZWVSb290CjEyIDAgUiA+PgplbmRvYmoKOSAwIG9iagpbIDEgMCBSICAvWFlaIDAgNzkyIDAgXQplbmRvYmoKNiAwIG9iago8PCAvVHlwZSAvRm9udCAvU3VidHlwZSAvVHJ1ZVR5cGUgL0Jhc2VGb250IC9BQUFBQUIrSGVsdmV0aWNhTmV1ZS1Cb2xkIC9Gb250RGVzY3JpcHRvcgoyMCAwIFIgL0VuY29kaW5nIC9NYWNSb21hbkVuY29kaW5nIC9GaXJzdENoYXIgMzIgL0xhc3RDaGFyIDEyMSAvV2lkdGhzIFsgMjc4CjAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCA2ODUgMCAwIDAKMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCA1NzQgMCAwIDAgNTc0IDAgMAowIDAgMCAwIDI1OCAwIDAgMCA2MTEgMCAzODkgNTM3IDM1MiAwIDAgMCAwIDUxOSBdID4+CmVuZG9iagoyMCAwIG9iago8PCAvVHlwZSAvRm9udERlc2NyaXB0b3IgL0ZvbnROYW1lIC9BQUFBQUIrSGVsdmV0aWNhTmV1ZS1Cb2xkIC9GbGFncyAzMiAvRm9udEJCb3gKWy0xMDE4IC00ODEgMTQzNyAxMTQxXSAvSXRhbGljQW5nbGUgMCAvQXNjZW50IDk3NSAvRGVzY2VudCAtMjE3IC9DYXBIZWlnaHQKNzE0IC9TdGVtViAxNTcgL0xlYWRpbmcgMjkgL1hIZWlnaHQgNTE3IC9TdGVtSCAxMzIgL0F2Z1dpZHRoIDQ3OCAvTWF4V2lkdGgKMTUwMCAvRm9udEZpbGUyIDIxIDAgUiA+PgplbmRvYmoKMjEgMCBvYmoKPDwgL0xlbmd0aDEgMzY1MiAvTGVuZ3RoIDIxMjQgL0ZpbHRlciAvRmxhdGVEZWNvZGUgPj4Kc3RyZWFtCngBrVdtbJtXFT73vv5IHMf2G38m/sj7+o3txHZiJ46d5mOpkzlRu1Ysa9dibwtt2rhroGnLSMYmMVGJVR0RRBP7MaGtGxL82BBIRirFy4+2PxCCCmkVvyoUUMUfxn4yKkHb2Dz3tRs1o0xVtdc6955z7r3nnvPccz+88tJqmax0jiTKH19eOEv6Z7qF6o/HX15RdJH4s6h3nTj74nJT/gGRoffFU6+eaMjm3xKZAifLC4sNme6hzp2EoiGzYdQ9J5dXXmnIpkuok6fOHG+2m38B2be88EpzftqErJxeWC43+tt8ov/ZM99aacjtt1DvOvtSudmfFSHfbbQ9UDLwbTRFXNc1yhBBNPTqGtEO+pPr0odH7BO3Waf0idBffvLf+0X911v98j1Trdt40bCKfq1NO/oY6eN6jILGTbR/23hRWNnxtVXJlWAbZCAHeRLsKskUo27qog6ATRRIXAWXpMgOjZN6dvShq2SjNDop5N0eZqdhSuzQOCi+wxBtkAsT+xNValdmXlvyFapkSUDLEIBVeCU1mCtgemGqE760UUfiCkb1UBCTyWSBTFcwJAPrKlQ2vQOHFCY/OeEPOmyQEWNkzET3Z4JzLlqm8/RDeheROmhf3UZGbqPrXCY0rdA36HVap+/SRTTL9aeonRvJxq+TDCvJfVVqnSv+irH1UpXVz1cLFPwIyEtHvtZfJZZUlJmlQoUdhcCTUMRVcFJSma1IkdkDRa2krClrexfXlFnl5MJixRDRazSU10oppUIHi0sony2qlXzJv82WS6Ux2DEIOxiC7mslWPh60wJqXZXaQidjcp9SkaJzxWeKlXMFfyVfKPlVVZmpXJsrVq4V/GqphF6mbU/hsViChs9m+GyKo72lYeUgbMBEaW1N2ITEo2rl2tqafw2R6BpNrTJqKhCp6CNFZqosP1cUTXlN9QuFpmoq/CgVYLs1ue9gcQaeqMITy/9ASoUHIG3bdhR9rXCvTYe0/UuC1PYokNofCVLHtqc7IJXhs0NA2vFwSLUvAHQb4fxDED7XQPjcQxB27kDY9cUIu7f9hpMeeOvWEfZ+SQj7HgXhzkdCuGvb0x0I++Fzl0A4sI1w3l+h7aQFwuc+l7L0f3P4cSEPPgA5+xfJzINz/Jf1O3ySFFCQcRrjxynHzlOOd0I+SiZuros7geEnPiuZcKLhpKLnmhpd/ZhF4zZ5zMEYJjWHGnaYMDYlE2ozteDku/9ZdMZDHpqly8zKetnvOOdv8JuSDae5TBL7GxcnuxkBq7LqlFWZXah9wnzP11L8SI3481t7+W8AWv0Oiks4byUc+hHCsZfCqQZqTW3os0riOHdswCoOd7ljND3oZxmnxDIjqjfD/jPPn/t57Z/v7WJtuZ/WbjMXM9XusMtbufffh01xuSr1z7iPO3ER5AmmXIn04JSEe6yF2DyYEdLuM3kwBFWOxsE5J6XMUIi7ZZfHqw2wmI1p4QGeHZ40xYYHuBY2mb02yWyT3K4QzwxN8mxaShYOJWJz0/EWy5sGIwu/kI7k0/7uwd35yXSA2TtVZzxt2Gj1d4dlR7fXZvMpcnzAY2QnhqZ75TZlNFX7TMs7rJ3tWqAjOtabHA3LFpPV6/H67cae+FJLq8kgSRa5y+XsspsCsV5xdXMKIr4exNeCm3D3BpbIRQKyVgfuoxu4EsWFKhQKMLQj5wRvBy9eEIJn6NgJCm6mB5kmgvaY1ZyI0MYbseVGNBF8lP3o76zN3x8ezvyFrRoCu49Njy/MRiOFY08UvxN6zTyZmMizMXs07N315sTpw5n43sWxicU9sbl5X2JSpAujMZS/19faL5IDaQcHJExu3MTKM6w6pdKDTjkjj63z61s5fQkRY66+jxcQoxP3/dUqJZEaXnLro71i9I1GyiTBK5sIb3PKSH9GtJ+C+PyUH6HaAYOd+kCjoL2gEmgJ9Cro+6Afgz4EfQT6A6h9vkrCei+s92LGPszoRQI2tHFo4yl47UZTBA8UEUoEuBLeI4IXOesDTxgiBlsoomdvpJFFyBkkl8vGmZzJZkJMT6FmYmlZNh5OB9utwZQWToVEXbu5zrueSY8eGg0ExopPpOe6+Hygf6JbmRgIBlMT3d0T/QH2wdbs7Wgs+dTR4ZHy/oFofFpgnkPxPWDnpsENFA3M3YiLIwIuImCIwIb8EV7b4LULvE33FSuBhIerHm82KhLCrGVz6zY1F2sPWGSbfygZtnBu3Lr7D22iv0virxsdwT7fUUzCRF6ye5h3lJYFKAzmNyiE95yYJoT5g6C2zQ28+XAg6rj2IgHcWD/RkoZ3acii5/gm8jjbzN0sPNTwUBVmNDSaQIRBghc5PKKFkMPYjwAzNiDd9z8zIN3PaG+ICeDFdv7ZBZ548nB/8tB0X2BgvDs01h9weAPW6C7pgqFv8ul4fC4fEw37D3X4Vbs7FnJ+MDwT75DjM5meQdVlNlvtPqfDaZGCfendUYc9kh8Kp7qdZoeiODvtZotb1UM31e+yA/wnSMGDYuNx3Xmx8bgI4EZjE3puNNdCvGZFdE5EasCpJ3gDOhI6WlHbUdsBjRG89wb2S1Zza+6MrB9EuZGsvlmzWLpP1w8f7uofV93JDovH2uM7yY3vvHOk9nEs3dXKpdOc+3oYHSFWv4v9Jd69biwP3i+w7QSJ/WhEbhiw75ieD0anJuHn9LhdJrMpGnOLvM2x7M23vslX3/61yR9wx12ehGfvgTyfqb3HjtX8dtkblZiBr3IJmYjQ9a/+Lg01uM+VbZAlPPsLtIeepoN0iA7TV+kFaBn+FiBR8JmAI02Jbzqxp3zq5fLK0vGFr5RXy/3TZ04t0n8BcHfSQQplbmRzdHJlYW0KZW5kb2JqCjcgMCBvYmoKPDwgL1R5cGUgL0ZvbnQgL1N1YnR5cGUgL1RydWVUeXBlIC9CYXNlRm9udCAvQUFBQUFDK0hlbHZldGljYU5ldWUgL0ZvbnREZXNjcmlwdG9yCjIyIDAgUiAvRW5jb2RpbmcgL01hY1JvbWFuRW5jb2RpbmcgL0ZpcnN0Q2hhciAzMiAvTGFzdENoYXIgMTIxIC9XaWR0aHMgWyAyNzgKMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDI3OCAwIDI3OCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCA2NDggMAowIDAgNjExIDAgMCA3MjIgMjU5IDAgMCAwIDAgNzIyIDc2MCAwIDAgMCAwIDU3NCAwIDAgOTI2IDAgMCAwIDAgMCAwIDAgMCAwCjUzNyA1OTMgNTM3IDU5MyA1MzcgMjk2IDAgNTU2IDIyMiAwIDUxOSAyMjIgODUzIDU1NiA1NzQgNTkzIDAgMzMzIDUwMCAzMTUKNTU2IDAgMCA1MTggNTAwIF0gPj4KZW5kb2JqCjIyIDAgb2JqCjw8IC9UeXBlIC9Gb250RGVzY3JpcHRvciAvRm9udE5hbWUgL0FBQUFBQytIZWx2ZXRpY2FOZXVlIC9GbGFncyAzMiAvRm9udEJCb3gKWy05NTEgLTQ4MSAxOTg3IDEwNzddIC9JdGFsaWNBbmdsZSAwIC9Bc2NlbnQgOTUyIC9EZXNjZW50IC0yMTMgL0NhcEhlaWdodAo3MTQgL1N0ZW1WIDk1IC9MZWFkaW5nIDI4IC9YSGVpZ2h0IDUxNyAvU3RlbUggODAgL0F2Z1dpZHRoIDQ0NyAvTWF4V2lkdGggMjIyNQovRm9udEZpbGUyIDIzIDAgUiA+PgplbmRvYmoKMjMgMCBvYmoKPDwgL0xlbmd0aDEgNzYwOCAvTGVuZ3RoIDQxNjYgL0ZpbHRlciAvRmxhdGVEZWNvZGUgPj4Kc3RyZWFtCngB5Vl9bFvXdb/38vtDlCh+i5RE6omkRFKkKJof+qYsUZasSlFsM6bsyIotK5aLuDYSN026LfDQxUmFrXULtFvSoCsSbO3QtVC2NZHZbTGabW3TBjA6LAEyoRg2bNiKIAiCtBvSitrvvPdIS1oWBEX+GLBHnXfPve/ec889X/fcq6sPfnKNWdk1pmHF1UtnrzD50a+j+PHqw1eDSp1/A6X3/isXLqn1W4xpey488Oj9St3wCGOuv1hfO3teqbNfocyto0Gp80Mou9cvXUU/enT/jte1By6vqt8N9P3wpbOPqPOzbdSDnzh7aQ0lnvYbePVcufzQVbnK2hMoz195cE3tzyuozyvf9rw58CCbZEJuU94dDFVtj9xC3wHvPObVrjSP/JzbNcQXe2HyPirYT/+pz/6r2Vqn4WVtFlWTSkceo9najbOA8Xl8v2Z4majse4JbzBnnVYwQzB3nL0G8YyzP4qyTOdAxEGcv4cvR/U1VpsXPH99iPFj6rYveqS1mRgWjGHPS3xw7BdS+O8QsQses4hVmx+fE3BYzLVae5/xzS1t89/GtKdZ+E9xqVs70gVQiGCxdnNrk96EiEmiIhYBpEsHpTU14+lhFWgpuBDdmz28Ep4PrZ89vasNyiQ9rG0up4CY7XrmI94lKaLO45G+ga0tLQ6CjJToYgu4bS6DwcZUCSrkptYNOusRccFMTWazcXdm8NuXfLE4t+UOhYGnz1mJl89aUP7S0hF76BqfgmJav8GwAz/oYvhsVKsdBAySWNjaIJmoiEtq8tbHh38BK5BYptMWZ2oCVUh9NuLTFi4sV+lSUQn5qkEJSCHwsTYG2KTF3vFICJyHixPw/RMqm9ojU0mAUfa1gzyKLtOkjEqntw4i0+UOJtKXB6T6R2sFzC4m09f1FKn2AQBsSLr6PhK8pEr72PhJ27JOw84Ml7GrwDSbd4NYlS9jzEUnY+2Ek7PtQEm5rcLpPwn7w3EYSDjQkXPRvsobRQsLXDpgs+19t+NcVefsekfN3WYa7Ebrc7DiBeHL3PbHKFsRP2ALXsGMo58V/sYgYY0LzVcQWH+sWd7NJteymkvegPcGK7KesJAysRKWmzIrUhnFyfz7PRjFXJx9mJrldz0yoGxG3uBolrUzP/hr1IKLZwbiJZvmhWK1R8Q8utOpnnVzqmaHR3YgYWH/MMmKpV/eUVtbEbKyZtTA7Wlvl8OxkLuZmHuZlPrS1MT8LsHZ5TAcCOD0z+D3MbrBb7B2e5DP8SdEjFsSTmi9qY9pndEO6Z3Vv6Yv6j+uf0b9gWDT8gbFgvG2smZ41vWueMl8xvwEKgmUY5z8WP8A6DWyN9guEuBTiOcDYgph3G5C6iY6ad9HachN7A2GmbYYgXqog9qb81GgeW1IbdNSgY1pq0GIAZsEAHTDsQ+/2p3nIHnLYQ3b+VO1VnsnULoind74kntoZFN+HJo7vfoJ9j11GNtBXxQsKAEdWcMIABnBjSFVlRVrtrYPgQWG2P513Zdw2YXCN8VF+fJjrbB770KHLl60Bv0c/YD82uEa0QY5oa5i/KiuWaGtaWBXtXJ6ItciUsscv4yHOd9/D6wb2OA2zsDDm00IwOoAJbDDIjEiwFtpjsWSw1J/284xDwzP5kCfDf/io+NQ3az87u8iTCxdr/8GjfL725/y5ndzrr4MmzboA+mPALSxTlU2FCJqwVu1t8KWV+aKZsJOqMxkxE+FG8Ao5Zuu/Bf527TJ/qPZ7/HPilZ3c4n8u/ssiBqpz/I48x5EqJlJkagHTepWUHvNZAALy1aE03sZKyQQMAC6vuMrMkAHNa5bnzUCDGbuE98IKf2RlpfYkTcqP1G6KV0ivNO8xTPW8LDvPPnkrNFmK+M/Yj63QSFkcGIP8SVyXeZ3bO6YKURvl6Q3EH8AMXs0pskKZvzq/iswYNEEcw7NlndA8GU78Snz+lOCfXD8lFI7F6M7LmP+vxCTJSrDI7tviJ+If4YFR9qMt1gPivYAezOjEjE7gbHvCD9ExeCdjEUAOMA24B3A/4GHAdcCXAX8MeAHwd4Cm5Qkd+wcg/woQy6AMqh3bWMc2PrwBfn8GEMsgbwLiA/QCBgGzgCXARcCjgM8CngL8CeAm4IeApmVYTDOGkZaaoV5JVa9EGjs0JjIDHcLltAmpKymizg7Ux0T2UBJ1m3g8MHJmYuLMSKBersTvuVYuX7snXi/5Wu7iiUzmxMVcvZx9Yn10dP2JWZRjY+tPYFEcEmRiFPozsOhe/cl6IoNTPIYMjhSpua3YQCYbcr298tbO34pP71wXn14kw+Xk/povglYzy+7Rs4lUALDAAynuclnXcmyXMZva1p8OOSSN+nNk8BN//9LKF8RXL3xN/O7ZF1f/SDwHxX9bHJMhJyo73wD33bs/F2ZhZ/3sML+X4uF3WQGG38S8wGLAEJAhXg+Y192mUDBhx6oKsIUCbKEAWyjAFgqwhQJsoQBbKDAj6f1xIF8CkN4LCIZBxNGbCOQUTT2o96vYFkuDbhoLjGGOqUacDVNYDTNjI84KasApotFgpAYjNVSheMHCEMcWC4N2AIEXLHwWyFNUWQbTRiBeQA+gAJgBVADrgEcARvAZBgedsE8BGkmiYYf+khBBEt6RxLkhyY4ATgIuAD4FkNd6HciXAWK5inUpnFRZusHTKNQe1ktdkayNkzFmYZz5MY1ii3qDNKaRTdXudGcG8lGbzlU3VmF2R0NRaTknjSf9HenxkDTeH3CFep25GU1ZdI/MJ6RSocvgtDRvtBwaHEq22/3dzthIpFU0hWOxcEtXPpooSK16g6HJ5w10tep7B/sP97aaOwt9tV90BHTft1oMJmc46GpvNXqk3laYEpiehE30wQ69LMG+tcWSMDwvPpCbeSEhippUalHS9pAEboPUqM2NNjfabMB9ipf74OW+upf7gPrg5T54uQ9e7oOX++DlPni5DwrzQWE+eLkPXu6Dl/vg5QplCZQlin8M7HSo+0MHvN4BlRJrDiVOZzMdkGbd0SFcO1dDAEmd5DxZFrbeZMoxvDTc3jG8NJI75RJ8uKV7OJEYi7baIyPx3tGog4J0ydPZaozNnsvnz80lonFuqY1GZgpdodyRSPd0viuYK5HvkQ/x9+BDEnu0CkuyyOwEWuSoGYCnBOApAXhKAJ4SgKcE4CkBeEoAUTMAwwkgagYQNQOImoF61AwgapLpIsZ5kCfRCj3yFhaScYooDEJvQencRpaRSWoorimmk8tLdywtM+Dmf1jRRYbnE6P3jnZ0jp4eXn3IdtJ4ZLxnqNveEh5L5op8JTmZcMXn1oaGzk5H1u8bORzMTnVHZwtdOcUmKE7YYBMO2MR3t1gflEDpGrHlAgt9gK7bAOj+o9sv3KCq7HuwKuBezODFDITHgMfARZx1MZfs+dSaoJ3cheZmeCwxR/tCu7ovtMNC8gf2BR3tkftFl3E91tI9Et9rDPyGbDNJ516bqR2whTeQCfzC0+kwxmWLOZqIxKdlfyLZaWAfZtjB6SquFBAFwZoTrLlUvyIZOgEcq6LMz4rSmpL3t+7GOtoQeWlgGwZykCGco3M3DSAbCCmBxKMqPx/KKZudi1wix79ee124I9lQMBv1nDhhKeViYz2tnH9GuPKnS9mliW7ROXZ6rHKVH+rI9ng80dy3MwOB1GhXar0y2DNzbnj4/ExPRdmneC/OLh521949T8meifsmGCaVTtIGhzZo7cSt/cCSqZPmtmJCusbeKGUP5WC0nmwS0VLfziXXavn8+a5OS5vF2mmdnj3Jq7VpXp2b6fJqtEe12onx+TnywyJeb8JG29jdVbyUiEXCsqk+SVGpDUARjErFnuSYQnySyCmeKImXAwN9oHono5JNx+1CbqUmEQguxbIjMhhNF8r22FTGk+7rNguKHLxbGk54C/21Z/mJWGkgYHaFvNyO2EoR42nwSOcPTEYJRF2NAhxRTCWV6klyOrmDsgxO0S0rtXPM/nS5LM6try/v/BIXUiABmsIAmnJOfSffpXXK8idKUAioGdX1HMgVs3lHRpOXDPZSefH5B7ZffRBS3Mn9zdHaO3z2L/+Zf12ZQ+X7g3LbUpkGghU8sj40Lth9jL24306atic0bAVJBl8G8vk6EqwjmzKC4Ea7CvX9PDYgue9KHQnWkU0Z2WL+bUoAm1iLHAs0kGEPZNmDRfeSJcitfrQm5AwD8rABfPgcUfUdwUdKtB0YRnhQtcd6wCC1wyyRUtYNQG8gAzVI2WK5OZQNt4fdpvLMeGfUbSz7+sajmXJby0L/pSEhdDu/5Ieb+2Id9s6Yr/YtfnhkprUz5gX2Gz2D3fZkrL+n8rGGzGDDdvhWaa/M9tswrc4FNinQudXVqZreb8FKtnnAbmWG91jtQ1mFwwMmewbHGSU/bAM//9/OB4/5EsOh0HDCVy9PBYtnRseWi8FgcXls9EwxyEVqdqCtbWA2lZpNt7WlZ1OD52Z7e2fPDQ6uzsZis6tQDOVSw8il7DDS/4u5FMXmO/nT3rxKPaccyKWyul8vl9IhIpr3J1PTB7dPxf5HETjmhQMhWz5PKdcUZO9NsPcm5fxLFwdKjDZRVLRn5MwuG0Gylx0tOxMzmdKpTtmm/21gPhc4JUbG8S8UzjqRp70GXQyxb9IVA9Gu4lyi7MZBhPs08KAcKdIp+YSaRu6KNF45oaaxHaQRTdLIXdPIXdPIXdPIXdPIXdPIXdPIXdPIXdPIXdPIXdNy7mpR98IYSheA7h1GtrGz59TdPIeJw9iuaBugA0g9s1MOI8hYpDtKiCZxaFCyWM+dhE9bP+RepTPBQjx613i0PTUa7Bjp73QGow5Xb5dblDVdg0cTXaW8NDBXmRvwhhPOtnTU+1z/ZG9rc2QsFR4IOXFMcLS7nb5mvckZ8qXGw812qRAdKHTaXV0hb2eL3uyJQmy44ePt4muIUchmDu5geuiJ9EV3V7SjebBm0h3tao18oBlnXVovZWdaNTvTogNDRx1KF8XerOSSXBk7zkLDPCsfm6DpF8qViq09FZqIOn023QWh+8pX5movdie8pjmNubWZTyATINUWoes3sT16KReg60aazorpDvKrnFgoyRby0VrhupEZ1LMCI/yESNAtVAg5o+wHkSxhdLGQy2dc/M29ucDgCT9MsLat5AH8TO1PkQf4+/rpkkiV4Q74syBPVe6dzNiPaDYtfFKDHgYYIlm6gkEemkzeI2/TUelH37tw48alH/zZ/b/9m5d4S+3t117jnre+8x30Ne6m5XW72XXIO067At1a2umsjENw4/DsogbXngb1GlNPp2kTVGLH9DchOfUUbIWArODVilOwFadgK07BVpyCrTgFW+unYCsOMxiBU7BTpdCf1tlwLolEsx0cUhrnGrqYyHBLc7sUDzR32Czt5jbJJL163++LL5wqRQ6FmrW6BZ3B5zkpRG0JqQfUIj+7z7ABBTvwDqKuQb5vZ904CcYRZ9PomYeXTyEzmgavM3DWOfYx3D3exRbZ3binO87KOIedxAXAaXavTI/jFhq5Hh49mGcT9EzGZ9YeeHjt6sXVswtr+I8t+29Q7uggCmVuZHN0cmVhbQplbmRvYmoKOCAwIG9iago8PCAvVHlwZSAvRm9udCAvU3VidHlwZSAvVHJ1ZVR5cGUgL0Jhc2VGb250IC9BQUFBQUQrSGVsdmV0aWNhTmV1ZSAvRm9udERlc2NyaXB0b3IKMjQgMCBSIC9Ub1VuaWNvZGUgMjUgMCBSIC9GaXJzdENoYXIgMzMgL0xhc3RDaGFyIDMzIC9XaWR0aHMgWyAyNzggXSA+PgplbmRvYmoKMjUgMCBvYmoKPDwgL0xlbmd0aCAyMjIgL0ZpbHRlciAvRmxhdGVEZWNvZGUgPj4Kc3RyZWFtCngBXZC9bsQgEIR7nmLLS3ECX42QootOcpEfxckDYFhbSPGC1rjw2weIc5FSbMHMfDCsvPZPPYUM8o2jGzDDFMgzrnFjhzDiHEh0F/DB5ePUNLfYJGSBh33NuPQ0RdBaAMj3gqyZdzg9+jjiQ9Ve2SMHmuH0eR2aMmwpfeGClEEJY8DjVK57tunFLgiyoefeFz/k/Vyov8THnhBKo0J0P5Vc9Lgm65AtzSi0UkbfbkYg+X/WAYzTkbx0RtdRStmW/3UqWr94r+Q25tKm7aEVrQUC4X1VKab6YJtvfCZwQQplbmRzdHJlYW0KZW5kb2JqCjI0IDAgb2JqCjw8IC9UeXBlIC9Gb250RGVzY3JpcHRvciAvRm9udE5hbWUgL0FBQUFBRCtIZWx2ZXRpY2FOZXVlIC9GbGFncyA0IC9Gb250QkJveApbLTk1MSAtNDgxIDE5ODcgMTA3N10gL0l0YWxpY0FuZ2xlIDAgL0FzY2VudCA5NTIgL0Rlc2NlbnQgLTIxMyAvQ2FwSGVpZ2h0CjcxNCAvU3RlbVYgOTUgL0xlYWRpbmcgMjggL1hIZWlnaHQgNTE3IC9TdGVtSCA4MCAvQXZnV2lkdGggNDQ3IC9NYXhXaWR0aCAyMjI1Ci9Gb250RmlsZTIgMjYgMCBSID4+CmVuZG9iagoyNiAwIG9iago8PCAvTGVuZ3RoMSAxNzg4IC9MZW5ndGggODQ1IC9GaWx0ZXIgL0ZsYXRlRGVjb2RlID4+CnN0cmVhbQp4Aa1VTUzTUBz/v7b7AKYyvkSK2mZCiBvZFD+iMWbEjqBEM8VD60FYoMIMA4LD6EGzi5cejBcPGo8ePNaLKVxY4kFjNPHg0RiPHo3BmzB/r20apkiI4XXv/T/fv7/3y+t/5YVFk2JUIZGyE6XCPLkj9B2ia+J2WfFs9gKy88b8VMm3q0RS39TM3RueHW6DfDRtFiY9m35BnpiGw7PZMchD06XyHc8OfYOMzsxN+PFwDHa4VLjjv58+w1ZmCyXTyw9/guybn7tV9u3nkJn5BdPPZzrsi15sw8qgCxTF5MNbD3BF6nM9PI75436nNLbnzE8WFzkuenVunAv68rU//uv8+sHIa+k4zAa/grtHdGpJ6o6+RLwSec2r1A3BobYkW8YOgTqSbAX0nqWTlKSD1IrE7iStIHKh3rVMEh456RBTcveKnZpDjTCwi6iN/0boGtR47TQ1CSGKCe8ojnBqxKGGvP6SsYeGw2oPHI32LwGtOHa9H6VSipIrajYbhyGk4DisQhNTypAt9gxd0ROGYinW+UlLGVKmC5O21ONKBEzLSCs2jepFrFd11c4acqCahnEadSReB1uQbhmocNOvAOm60mtICqVGFFvszeuXdbuiyXZWM2RVVXJ2Na/bVU1WDQNZ4QApEPPje5gjwBw+jHjUqzKKGihhWBavCUvoVe2qZckWTuJ6EqrDyHfgpDxH7Mk5LJvXeSibUGXuSKgJFTgMDbUbUiOjeg5IVI6k8S9KSdtAaVMAFLkxwGtyKd21Q5Tu3g6le7ZFaXOAtI7SODA3c0pbNqc0sQWhAcPZTRiueAxXNmG4tY7htq0Zbg9wA2QH0La7DO/dIYY7t8Pwvm0x3BUgrWNYBuYuznB3wHBWtim4tGC48seVpX/e4f+lfP8GytkqDbAOdA/evbxuFaMwOj+RGniIhvHwBjlAjL0X3qJtRcjkvQyfXxq9BjPajO/xI2Z6CYniKrzNS+hbXGv4TGgwOR19IS1zZ+NZw3eEuCNEEndI2IC3YEMIGnrkauYIU+Nqa1yNsyfrH9jAwPqU8HTtsfBk7ZTwBhnuqD2jo572x4o4EyKLs8VMJjPoxhi1+KcM89Y5yIeWHDZnbpvl4kThkol/PfoN6L+nmgplbmRzdHJlYW0KZW5kb2JqCjI3IDAgb2JqCjw8IC9UaXRsZSAoYXBwbGVzKSAvUHJvZHVjZXIgKG1hY09TIFZlcnNpb24gMTUuMiBcKEJ1aWxkIDI0QzEwMVwpIFF1YXJ0eiBQREZDb250ZXh0KQovQ3JlYXRvciAoUGFnZXMpIC9DcmVhdGlvbkRhdGUgKEQ6MjAyNTAyMDYxNjAzNDFaMDAnMDAnKSAvTW9kRGF0ZSAoRDoyMDI1MDIwNjE2MDM0MVowMCcwMCcpCj4+CmVuZG9iagp4cmVmCjAgMjgKMDAwMDAwMDAwMCA2NTUzNSBmIAowMDAwMDAwNTEyIDAwMDAwIG4gCjAwMDAwMDM5NTggMDAwMDAgbiAKMDAwMDAwMDAyMiAwMDAwMCBuIAowMDAwMDAwNjE2IDAwMDAwIG4gCjAwMDAwMDM0NDggMDAwMDAgbiAKMDAwMDAwNDE4MiAwMDAwMCBuIAowMDAwMDA3MDQ4IDAwMDAwIG4gCjAwMDAwMTE5ODUgMDAwMDAgbiAKMDAwMDAwNDE0MyAwMDAwMCBuIAowMDAwMDAwNzM1IDAwMDAwIG4gCjAwMDAwMDM1NzEgMDAwMDAgbiAKMDAwMDAwMzQ4NCAwMDAwMCBuIAowMDAwMDAwMDAwIDAwMDAwIG4gCjAwMDAwMDAwMDAgMDAwMDAgbiAKMDAwMDAwMzY3MCAwMDAwMCBuIAowMDAwMDAzNzQyIDAwMDAwIG4gCjAwMDAwMDM4MTQgMDAwMDAgbiAKMDAwMDAwMzg4NiAwMDAwMCBuIAowMDAwMDA0MDQxIDAwMDAwIG4gCjAwMDAwMDQ1NjIgMDAwMDAgbiAKMDAwMDAwNDgzNiAwMDAwMCBuIAowMDAwMDA3NDY1IDAwMDAwIG4gCjAwMDAwMDc3MzEgMDAwMDAgbiAKMDAwMDAxMjQ0OCAwMDAwMCBuIAowMDAwMDEyMTUzIDAwMDAwIG4gCjAwMDAwMTI3MTMgMDAwMDAgbiAKMDAwMDAxMzY0NSAwMDAwMCBuIAp0cmFpbGVyCjw8IC9TaXplIDI4IC9Sb290IDE5IDAgUiAvSW5mbyAyNyAwIFIgL0lEIFsgPGI2ZTBhMjA4YmMwOWEwNDQ0NjU3MmU0NGQ1ODViNDQwPgo8YjZlMGEyMDhiYzA5YTA0NDQ2NTcyZTQ0ZDU4NWI0NDA+IF0gPj4Kc3RhcnR4cmVmCjEzODQxCiUlRU9GCg=="}]},
       {"role": "assistant", "content": [{"type": "output_text", "text": "The title
-      of the document is: **\"Apples are tasty\"**", "annotations": []}], "status":
+      of this document is: **Apples are tasty**.", "annotations": []}], "status":
       "completed", "type": "message", "id": "msg_missing_id"}, {"role": "user", "content":
       [{"type": "input_text", "text": "What apple is not tasty according to the document?"}]},
       {"role": "user", "content": [{"type": "input_text", "text": "Two word answer
@@ -197,16 +199,15 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
-      - '20072'
+      - '20070'
       Content-Type:
       - application/json
       Cookie:
-      - __cf_bm=FkIISMrKRYVQd3v._7IaK8sXgcM37rIqK0kr0ySsPNk-1767213684-1.0.1.1-bwUR.XTyytfn8jsU2zy1F29lBRmss2m4HoUWYpfHdE2Joo03eVm4rHwX24I5ZSQUNpgRJZGB5v6XjD2Lrc_jqLdixuJJ1Jde0cDdcciEwJ0;
-        _cfuvid=0TRXVfA0NhuONi_lAKO0nBUpsiPdcHusgWT2mYt3i0o-1767213684898-0.0.1.1-604800000
+      - __cf_bm=1rBv8pKxgEB0HW14_fTUnirGI1Ba4CqpP888.57aHbo-1776367268.1490805-1.0.1.1-Jr2nsDLfGeXNs.SEVp1e3Yw2AP5Y_y5yIWlXcvwYmBK5clllVwl1DEuCIQIBsCXm.qVlfp0t1egN.sHFtqxi8ptjUd_OY69.JzO0HcNuTpOcnlgQyIC7rse1CA7Jo0Yt
       Host:
       - api.openai.com
       X-Stainless-Async:
@@ -219,69 +220,73 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0c04976afa97caa60169558a75750481a1934b0516e2483f53","object":"response","created_at":1767213685,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.created","response":{"id":"resp_0952d855dd8a50700169e136a5ac5c8191b3fa27ff592e6abe","object":"response","created_at":1776367270,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0c04976afa97caa60169558a75750481a1934b0516e2483f53","object":"response","created_at":1767213685,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.in_progress","response":{"id":"resp_0952d855dd8a50700169e136a5ac5c8191b3fa27ff592e6abe","object":"response","created_at":1776367270,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0c04976afa97caa60169558a75d7c481a1af0858209aab33e0","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","item":{"id":"msg_0952d855dd8a50700169e136a6ac0c8191bab60cea36643d95","type":"message","status":"in_progress","content":[],"role":"assistant"},"output_index":0,"sequence_number":2}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0c04976afa97caa60169558a75d7c481a1af0858209aab33e0","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","content_index":0,"item_id":"msg_0952d855dd8a50700169e136a6ac0c8191bab60cea36643d95","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":3}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_0c04976afa97caa60169558a75d7c481a1af0858209aab33e0","output_index":0,"content_index":0,"delta":"Red","logprobs":[],"obfuscation":"DDWmaUsyjfu9p"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"Red","item_id":"msg_0952d855dd8a50700169e136a6ac0c8191bab60cea36643d95","logprobs":[],"obfuscation":"53M7JVW7vKbtm","output_index":0,"sequence_number":4}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_0c04976afa97caa60169558a75d7c481a1af0858209aab33e0","output_index":0,"content_index":0,"delta":"
-        delicious","logprobs":[],"obfuscation":"m5Lt71"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" Delicious","item_id":"msg_0952d855dd8a50700169e136a6ac0c8191bab60cea36643d95","logprobs":[],"obfuscation":"kZyDd6","output_index":0,"sequence_number":5}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":6,"item_id":"msg_0c04976afa97caa60169558a75d7c481a1af0858209aab33e0","output_index":0,"content_index":0,"text":"Red
-        delicious","logprobs":[]}
+        data: {"type":"response.output_text.done","content_index":0,"item_id":"msg_0952d855dd8a50700169e136a6ac0c8191bab60cea36643d95","logprobs":[],"output_index":0,"sequence_number":6,"text":"Red
+        Delicious"}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":7,"item_id":"msg_0c04976afa97caa60169558a75d7c481a1af0858209aab33e0","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"Red
-        delicious"}}
+        data: {"type":"response.content_part.done","content_index":0,"item_id":"msg_0952d855dd8a50700169e136a6ac0c8191bab60cea36643d95","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"Red
+        Delicious"},"sequence_number":7}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":8,"output_index":0,"item":{"id":"msg_0c04976afa97caa60169558a75d7c481a1af0858209aab33e0","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Red
-        delicious"}],"role":"assistant"}}
+        data: {"type":"response.output_item.done","item":{"id":"msg_0952d855dd8a50700169e136a6ac0c8191bab60cea36643d95","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Red
+        Delicious"}],"role":"assistant"},"output_index":0,"sequence_number":8}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":9,"response":{"id":"resp_0c04976afa97caa60169558a75750481a1934b0516e2483f53","object":"response","created_at":1767213685,"status":"completed","background":false,"completed_at":1767213685,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"msg_0c04976afa97caa60169558a75d7c481a1af0858209aab33e0","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Red
-        delicious"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":98,"input_tokens_details":{"cached_tokens":0},"output_tokens":3,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":101},"user":null,"metadata":{}}}
+        data: {"type":"response.completed","response":{"id":"resp_0952d855dd8a50700169e136a5ac5c8191b3fa27ff592e6abe","object":"response","created_at":1776367270,"status":"completed","background":false,"completed_at":1776367270,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"msg_0952d855dd8a50700169e136a6ac0c8191bab60cea36643d95","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Red
+        Delicious"}],"role":"assistant"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":110,"input_tokens_details":{"cached_tokens":0},"output_tokens":3,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":113},"user":null,"metadata":{}},"sequence_number":9}
+
+
+        event: response.rate_limits.updated
+
+        data: {"type":"response.rate_limits.updated","rate_limits":{"limit_requests":"10000","limit_tokens":"30000000","remaining_requests":"9999","remaining_tokens":"30000000","reset_requests_ms":6,"reset_tokens_ms":0},"sequence_number":10}
 
 
         '
     headers:
       CF-RAY:
-      - 9b6c98fd79a722f3-ORD
+      - 9ed58d2adc4fb271-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:25 GMT
+      - Thu, 16 Apr 2026 19:21:10 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -295,11 +300,21 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       openai-processing-ms:
-      - '127'
+      - '821'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '131'
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '30000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '29999871'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
     status:
       code: 200
       message: OK

--- a/tests/_vcr/test_provider_openai/test_openai_respects_turns_interface.yaml
+++ b/tests/_vcr/test_provider_openai/test_openai_respects_turns_interface.yaml
@@ -8,7 +8,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -27,89 +27,93 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_08b62f06123921160169558a5d48a081a199a956dbe193638b","object":"response","created_at":1767213661,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.created","response":{"id":"resp_04153e72d610435e0169e13689a79c8194b00bc3ccc5f0af72","object":"response","created_at":1776367241,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_08b62f06123921160169558a5d48a081a199a956dbe193638b","object":"response","created_at":1767213661,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.in_progress","response":{"id":"resp_04153e72d610435e0169e13689a79c8194b00bc3ccc5f0af72","object":"response","created_at":1776367241,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_08b62f06123921160169558a5d747881a19036b4f60609ad0c","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","item":{"id":"msg_04153e72d610435e0169e13689f8d48194a0b874ae988134e5","type":"message","status":"in_progress","content":[],"role":"assistant"},"output_index":0,"sequence_number":2}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_08b62f06123921160169558a5d747881a19036b4f60609ad0c","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","content_index":0,"item_id":"msg_04153e72d610435e0169e13689f8d48194a0b874ae988134e5","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":3}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_08b62f06123921160169558a5d747881a19036b4f60609ad0c","output_index":0,"content_index":0,"delta":"CH","logprobs":[],"obfuscation":"O4LdIl8MAnWxjS"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"CH","item_id":"msg_04153e72d610435e0169e13689f8d48194a0b874ae988134e5","logprobs":[],"obfuscation":"oRhB9ser4jL6FZ","output_index":0,"sequence_number":4}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_08b62f06123921160169558a5d747881a19036b4f60609ad0c","output_index":0,"content_index":0,"delta":"RIST","logprobs":[],"obfuscation":"kWuTSD7n0Gfp"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"RIST","item_id":"msg_04153e72d610435e0169e13689f8d48194a0b874ae988134e5","logprobs":[],"obfuscation":"nGkECfrz3eOL","output_index":0,"sequence_number":5}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_08b62f06123921160169558a5d747881a19036b4f60609ad0c","output_index":0,"content_index":0,"delta":"OP","logprobs":[],"obfuscation":"woBoz1a2SxQAWM"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"OP","item_id":"msg_04153e72d610435e0169e13689f8d48194a0b874ae988134e5","logprobs":[],"obfuscation":"oF0XCegow43hDW","output_index":0,"sequence_number":6}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_08b62f06123921160169558a5d747881a19036b4f60609ad0c","output_index":0,"content_index":0,"delta":"HER","logprobs":[],"obfuscation":"i4C9eSxA1RtXk"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"HER","item_id":"msg_04153e72d610435e0169e13689f8d48194a0b874ae988134e5","logprobs":[],"obfuscation":"sA9ehax9Rq5WU","output_index":0,"sequence_number":7}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_08b62f06123921160169558a5d747881a19036b4f60609ad0c","output_index":0,"content_index":0,"delta":"
-        ROB","logprobs":[],"obfuscation":"q6YqwwNdFFyT"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" ROB","item_id":"msg_04153e72d610435e0169e13689f8d48194a0b874ae988134e5","logprobs":[],"obfuscation":"j3jodOa3121Z","output_index":0,"sequence_number":8}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_08b62f06123921160169558a5d747881a19036b4f60609ad0c","output_index":0,"content_index":0,"delta":"IN","logprobs":[],"obfuscation":"pjmtLvVveBa9kR"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"IN","item_id":"msg_04153e72d610435e0169e13689f8d48194a0b874ae988134e5","logprobs":[],"obfuscation":"wkCfXDSyUA7l5l","output_index":0,"sequence_number":9}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":10,"item_id":"msg_08b62f06123921160169558a5d747881a19036b4f60609ad0c","output_index":0,"content_index":0,"text":"CHRISTOPHER
-        ROBIN","logprobs":[]}
+        data: {"type":"response.output_text.done","content_index":0,"item_id":"msg_04153e72d610435e0169e13689f8d48194a0b874ae988134e5","logprobs":[],"output_index":0,"sequence_number":10,"text":"CHRISTOPHER
+        ROBIN"}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":11,"item_id":"msg_08b62f06123921160169558a5d747881a19036b4f60609ad0c","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"CHRISTOPHER
-        ROBIN"}}
+        data: {"type":"response.content_part.done","content_index":0,"item_id":"msg_04153e72d610435e0169e13689f8d48194a0b874ae988134e5","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"CHRISTOPHER
+        ROBIN"},"sequence_number":11}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":12,"output_index":0,"item":{"id":"msg_08b62f06123921160169558a5d747881a19036b4f60609ad0c","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"CHRISTOPHER
-        ROBIN"}],"role":"assistant"}}
+        data: {"type":"response.output_item.done","item":{"id":"msg_04153e72d610435e0169e13689f8d48194a0b874ae988134e5","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"CHRISTOPHER
+        ROBIN"}],"role":"assistant"},"output_index":0,"sequence_number":12}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":13,"response":{"id":"resp_08b62f06123921160169558a5d48a081a199a956dbe193638b","object":"response","created_at":1767213661,"status":"completed","background":false,"completed_at":1767213661,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"msg_08b62f06123921160169558a5d747881a19036b4f60609ad0c","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"CHRISTOPHER
-        ROBIN"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":35,"input_tokens_details":{"cached_tokens":0},"output_tokens":7,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":42},"user":null,"metadata":{}}}
+        data: {"type":"response.completed","response":{"id":"resp_04153e72d610435e0169e13689a79c8194b00bc3ccc5f0af72","object":"response","created_at":1776367241,"status":"completed","background":false,"completed_at":1776367242,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"msg_04153e72d610435e0169e13689f8d48194a0b874ae988134e5","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"CHRISTOPHER
+        ROBIN"}],"role":"assistant"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":35,"input_tokens_details":{"cached_tokens":0},"output_tokens":7,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":42},"user":null,"metadata":{}},"sequence_number":13}
+
+
+        event: response.rate_limits.updated
+
+        data: {"type":"response.rate_limits.updated","rate_limits":{"limit_requests":"10000","limit_tokens":"30000000","remaining_requests":"9999","remaining_tokens":"30000000","reset_requests_ms":6,"reset_tokens_ms":0},"sequence_number":14}
 
 
         '
     headers:
       CF-RAY:
-      - 9b6c9866ac4a22f7-ORD
+      - 9ed58c7bfb7422f1-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:01 GMT
+      - Thu, 16 Apr 2026 19:20:41 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -123,11 +127,21 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       openai-processing-ms:
-      - '43'
+      - '91'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '46'
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '30000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '29999946'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
     status:
       code: 200
       message: OK
@@ -140,7 +154,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -159,89 +173,93 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_037c36289d8760b00169558a5dd1d0819eb5bd2bed5fcce2d2","object":"response","created_at":1767213661,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.created","response":{"id":"resp_0ff7bd05b15f5ee60169e1368a68908192980f7adb8b78ab10","object":"response","created_at":1776367242,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_037c36289d8760b00169558a5dd1d0819eb5bd2bed5fcce2d2","object":"response","created_at":1767213661,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.in_progress","response":{"id":"resp_0ff7bd05b15f5ee60169e1368a68908192980f7adb8b78ab10","object":"response","created_at":1776367242,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_037c36289d8760b00169558a5e11e4819e99bbe84d53df45ea","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","item":{"id":"msg_0ff7bd05b15f5ee60169e1368aae688192a9bc58a8fe0566ee","type":"message","status":"in_progress","content":[],"role":"assistant"},"output_index":0,"sequence_number":2}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_037c36289d8760b00169558a5e11e4819e99bbe84d53df45ea","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","content_index":0,"item_id":"msg_0ff7bd05b15f5ee60169e1368aae688192a9bc58a8fe0566ee","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":3}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_037c36289d8760b00169558a5e11e4819e99bbe84d53df45ea","output_index":0,"content_index":0,"delta":"CH","logprobs":[],"obfuscation":"UnB1sOINZtxwxr"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"CH","item_id":"msg_0ff7bd05b15f5ee60169e1368aae688192a9bc58a8fe0566ee","logprobs":[],"obfuscation":"DNXSXCrqG4DFU4","output_index":0,"sequence_number":4}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_037c36289d8760b00169558a5e11e4819e99bbe84d53df45ea","output_index":0,"content_index":0,"delta":"RIST","logprobs":[],"obfuscation":"8hA1c9t7QTK6"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"RIST","item_id":"msg_0ff7bd05b15f5ee60169e1368aae688192a9bc58a8fe0566ee","logprobs":[],"obfuscation":"ACGUAeUDW5td","output_index":0,"sequence_number":5}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_037c36289d8760b00169558a5e11e4819e99bbe84d53df45ea","output_index":0,"content_index":0,"delta":"OP","logprobs":[],"obfuscation":"M5P73lwcSNqOqE"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"OP","item_id":"msg_0ff7bd05b15f5ee60169e1368aae688192a9bc58a8fe0566ee","logprobs":[],"obfuscation":"bXdqKfHVFvPqGn","output_index":0,"sequence_number":6}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_037c36289d8760b00169558a5e11e4819e99bbe84d53df45ea","output_index":0,"content_index":0,"delta":"HER","logprobs":[],"obfuscation":"J6qtJ5dHZdmxr"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"HER","item_id":"msg_0ff7bd05b15f5ee60169e1368aae688192a9bc58a8fe0566ee","logprobs":[],"obfuscation":"tgYSPQCEuL9mJ","output_index":0,"sequence_number":7}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_037c36289d8760b00169558a5e11e4819e99bbe84d53df45ea","output_index":0,"content_index":0,"delta":"
-        ROB","logprobs":[],"obfuscation":"Q4IqCOjy88ll"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" ROB","item_id":"msg_0ff7bd05b15f5ee60169e1368aae688192a9bc58a8fe0566ee","logprobs":[],"obfuscation":"XlDkgycAvzPC","output_index":0,"sequence_number":8}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_037c36289d8760b00169558a5e11e4819e99bbe84d53df45ea","output_index":0,"content_index":0,"delta":"IN","logprobs":[],"obfuscation":"TzKjaTgvievYt5"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"IN","item_id":"msg_0ff7bd05b15f5ee60169e1368aae688192a9bc58a8fe0566ee","logprobs":[],"obfuscation":"WDL2NB1aRICdrF","output_index":0,"sequence_number":9}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":10,"item_id":"msg_037c36289d8760b00169558a5e11e4819e99bbe84d53df45ea","output_index":0,"content_index":0,"text":"CHRISTOPHER
-        ROBIN","logprobs":[]}
+        data: {"type":"response.output_text.done","content_index":0,"item_id":"msg_0ff7bd05b15f5ee60169e1368aae688192a9bc58a8fe0566ee","logprobs":[],"output_index":0,"sequence_number":10,"text":"CHRISTOPHER
+        ROBIN"}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":11,"item_id":"msg_037c36289d8760b00169558a5e11e4819e99bbe84d53df45ea","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"CHRISTOPHER
-        ROBIN"}}
+        data: {"type":"response.content_part.done","content_index":0,"item_id":"msg_0ff7bd05b15f5ee60169e1368aae688192a9bc58a8fe0566ee","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"CHRISTOPHER
+        ROBIN"},"sequence_number":11}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":12,"output_index":0,"item":{"id":"msg_037c36289d8760b00169558a5e11e4819e99bbe84d53df45ea","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"CHRISTOPHER
-        ROBIN"}],"role":"assistant"}}
+        data: {"type":"response.output_item.done","item":{"id":"msg_0ff7bd05b15f5ee60169e1368aae688192a9bc58a8fe0566ee","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"CHRISTOPHER
+        ROBIN"}],"role":"assistant"},"output_index":0,"sequence_number":12}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":13,"response":{"id":"resp_037c36289d8760b00169558a5dd1d0819eb5bd2bed5fcce2d2","object":"response","created_at":1767213661,"status":"completed","background":false,"completed_at":1767213662,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"msg_037c36289d8760b00169558a5e11e4819e99bbe84d53df45ea","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"CHRISTOPHER
-        ROBIN"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":35,"input_tokens_details":{"cached_tokens":0},"output_tokens":7,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":42},"user":null,"metadata":{}}}
+        data: {"type":"response.completed","response":{"id":"resp_0ff7bd05b15f5ee60169e1368a68908192980f7adb8b78ab10","object":"response","created_at":1776367242,"status":"completed","background":false,"completed_at":1776367242,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"msg_0ff7bd05b15f5ee60169e1368aae688192a9bc58a8fe0566ee","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"CHRISTOPHER
+        ROBIN"}],"role":"assistant"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":35,"input_tokens_details":{"cached_tokens":0},"output_tokens":7,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":42},"user":null,"metadata":{}},"sequence_number":13}
+
+
+        event: response.rate_limits.updated
+
+        data: {"type":"response.rate_limits.updated","rate_limits":{"limit_requests":"10000","limit_tokens":"30000000","remaining_requests":"9999","remaining_tokens":"30000000","reset_requests_ms":6,"reset_tokens_ms":0},"sequence_number":14}
 
 
         '
     headers:
       CF-RAY:
-      - 9b6c986a1eb9da16-ORD
+      - 9ed58c808d5660ac-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:01 GMT
+      - Thu, 16 Apr 2026 19:20:42 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -255,11 +273,21 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       openai-processing-ms:
-      - '49'
+      - '92'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '52'
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '30000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '29999946'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
     status:
       code: 200
       message: OK
@@ -274,7 +302,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -293,127 +321,133 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0ec52ddff5b68e520169558a5e761c8193a667e52751a06a17","object":"response","created_at":1767213662,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.created","response":{"id":"resp_04cea2c18a6c6eb40169e1368b07688196adc8b97a39096e3a","object":"response","created_at":1776367243,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0ec52ddff5b68e520169558a5e761c8193a667e52751a06a17","object":"response","created_at":1767213662,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.in_progress","response":{"id":"resp_04cea2c18a6c6eb40169e1368b07688196adc8b97a39096e3a","object":"response","created_at":1776367243,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0ec52ddff5b68e520169558a5ee0588193843ab9bfa45d5b1e","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","item":{"id":"msg_04cea2c18a6c6eb40169e1368b5b948196b2e99882a993210f","type":"message","status":"in_progress","content":[],"role":"assistant"},"output_index":0,"sequence_number":2}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0ec52ddff5b68e520169558a5ee0588193843ab9bfa45d5b1e","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","content_index":0,"item_id":"msg_04cea2c18a6c6eb40169e1368b5b948196b2e99882a993210f","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":3}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_0ec52ddff5b68e520169558a5ee0588193843ab9bfa45d5b1e","output_index":0,"content_index":0,"delta":"Your","logprobs":[],"obfuscation":"I5EJVbaG8l0t"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"Your","item_id":"msg_04cea2c18a6c6eb40169e1368b5b948196b2e99882a993210f","logprobs":[],"obfuscation":"3Caup4LrBACb","output_index":0,"sequence_number":4}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_0ec52ddff5b68e520169558a5ee0588193843ab9bfa45d5b1e","output_index":0,"content_index":0,"delta":"
-        name","logprobs":[],"obfuscation":"7TRyC7ADDNe"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" name","item_id":"msg_04cea2c18a6c6eb40169e1368b5b948196b2e99882a993210f","logprobs":[],"obfuscation":"bh1mxXtz3Qd","output_index":0,"sequence_number":5}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_0ec52ddff5b68e520169558a5ee0588193843ab9bfa45d5b1e","output_index":0,"content_index":0,"delta":"
-        is","logprobs":[],"obfuscation":"0kRaKHNeSHmk8"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" is","item_id":"msg_04cea2c18a6c6eb40169e1368b5b948196b2e99882a993210f","logprobs":[],"obfuscation":"yPpaouyEzobgd","output_index":0,"sequence_number":6}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_0ec52ddff5b68e520169558a5ee0588193843ab9bfa45d5b1e","output_index":0,"content_index":0,"delta":"
-        Steve","logprobs":[],"obfuscation":"d4T2ls1vtR"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" Steve","item_id":"msg_04cea2c18a6c6eb40169e1368b5b948196b2e99882a993210f","logprobs":[],"obfuscation":"msWeDYpbgP","output_index":0,"sequence_number":7}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_0ec52ddff5b68e520169558a5ee0588193843ab9bfa45d5b1e","output_index":0,"content_index":0,"delta":"!","logprobs":[],"obfuscation":"E2ZpHUDKFeVpEix"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_04cea2c18a6c6eb40169e1368b5b948196b2e99882a993210f","logprobs":[],"obfuscation":"upFCNTXtendWyda","output_index":0,"sequence_number":8}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_0ec52ddff5b68e520169558a5ee0588193843ab9bfa45d5b1e","output_index":0,"content_index":0,"delta":"
-        How","logprobs":[],"obfuscation":"5tHhq30nZOzf"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" How","item_id":"msg_04cea2c18a6c6eb40169e1368b5b948196b2e99882a993210f","logprobs":[],"obfuscation":"UR2DzeaJLd0l","output_index":0,"sequence_number":9}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_0ec52ddff5b68e520169558a5ee0588193843ab9bfa45d5b1e","output_index":0,"content_index":0,"delta":"
-        can","logprobs":[],"obfuscation":"gLyQa3L331VD"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" can","item_id":"msg_04cea2c18a6c6eb40169e1368b5b948196b2e99882a993210f","logprobs":[],"obfuscation":"OHIAplN3GMfG","output_index":0,"sequence_number":10}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_0ec52ddff5b68e520169558a5ee0588193843ab9bfa45d5b1e","output_index":0,"content_index":0,"delta":"
-        I","logprobs":[],"obfuscation":"4Jh3r1D7L87jee"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" I","item_id":"msg_04cea2c18a6c6eb40169e1368b5b948196b2e99882a993210f","logprobs":[],"obfuscation":"eqynCL5Qwwhzuy","output_index":0,"sequence_number":11}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_0ec52ddff5b68e520169558a5ee0588193843ab9bfa45d5b1e","output_index":0,"content_index":0,"delta":"
-        assist","logprobs":[],"obfuscation":"cEwAAjjxP"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" assist","item_id":"msg_04cea2c18a6c6eb40169e1368b5b948196b2e99882a993210f","logprobs":[],"obfuscation":"1qgXS9DHR","output_index":0,"sequence_number":12}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_0ec52ddff5b68e520169558a5ee0588193843ab9bfa45d5b1e","output_index":0,"content_index":0,"delta":"
-        you","logprobs":[],"obfuscation":"hgyQXqpzlkLR"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" you","item_id":"msg_04cea2c18a6c6eb40169e1368b5b948196b2e99882a993210f","logprobs":[],"obfuscation":"7F8sqUlgVsf3","output_index":0,"sequence_number":13}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_0ec52ddff5b68e520169558a5ee0588193843ab9bfa45d5b1e","output_index":0,"content_index":0,"delta":"
-        today","logprobs":[],"obfuscation":"0QBLjOoiCp"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" further","item_id":"msg_04cea2c18a6c6eb40169e1368b5b948196b2e99882a993210f","logprobs":[],"obfuscation":"5FukIEt6","output_index":0,"sequence_number":14}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_0ec52ddff5b68e520169558a5ee0588193843ab9bfa45d5b1e","output_index":0,"content_index":0,"delta":"?","logprobs":[],"obfuscation":"wcTRE3OFnC3oYop"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":",","item_id":"msg_04cea2c18a6c6eb40169e1368b5b948196b2e99882a993210f","logprobs":[],"obfuscation":"DQH2i0SDbow5S42","output_index":0,"sequence_number":15}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" Steve","item_id":"msg_04cea2c18a6c6eb40169e1368b5b948196b2e99882a993210f","logprobs":[],"obfuscation":"UBYmRsDGj4","output_index":0,"sequence_number":16}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"?","item_id":"msg_04cea2c18a6c6eb40169e1368b5b948196b2e99882a993210f","logprobs":[],"obfuscation":"mrntuE9x6oPYORW","output_index":0,"sequence_number":17}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":16,"item_id":"msg_0ec52ddff5b68e520169558a5ee0588193843ab9bfa45d5b1e","output_index":0,"content_index":0,"text":"Your
-        name is Steve! How can I assist you today?","logprobs":[]}
+        data: {"type":"response.output_text.done","content_index":0,"item_id":"msg_04cea2c18a6c6eb40169e1368b5b948196b2e99882a993210f","logprobs":[],"output_index":0,"sequence_number":18,"text":"Your
+        name is Steve. How can I assist you further, Steve?"}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":17,"item_id":"msg_0ec52ddff5b68e520169558a5ee0588193843ab9bfa45d5b1e","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"Your
-        name is Steve! How can I assist you today?"}}
+        data: {"type":"response.content_part.done","content_index":0,"item_id":"msg_04cea2c18a6c6eb40169e1368b5b948196b2e99882a993210f","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"Your
+        name is Steve. How can I assist you further, Steve?"},"sequence_number":19}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":18,"output_index":0,"item":{"id":"msg_0ec52ddff5b68e520169558a5ee0588193843ab9bfa45d5b1e","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Your
-        name is Steve! How can I assist you today?"}],"role":"assistant"}}
+        data: {"type":"response.output_item.done","item":{"id":"msg_04cea2c18a6c6eb40169e1368b5b948196b2e99882a993210f","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Your
+        name is Steve. How can I assist you further, Steve?"}],"role":"assistant"},"output_index":0,"sequence_number":20}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":19,"response":{"id":"resp_0ec52ddff5b68e520169558a5e761c8193a667e52751a06a17","object":"response","created_at":1767213662,"status":"completed","background":false,"completed_at":1767213662,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"msg_0ec52ddff5b68e520169558a5ee0588193843ab9bfa45d5b1e","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Your
-        name is Steve! How can I assist you today?"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":34,"input_tokens_details":{"cached_tokens":0},"output_tokens":13,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":47},"user":null,"metadata":{}}}
+        data: {"type":"response.completed","response":{"id":"resp_04cea2c18a6c6eb40169e1368b07688196adc8b97a39096e3a","object":"response","created_at":1776367243,"status":"completed","background":false,"completed_at":1776367243,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"msg_04cea2c18a6c6eb40169e1368b5b948196b2e99882a993210f","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Your
+        name is Steve. How can I assist you further, Steve?"}],"role":"assistant"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":34,"input_tokens_details":{"cached_tokens":0},"output_tokens":15,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":49},"user":null,"metadata":{}},"sequence_number":21}
+
+
+        event: response.rate_limits.updated
+
+        data: {"type":"response.rate_limits.updated","rate_limits":{"limit_requests":"10000","limit_tokens":"30000000","remaining_requests":"9999","remaining_tokens":"30000000","reset_requests_ms":6,"reset_tokens_ms":0},"sequence_number":22}
 
 
         '
     headers:
       CF-RAY:
-      - 9b6c986e086183b9-ORD
+      - 9ed58c84bc9ceaca-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:02 GMT
+      - Thu, 16 Apr 2026 19:20:43 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -427,11 +461,21 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       openai-processing-ms:
-      - '48'
+      - '110'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '50'
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '30000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '29999947'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
     status:
       code: 200
       message: OK

--- a/tests/_vcr/test_provider_openai/test_openai_service_tier_affects_pricing.yaml
+++ b/tests/_vcr/test_provider_openai/test_openai_service_tier_affects_pricing.yaml
@@ -7,7 +7,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -26,102 +26,98 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_07479e5c006cc33d0169558a76f4ec8196bc9fc01c60d88056","object":"response","created_at":1767213686,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"priority","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.created","response":{"id":"resp_04868c1ef3d5b5c20169e136a7c1a881968b6770add74d7c7b","object":"response","created_at":1776367271,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"priority","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_07479e5c006cc33d0169558a76f4ec8196bc9fc01c60d88056","object":"response","created_at":1767213686,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"priority","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.in_progress","response":{"id":"resp_04868c1ef3d5b5c20169e136a7c1a881968b6770add74d7c7b","object":"response","created_at":1776367271,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"priority","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_07479e5c006cc33d0169558a7737408196ba46e0a454fc6d6f","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","item":{"id":"msg_04868c1ef3d5b5c20169e136a8075c8196b916424f9890e2f4","type":"message","status":"in_progress","content":[],"role":"assistant"},"output_index":0,"sequence_number":2}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_07479e5c006cc33d0169558a7737408196ba46e0a454fc6d6f","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","content_index":0,"item_id":"msg_04868c1ef3d5b5c20169e136a8075c8196b916424f9890e2f4","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":3}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_07479e5c006cc33d0169558a7737408196ba46e0a454fc6d6f","output_index":0,"content_index":0,"delta":"1","logprobs":[],"obfuscation":"6CtzGdHFttwDZlx"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"1","item_id":"msg_04868c1ef3d5b5c20169e136a8075c8196b916424f9890e2f4","logprobs":[],"obfuscation":"fRKTJguAprlt71D","output_index":0,"sequence_number":4}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_07479e5c006cc33d0169558a7737408196ba46e0a454fc6d6f","output_index":0,"content_index":0,"delta":"
-        +","logprobs":[],"obfuscation":"Ipiyf0ANVXrFel"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" +","item_id":"msg_04868c1ef3d5b5c20169e136a8075c8196b916424f9890e2f4","logprobs":[],"obfuscation":"DRZJp8NDtWI92T","output_index":0,"sequence_number":5}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_07479e5c006cc33d0169558a7737408196ba46e0a454fc6d6f","output_index":0,"content_index":0,"delta":"
-        ","logprobs":[],"obfuscation":"vqgu4bJb3v4glwD"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_04868c1ef3d5b5c20169e136a8075c8196b916424f9890e2f4","logprobs":[],"obfuscation":"ZiIIpsTQifTsneU","output_index":0,"sequence_number":6}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_07479e5c006cc33d0169558a7737408196ba46e0a454fc6d6f","output_index":0,"content_index":0,"delta":"1","logprobs":[],"obfuscation":"VjXCUlT1ziX6TiE"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"1","item_id":"msg_04868c1ef3d5b5c20169e136a8075c8196b916424f9890e2f4","logprobs":[],"obfuscation":"kl8tURnbXWGztF8","output_index":0,"sequence_number":7}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_07479e5c006cc33d0169558a7737408196ba46e0a454fc6d6f","output_index":0,"content_index":0,"delta":"
-        =","logprobs":[],"obfuscation":"uUwDDplSzoLA17"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" =","item_id":"msg_04868c1ef3d5b5c20169e136a8075c8196b916424f9890e2f4","logprobs":[],"obfuscation":"C7f0laiTvog5HW","output_index":0,"sequence_number":8}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_07479e5c006cc33d0169558a7737408196ba46e0a454fc6d6f","output_index":0,"content_index":0,"delta":"
-        ","logprobs":[],"obfuscation":"1KWT7SixCtgsdkH"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_04868c1ef3d5b5c20169e136a8075c8196b916424f9890e2f4","logprobs":[],"obfuscation":"KHRfNGfXyEiItyF","output_index":0,"sequence_number":9}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_07479e5c006cc33d0169558a7737408196ba46e0a454fc6d6f","output_index":0,"content_index":0,"delta":"2","logprobs":[],"obfuscation":"pSjqbnYGFctGoSP"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_07479e5c006cc33d0169558a7737408196ba46e0a454fc6d6f","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"ETgVtUQkdvgVcOJ"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"2","item_id":"msg_04868c1ef3d5b5c20169e136a8075c8196b916424f9890e2f4","logprobs":[],"obfuscation":"7ImQk9atDQ9o2uP","output_index":0,"sequence_number":10}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":12,"item_id":"msg_07479e5c006cc33d0169558a7737408196ba46e0a454fc6d6f","output_index":0,"content_index":0,"text":"1
-        + 1 = 2.","logprobs":[]}
+        data: {"type":"response.output_text.done","content_index":0,"item_id":"msg_04868c1ef3d5b5c20169e136a8075c8196b916424f9890e2f4","logprobs":[],"output_index":0,"sequence_number":11,"text":"1
+        + 1 = 2"}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":13,"item_id":"msg_07479e5c006cc33d0169558a7737408196ba46e0a454fc6d6f","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"1
-        + 1 = 2."}}
+        data: {"type":"response.content_part.done","content_index":0,"item_id":"msg_04868c1ef3d5b5c20169e136a8075c8196b916424f9890e2f4","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"1
+        + 1 = 2"},"sequence_number":12}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":14,"output_index":0,"item":{"id":"msg_07479e5c006cc33d0169558a7737408196ba46e0a454fc6d6f","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"1
-        + 1 = 2."}],"role":"assistant"}}
+        data: {"type":"response.output_item.done","item":{"id":"msg_04868c1ef3d5b5c20169e136a8075c8196b916424f9890e2f4","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"1
+        + 1 = 2"}],"role":"assistant"},"output_index":0,"sequence_number":13}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":15,"response":{"id":"resp_07479e5c006cc33d0169558a76f4ec8196bc9fc01c60d88056","object":"response","created_at":1767213686,"status":"completed","background":false,"completed_at":1767213687,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"msg_07479e5c006cc33d0169558a7737408196ba46e0a454fc6d6f","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"1
-        + 1 = 2."}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"priority","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":14,"input_tokens_details":{"cached_tokens":0},"output_tokens":9,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":23},"user":null,"metadata":{}}}
+        data: {"type":"response.completed","response":{"id":"resp_04868c1ef3d5b5c20169e136a7c1a881968b6770add74d7c7b","object":"response","created_at":1776367271,"status":"completed","background":false,"completed_at":1776367272,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"msg_04868c1ef3d5b5c20169e136a8075c8196b916424f9890e2f4","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"1
+        + 1 = 2"}],"role":"assistant"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"priority","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":14,"input_tokens_details":{"cached_tokens":0},"output_tokens":8,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":22},"user":null,"metadata":{}},"sequence_number":14}
+
+
+        event: response.rate_limits.updated
+
+        data: {"type":"response.rate_limits.updated","rate_limits":{"limit_requests":"10000","limit_tokens":"30000000","remaining_requests":"9999","remaining_tokens":"30000000","reset_requests_ms":6,"reset_tokens_ms":0},"sequence_number":15}
 
 
         '
     headers:
       CF-RAY:
-      - 9b6c99072b27eadc-ORD
+      - 9ed58d3839a135c0-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:27 GMT
+      - Thu, 16 Apr 2026 19:21:11 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -135,11 +131,21 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       openai-processing-ms:
-      - '46'
+      - '115'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '49'
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '30000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '29999967'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
     status:
       code: 200
       message: OK

--- a/tests/_vcr/test_provider_openai/test_openai_simple_request.yaml
+++ b/tests/_vcr/test_provider_openai/test_openai_simple_request.yaml
@@ -8,7 +8,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -27,59 +27,64 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0161555249e1c4470169558a5c01c08196a5afd85fde015446","object":"response","created_at":1767213660,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.created","response":{"id":"resp_0c4c59373cae39e30169e13688108081a3b476aa3247e1a5eb","object":"response","created_at":1776367240,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0161555249e1c4470169558a5c01c08196a5afd85fde015446","object":"response","created_at":1767213660,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.in_progress","response":{"id":"resp_0c4c59373cae39e30169e13688108081a3b476aa3247e1a5eb","object":"response","created_at":1776367240,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0161555249e1c4470169558a5c385c81969f8c938d47949fa0","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","item":{"id":"msg_0c4c59373cae39e30169e13688607481a38d4e1e175f3b994e","type":"message","status":"in_progress","content":[],"role":"assistant"},"output_index":0,"sequence_number":2}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0161555249e1c4470169558a5c385c81969f8c938d47949fa0","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","content_index":0,"item_id":"msg_0c4c59373cae39e30169e13688607481a38d4e1e175f3b994e","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":3}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_0161555249e1c4470169558a5c385c81969f8c938d47949fa0","output_index":0,"content_index":0,"delta":"2","logprobs":[],"obfuscation":"GY47sdr3CFnXPVm"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"2","item_id":"msg_0c4c59373cae39e30169e13688607481a38d4e1e175f3b994e","logprobs":[],"obfuscation":"rbl02DIrlWCIDAY","output_index":0,"sequence_number":4}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":5,"item_id":"msg_0161555249e1c4470169558a5c385c81969f8c938d47949fa0","output_index":0,"content_index":0,"text":"2","logprobs":[]}
+        data: {"type":"response.output_text.done","content_index":0,"item_id":"msg_0c4c59373cae39e30169e13688607481a38d4e1e175f3b994e","logprobs":[],"output_index":0,"sequence_number":5,"text":"2"}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":6,"item_id":"msg_0161555249e1c4470169558a5c385c81969f8c938d47949fa0","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"2"}}
+        data: {"type":"response.content_part.done","content_index":0,"item_id":"msg_0c4c59373cae39e30169e13688607481a38d4e1e175f3b994e","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"2"},"sequence_number":6}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":7,"output_index":0,"item":{"id":"msg_0161555249e1c4470169558a5c385c81969f8c938d47949fa0","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"2"}],"role":"assistant"}}
+        data: {"type":"response.output_item.done","item":{"id":"msg_0c4c59373cae39e30169e13688607481a38d4e1e175f3b994e","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"2"}],"role":"assistant"},"output_index":0,"sequence_number":7}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":8,"response":{"id":"resp_0161555249e1c4470169558a5c01c08196a5afd85fde015446","object":"response","created_at":1767213660,"status":"completed","background":false,"completed_at":1767213660,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"msg_0161555249e1c4470169558a5c385c81969f8c938d47949fa0","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"2"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":27,"input_tokens_details":{"cached_tokens":0},"output_tokens":2,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":29},"user":null,"metadata":{}}}
+        data: {"type":"response.completed","response":{"id":"resp_0c4c59373cae39e30169e13688108081a3b476aa3247e1a5eb","object":"response","created_at":1776367240,"status":"completed","background":false,"completed_at":1776367240,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"msg_0c4c59373cae39e30169e13688607481a38d4e1e175f3b994e","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"2"}],"role":"assistant"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":27,"input_tokens_details":{"cached_tokens":0},"output_tokens":2,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":29},"user":null,"metadata":{}},"sequence_number":8}
+
+
+        event: response.rate_limits.updated
+
+        data: {"type":"response.rate_limits.updated","rate_limits":{"limit_requests":"10000","limit_tokens":"30000000","remaining_requests":"9999","remaining_tokens":"30000000","reset_requests_ms":6,"reset_tokens_ms":0},"sequence_number":9}
 
 
         '
     headers:
       CF-RAY:
-      - 9b6c985ebafa1ee4-ORD
+      - 9ed58c72288e9d58-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:00 GMT
+      - Thu, 16 Apr 2026 19:20:40 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -93,11 +98,21 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       openai-processing-ms:
-      - '58'
+      - '76'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '64'
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '30000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '29999954'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
     status:
       code: 200
       message: OK

--- a/tests/_vcr/test_provider_openai/test_openai_simple_streaming_request.yaml
+++ b/tests/_vcr/test_provider_openai/test_openai_simple_streaming_request.yaml
@@ -8,7 +8,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -27,59 +27,64 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_043c58b745a023280169558a5c842c819f9be26eaed0d88744","object":"response","created_at":1767213660,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.created","response":{"id":"resp_0bcff009012f80910169e13688efec81a0b6365505b6fbd249","object":"response","created_at":1776367240,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_043c58b745a023280169558a5c842c819f9be26eaed0d88744","object":"response","created_at":1767213660,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.in_progress","response":{"id":"resp_0bcff009012f80910169e13688efec81a0b6365505b6fbd249","object":"response","created_at":1776367240,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_043c58b745a023280169558a5ccf6c819fbaa163474e8f6c3b","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","item":{"id":"msg_0bcff009012f80910169e136894f5081a0a527c19a7a4f43f0","type":"message","status":"in_progress","content":[],"role":"assistant"},"output_index":0,"sequence_number":2}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_043c58b745a023280169558a5ccf6c819fbaa163474e8f6c3b","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","content_index":0,"item_id":"msg_0bcff009012f80910169e136894f5081a0a527c19a7a4f43f0","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":3}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_043c58b745a023280169558a5ccf6c819fbaa163474e8f6c3b","output_index":0,"content_index":0,"delta":"2","logprobs":[],"obfuscation":"FjGkbNZcsqozhTe"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"2","item_id":"msg_0bcff009012f80910169e136894f5081a0a527c19a7a4f43f0","logprobs":[],"obfuscation":"senLFDIPDzsV5wy","output_index":0,"sequence_number":4}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":5,"item_id":"msg_043c58b745a023280169558a5ccf6c819fbaa163474e8f6c3b","output_index":0,"content_index":0,"text":"2","logprobs":[]}
+        data: {"type":"response.output_text.done","content_index":0,"item_id":"msg_0bcff009012f80910169e136894f5081a0a527c19a7a4f43f0","logprobs":[],"output_index":0,"sequence_number":5,"text":"2"}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":6,"item_id":"msg_043c58b745a023280169558a5ccf6c819fbaa163474e8f6c3b","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"2"}}
+        data: {"type":"response.content_part.done","content_index":0,"item_id":"msg_0bcff009012f80910169e136894f5081a0a527c19a7a4f43f0","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"2"},"sequence_number":6}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":7,"output_index":0,"item":{"id":"msg_043c58b745a023280169558a5ccf6c819fbaa163474e8f6c3b","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"2"}],"role":"assistant"}}
+        data: {"type":"response.output_item.done","item":{"id":"msg_0bcff009012f80910169e136894f5081a0a527c19a7a4f43f0","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"2"}],"role":"assistant"},"output_index":0,"sequence_number":7}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":8,"response":{"id":"resp_043c58b745a023280169558a5c842c819f9be26eaed0d88744","object":"response","created_at":1767213660,"status":"completed","background":false,"completed_at":1767213660,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"msg_043c58b745a023280169558a5ccf6c819fbaa163474e8f6c3b","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"2"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":27,"input_tokens_details":{"cached_tokens":0},"output_tokens":2,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":29},"user":null,"metadata":{}}}
+        data: {"type":"response.completed","response":{"id":"resp_0bcff009012f80910169e13688efec81a0b6365505b6fbd249","object":"response","created_at":1776367240,"status":"completed","background":false,"completed_at":1776367241,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"msg_0bcff009012f80910169e136894f5081a0a527c19a7a4f43f0","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"2"}],"role":"assistant"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":27,"input_tokens_details":{"cached_tokens":0},"output_tokens":2,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":29},"user":null,"metadata":{}},"sequence_number":8}
+
+
+        event: response.rate_limits.updated
+
+        data: {"type":"response.rate_limits.updated","rate_limits":{"limit_requests":"10000","limit_tokens":"30000000","remaining_requests":"9999","remaining_tokens":"30000000","reset_requests_ms":6,"reset_tokens_ms":0},"sequence_number":9}
 
 
         '
     headers:
       CF-RAY:
-      - 9b6c9861fc2e6216-ORD
+      - 9ed58c775ca8cd87-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:00 GMT
+      - Thu, 16 Apr 2026 19:20:41 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -93,11 +98,21 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       openai-processing-ms:
-      - '46'
+      - '165'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '49'
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '30000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '29999954'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
     status:
       code: 200
       message: OK

--- a/tests/_vcr/test_provider_openai/test_openai_tool_variations.yaml
+++ b/tests/_vcr/test_provider_openai/test_openai_tool_variations.yaml
@@ -11,7 +11,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -30,52 +30,57 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_095ae5869262eb310169558a5f38308194be0c3cfb5bd19062","object":"response","created_at":1767213663,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
-        the current date","name":"get_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.created","response":{"id":"resp_0ff17e96062fb9450169e1368bdac48194bff006da0be0df0d","object":"response","created_at":1776367243,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
+        the current date","name":"get_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_095ae5869262eb310169558a5f38308194be0c3cfb5bd19062","object":"response","created_at":1767213663,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
-        the current date","name":"get_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.in_progress","response":{"id":"resp_0ff17e96062fb9450169e1368bdac48194bff006da0be0df0d","object":"response","created_at":1776367243,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
+        the current date","name":"get_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_095ae5869262eb310169558a5f78dc8194a4a9b86ec20cfb5d","type":"function_call","status":"in_progress","arguments":"","call_id":"call_5geSAlFGzG5TPzGlXgPB1cfH","name":"get_date"}}
+        data: {"type":"response.output_item.added","item":{"id":"fc_0ff17e96062fb9450169e1368c2efc8194aac851dc3b3ef504","type":"function_call","status":"in_progress","arguments":"","call_id":"call_zeuyPQ7D75XpzVD4CQNrfUiJ","name":"get_date"},"output_index":0,"sequence_number":2}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_095ae5869262eb310169558a5f78dc8194a4a9b86ec20cfb5d","output_index":0,"delta":"{}","obfuscation":"OQHgOH7HbOYTc4"}
+        data: {"type":"response.function_call_arguments.delta","delta":"{}","item_id":"fc_0ff17e96062fb9450169e1368c2efc8194aac851dc3b3ef504","obfuscation":"Bp3mNxWBBopKNZ","output_index":0,"sequence_number":3}
 
 
         event: response.function_call_arguments.done
 
-        data: {"type":"response.function_call_arguments.done","sequence_number":4,"item_id":"fc_095ae5869262eb310169558a5f78dc8194a4a9b86ec20cfb5d","output_index":0,"arguments":"{}"}
+        data: {"type":"response.function_call_arguments.done","arguments":"{}","item_id":"fc_0ff17e96062fb9450169e1368c2efc8194aac851dc3b3ef504","output_index":0,"sequence_number":4}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":5,"output_index":0,"item":{"id":"fc_095ae5869262eb310169558a5f78dc8194a4a9b86ec20cfb5d","type":"function_call","status":"completed","arguments":"{}","call_id":"call_5geSAlFGzG5TPzGlXgPB1cfH","name":"get_date"}}
+        data: {"type":"response.output_item.done","item":{"id":"fc_0ff17e96062fb9450169e1368c2efc8194aac851dc3b3ef504","type":"function_call","status":"completed","arguments":"{}","call_id":"call_zeuyPQ7D75XpzVD4CQNrfUiJ","name":"get_date"},"output_index":0,"sequence_number":5}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":6,"response":{"id":"resp_095ae5869262eb310169558a5f38308194be0c3cfb5bd19062","object":"response","created_at":1767213663,"status":"completed","background":false,"completed_at":1767213663,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"fc_095ae5869262eb310169558a5f78dc8194a4a9b86ec20cfb5d","type":"function_call","status":"completed","arguments":"{}","call_id":"call_5geSAlFGzG5TPzGlXgPB1cfH","name":"get_date"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
-        the current date","name":"get_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":61,"input_tokens_details":{"cached_tokens":0},"output_tokens":11,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":72},"user":null,"metadata":{}}}
+        data: {"type":"response.completed","response":{"id":"resp_0ff17e96062fb9450169e1368bdac48194bff006da0be0df0d","object":"response","created_at":1776367243,"status":"completed","background":false,"completed_at":1776367244,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"fc_0ff17e96062fb9450169e1368c2efc8194aac851dc3b3ef504","type":"function_call","status":"completed","arguments":"{}","call_id":"call_zeuyPQ7D75XpzVD4CQNrfUiJ","name":"get_date"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
+        the current date","name":"get_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":61,"input_tokens_details":{"cached_tokens":0},"output_tokens":11,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":72},"user":null,"metadata":{}},"sequence_number":6}
+
+
+        event: response.rate_limits.updated
+
+        data: {"type":"response.rate_limits.updated","rate_limits":{"limit_requests":"10000","limit_tokens":"30000000","remaining_requests":"9999","remaining_tokens":"30000000","reset_requests_ms":6,"reset_tokens_ms":0},"sequence_number":7}
 
 
         '
     headers:
       CF-RAY:
-      - 9b6c9872ee74f60b-ORD
+      - 9ed58c89ad391b04-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:03 GMT
+      - Thu, 16 Apr 2026 19:20:43 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -89,11 +94,21 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       openai-processing-ms:
-      - '50'
+      - '122'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '53'
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '30000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '29999722'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
     status:
       code: 200
       message: OK
@@ -101,9 +116,9 @@ interactions:
     body: '{"input": [{"role": "system", "content": [{"type": "input_text", "text":
       "Always use a tool to help you answer. Reply with ''It is ____.''."}]}, {"role":
       "user", "content": [{"type": "input_text", "text": "What''s the current date
-      in YYYY-MM-DD format?"}]}, {"type": "function_call", "call_id": "fc_095ae5869262eb310169558a5f78dc8194a4a9b86ec20cfb5d",
+      in YYYY-MM-DD format?"}]}, {"type": "function_call", "call_id": "fc_0ff17e96062fb9450169e1368c2efc8194aac851dc3b3ef504",
       "name": "get_date", "arguments": "{}"}, {"type": "function_call_output", "call_id":
-      "fc_095ae5869262eb310169558a5f78dc8194a4a9b86ec20cfb5d", "output": "2024-01-01"}],
+      "fc_0ff17e96062fb9450169e1368c2efc8194aac851dc3b3ef504", "output": "2024-01-01"}],
       "model": "gpt-4.1", "store": false, "stream": true, "tools": [{"type": "function",
       "name": "get_date", "description": "Gets the current date", "parameters": {"properties":
       {}, "type": "object", "additionalProperties": false, "required": []}, "strict":
@@ -112,7 +127,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -120,8 +135,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - __cf_bm=MTbvVdZV6ZZItTrhPN_VOz2Hezayu6zWDL3kvo47WD4-1767213663-1.0.1.1-kSDYFy_lDaRIIPAzb5BOOK5m93ZMFUb5oz3rjHuHYRJ3alsF_r6MUrSQL4wEpWCQrP8L5q3C96E_cJKJxWClNoYELJ8sP4ztRBk.2Dpx1a8;
-        _cfuvid=9.hG5ntmUYFVwtxA_3wrljcEM_aPdJPBdMmTfBOuRcE-1767213663281-0.0.1.1-604800000
+      - __cf_bm=QNF3cnR1DSkaNmraMjyksYlaMSwNLSH.kLtw78zTEaw-1776367243.7870631-1.0.1.1-aDoIPPeDcPnBid0VVGAfnGx3kb1pGOhwYOXOKXTIMyFSCwLy37D.qXUiZBMmx84aGmn6nGkETlDSbP17.ofvanDmRmzeZsxup_61SZ_GbQfE_ILxz0b.LdLCGwa7DONx
       Host:
       - api.openai.com
       X-Stainless-Async:
@@ -134,113 +148,116 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_09846402a159165f0169558a5fc944819f8e0ebe431e86d340","object":"response","created_at":1767213663,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
-        the current date","name":"get_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.created","response":{"id":"resp_074ffe63cab217780169e1368c7e40819eaf21a1c8d056650e","object":"response","created_at":1776367244,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
+        the current date","name":"get_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_09846402a159165f0169558a5fc944819f8e0ebe431e86d340","object":"response","created_at":1767213663,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
-        the current date","name":"get_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.in_progress","response":{"id":"resp_074ffe63cab217780169e1368c7e40819eaf21a1c8d056650e","object":"response","created_at":1776367244,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
+        the current date","name":"get_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_09846402a159165f0169558a60119c819f8c05e212e00784c5","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","item":{"id":"msg_074ffe63cab217780169e1368cba30819ea83a8a01caf4e0e0","type":"message","status":"in_progress","content":[],"role":"assistant"},"output_index":0,"sequence_number":2}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_09846402a159165f0169558a60119c819f8c05e212e00784c5","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","content_index":0,"item_id":"msg_074ffe63cab217780169e1368cba30819ea83a8a01caf4e0e0","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":3}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_09846402a159165f0169558a60119c819f8c05e212e00784c5","output_index":0,"content_index":0,"delta":"It","logprobs":[],"obfuscation":"DRBdYZ5WtfWias"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"It","item_id":"msg_074ffe63cab217780169e1368cba30819ea83a8a01caf4e0e0","logprobs":[],"obfuscation":"uoDDFUoln1rwYs","output_index":0,"sequence_number":4}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_09846402a159165f0169558a60119c819f8c05e212e00784c5","output_index":0,"content_index":0,"delta":"
-        is","logprobs":[],"obfuscation":"5JA3BVTKvuJZl"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" is","item_id":"msg_074ffe63cab217780169e1368cba30819ea83a8a01caf4e0e0","logprobs":[],"obfuscation":"iAerXtziTkLKu","output_index":0,"sequence_number":5}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_09846402a159165f0169558a60119c819f8c05e212e00784c5","output_index":0,"content_index":0,"delta":"
-        ","logprobs":[],"obfuscation":"OdEZuGSUWbUNjMq"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" ","item_id":"msg_074ffe63cab217780169e1368cba30819ea83a8a01caf4e0e0","logprobs":[],"obfuscation":"tGV0frC2albMNOy","output_index":0,"sequence_number":6}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_09846402a159165f0169558a60119c819f8c05e212e00784c5","output_index":0,"content_index":0,"delta":"202","logprobs":[],"obfuscation":"P5lb4JilrS8JJ"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"202","item_id":"msg_074ffe63cab217780169e1368cba30819ea83a8a01caf4e0e0","logprobs":[],"obfuscation":"AzHlkqg67J2es","output_index":0,"sequence_number":7}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_09846402a159165f0169558a60119c819f8c05e212e00784c5","output_index":0,"content_index":0,"delta":"4","logprobs":[],"obfuscation":"1Pw8XUrkt7pciIZ"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"4","item_id":"msg_074ffe63cab217780169e1368cba30819ea83a8a01caf4e0e0","logprobs":[],"obfuscation":"LqBCnoZrJ0ciIq6","output_index":0,"sequence_number":8}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_09846402a159165f0169558a60119c819f8c05e212e00784c5","output_index":0,"content_index":0,"delta":"-","logprobs":[],"obfuscation":"Rjwue1FR1cKw5LO"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"-","item_id":"msg_074ffe63cab217780169e1368cba30819ea83a8a01caf4e0e0","logprobs":[],"obfuscation":"7WsMEkE5ftr11Kr","output_index":0,"sequence_number":9}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_09846402a159165f0169558a60119c819f8c05e212e00784c5","output_index":0,"content_index":0,"delta":"01","logprobs":[],"obfuscation":"RkAoD5skvWk05i"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"01","item_id":"msg_074ffe63cab217780169e1368cba30819ea83a8a01caf4e0e0","logprobs":[],"obfuscation":"wBUPCiXJ6cSRRr","output_index":0,"sequence_number":10}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_09846402a159165f0169558a60119c819f8c05e212e00784c5","output_index":0,"content_index":0,"delta":"-","logprobs":[],"obfuscation":"LSktQt4kOMgfQvl"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"-","item_id":"msg_074ffe63cab217780169e1368cba30819ea83a8a01caf4e0e0","logprobs":[],"obfuscation":"3wZCSCHQJPsp6s2","output_index":0,"sequence_number":11}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_09846402a159165f0169558a60119c819f8c05e212e00784c5","output_index":0,"content_index":0,"delta":"01","logprobs":[],"obfuscation":"h24zpd5ZeySRKO"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"01","item_id":"msg_074ffe63cab217780169e1368cba30819ea83a8a01caf4e0e0","logprobs":[],"obfuscation":"1fPp8a7kcRiCea","output_index":0,"sequence_number":12}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_09846402a159165f0169558a60119c819f8c05e212e00784c5","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"ENQfVcmZ6DJYoZp"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_074ffe63cab217780169e1368cba30819ea83a8a01caf4e0e0","logprobs":[],"obfuscation":"FASzCO4Ftxebgyu","output_index":0,"sequence_number":13}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":14,"item_id":"msg_09846402a159165f0169558a60119c819f8c05e212e00784c5","output_index":0,"content_index":0,"text":"It
-        is 2024-01-01.","logprobs":[]}
+        data: {"type":"response.output_text.done","content_index":0,"item_id":"msg_074ffe63cab217780169e1368cba30819ea83a8a01caf4e0e0","logprobs":[],"output_index":0,"sequence_number":14,"text":"It
+        is 2024-01-01."}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":15,"item_id":"msg_09846402a159165f0169558a60119c819f8c05e212e00784c5","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"It
-        is 2024-01-01."}}
+        data: {"type":"response.content_part.done","content_index":0,"item_id":"msg_074ffe63cab217780169e1368cba30819ea83a8a01caf4e0e0","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"It
+        is 2024-01-01."},"sequence_number":15}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"msg_09846402a159165f0169558a60119c819f8c05e212e00784c5","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"It
-        is 2024-01-01."}],"role":"assistant"}}
+        data: {"type":"response.output_item.done","item":{"id":"msg_074ffe63cab217780169e1368cba30819ea83a8a01caf4e0e0","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"It
+        is 2024-01-01."}],"role":"assistant"},"output_index":0,"sequence_number":16}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_09846402a159165f0169558a5fc944819f8e0ebe431e86d340","object":"response","created_at":1767213663,"status":"completed","background":false,"completed_at":1767213664,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"msg_09846402a159165f0169558a60119c819f8c05e212e00784c5","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"It
-        is 2024-01-01."}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
-        the current date","name":"get_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":83,"input_tokens_details":{"cached_tokens":0},"output_tokens":12,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":95},"user":null,"metadata":{}}}
+        data: {"type":"response.completed","response":{"id":"resp_074ffe63cab217780169e1368c7e40819eaf21a1c8d056650e","object":"response","created_at":1776367244,"status":"completed","background":false,"completed_at":1776367244,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"msg_074ffe63cab217780169e1368cba30819ea83a8a01caf4e0e0","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"It
+        is 2024-01-01."}],"role":"assistant"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
+        the current date","name":"get_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":83,"input_tokens_details":{"cached_tokens":0},"output_tokens":12,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":95},"user":null,"metadata":{}},"sequence_number":17}
+
+
+        event: response.rate_limits.updated
+
+        data: {"type":"response.rate_limits.updated","rate_limits":{"limit_requests":"10000","limit_tokens":"30000000","remaining_requests":"9999","remaining_tokens":"30000000","reset_requests_ms":6,"reset_tokens_ms":0},"sequence_number":18}
 
 
         '
     headers:
       CF-RAY:
-      - 9b6c98765c2086fc-ORD
+      - 9ed58c8dcced6189-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:03 GMT
+      - Thu, 16 Apr 2026 19:20:44 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -254,11 +271,21 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       openai-processing-ms:
-      - '55'
+      - '85'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '68'
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '30000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '29999700'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
     status:
       code: 200
       message: OK
@@ -266,9 +293,9 @@ interactions:
     body: '{"input": [{"role": "system", "content": [{"type": "input_text", "text":
       "Always use a tool to help you answer. Reply with ''It is ____.''."}]}, {"role":
       "user", "content": [{"type": "input_text", "text": "What''s the current date
-      in YYYY-MM-DD format?"}]}, {"type": "function_call", "call_id": "fc_095ae5869262eb310169558a5f78dc8194a4a9b86ec20cfb5d",
+      in YYYY-MM-DD format?"}]}, {"type": "function_call", "call_id": "fc_0ff17e96062fb9450169e1368c2efc8194aac851dc3b3ef504",
       "name": "get_date", "arguments": "{}"}, {"type": "function_call_output", "call_id":
-      "fc_095ae5869262eb310169558a5f78dc8194a4a9b86ec20cfb5d", "output": "2024-01-01"},
+      "fc_0ff17e96062fb9450169e1368c2efc8194aac851dc3b3ef504", "output": "2024-01-01"},
       {"role": "assistant", "content": [{"type": "output_text", "text": "It is 2024-01-01.",
       "annotations": []}], "status": "completed", "type": "message", "id": "msg_missing_id"},
       {"role": "user", "content": [{"type": "input_text", "text": "What month is it?
@@ -280,7 +307,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -288,8 +315,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - __cf_bm=MTbvVdZV6ZZItTrhPN_VOz2Hezayu6zWDL3kvo47WD4-1767213663-1.0.1.1-kSDYFy_lDaRIIPAzb5BOOK5m93ZMFUb5oz3rjHuHYRJ3alsF_r6MUrSQL4wEpWCQrP8L5q3C96E_cJKJxWClNoYELJ8sP4ztRBk.2Dpx1a8;
-        _cfuvid=9.hG5ntmUYFVwtxA_3wrljcEM_aPdJPBdMmTfBOuRcE-1767213663281-0.0.1.1-604800000
+      - __cf_bm=QNF3cnR1DSkaNmraMjyksYlaMSwNLSH.kLtw78zTEaw-1776367243.7870631-1.0.1.1-aDoIPPeDcPnBid0VVGAfnGx3kb1pGOhwYOXOKXTIMyFSCwLy37D.qXUiZBMmx84aGmn6nGkETlDSbP17.ofvanDmRmzeZsxup_61SZ_GbQfE_ILxz0b.LdLCGwa7DONx
       Host:
       - api.openai.com
       X-Stainless-Async:
@@ -302,83 +328,86 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_07a62e25b6f78cd30169558a606dc081909d6186143622fa42","object":"response","created_at":1767213664,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
-        the current date","name":"get_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.created","response":{"id":"resp_01a8411e1f5c627e0169e1368d237c819ca5896fe932970ea9","object":"response","created_at":1776367245,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
+        the current date","name":"get_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_07a62e25b6f78cd30169558a606dc081909d6186143622fa42","object":"response","created_at":1767213664,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
-        the current date","name":"get_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.in_progress","response":{"id":"resp_01a8411e1f5c627e0169e1368d237c819ca5896fe932970ea9","object":"response","created_at":1776367245,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
+        the current date","name":"get_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_07a62e25b6f78cd30169558a60ae3c8190a4df1d5aaa81b81a","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","item":{"id":"msg_01a8411e1f5c627e0169e1368d7454819c83cabfaf73f6bd54","type":"message","status":"in_progress","content":[],"role":"assistant"},"output_index":0,"sequence_number":2}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_07a62e25b6f78cd30169558a60ae3c8190a4df1d5aaa81b81a","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","content_index":0,"item_id":"msg_01a8411e1f5c627e0169e1368d7454819c83cabfaf73f6bd54","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":3}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_07a62e25b6f78cd30169558a60ae3c8190a4df1d5aaa81b81a","output_index":0,"content_index":0,"delta":"It","logprobs":[],"obfuscation":"HYPRWn5SSsa2IJ"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"It","item_id":"msg_01a8411e1f5c627e0169e1368d7454819c83cabfaf73f6bd54","logprobs":[],"obfuscation":"7VZyK7pmOyrZi4","output_index":0,"sequence_number":4}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_07a62e25b6f78cd30169558a60ae3c8190a4df1d5aaa81b81a","output_index":0,"content_index":0,"delta":"
-        is","logprobs":[],"obfuscation":"I27LRIELsDTmT"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" is","item_id":"msg_01a8411e1f5c627e0169e1368d7454819c83cabfaf73f6bd54","logprobs":[],"obfuscation":"Az3VsfJEZK5V1","output_index":0,"sequence_number":5}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_07a62e25b6f78cd30169558a60ae3c8190a4df1d5aaa81b81a","output_index":0,"content_index":0,"delta":"
-        January","logprobs":[],"obfuscation":"PqPiyPBt"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" January","item_id":"msg_01a8411e1f5c627e0169e1368d7454819c83cabfaf73f6bd54","logprobs":[],"obfuscation":"wvrhdTNS","output_index":0,"sequence_number":6}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_07a62e25b6f78cd30169558a60ae3c8190a4df1d5aaa81b81a","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"JWZKoU31SrquVqj"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_01a8411e1f5c627e0169e1368d7454819c83cabfaf73f6bd54","logprobs":[],"obfuscation":"6X01itO9JIwUu7Y","output_index":0,"sequence_number":7}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":8,"item_id":"msg_07a62e25b6f78cd30169558a60ae3c8190a4df1d5aaa81b81a","output_index":0,"content_index":0,"text":"It
-        is January.","logprobs":[]}
+        data: {"type":"response.output_text.done","content_index":0,"item_id":"msg_01a8411e1f5c627e0169e1368d7454819c83cabfaf73f6bd54","logprobs":[],"output_index":0,"sequence_number":8,"text":"It
+        is January."}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":9,"item_id":"msg_07a62e25b6f78cd30169558a60ae3c8190a4df1d5aaa81b81a","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"It
-        is January."}}
+        data: {"type":"response.content_part.done","content_index":0,"item_id":"msg_01a8411e1f5c627e0169e1368d7454819c83cabfaf73f6bd54","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"It
+        is January."},"sequence_number":9}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":10,"output_index":0,"item":{"id":"msg_07a62e25b6f78cd30169558a60ae3c8190a4df1d5aaa81b81a","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"It
-        is January."}],"role":"assistant"}}
+        data: {"type":"response.output_item.done","item":{"id":"msg_01a8411e1f5c627e0169e1368d7454819c83cabfaf73f6bd54","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"It
+        is January."}],"role":"assistant"},"output_index":0,"sequence_number":10}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":11,"response":{"id":"resp_07a62e25b6f78cd30169558a606dc081909d6186143622fa42","object":"response","created_at":1767213664,"status":"completed","background":false,"completed_at":1767213664,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"msg_07a62e25b6f78cd30169558a60ae3c8190a4df1d5aaa81b81a","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"It
-        is January."}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
-        the current date","name":"get_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":111,"input_tokens_details":{"cached_tokens":0},"output_tokens":6,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":117},"user":null,"metadata":{}}}
+        data: {"type":"response.completed","response":{"id":"resp_01a8411e1f5c627e0169e1368d237c819ca5896fe932970ea9","object":"response","created_at":1776367245,"status":"completed","background":false,"completed_at":1776367245,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"msg_01a8411e1f5c627e0169e1368d7454819c83cabfaf73f6bd54","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"It
+        is January."}],"role":"assistant"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
+        the current date","name":"get_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":111,"input_tokens_details":{"cached_tokens":0},"output_tokens":6,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":117},"user":null,"metadata":{}},"sequence_number":11}
+
+
+        event: response.rate_limits.updated
+
+        data: {"type":"response.rate_limits.updated","rate_limits":{"limit_requests":"10000","limit_tokens":"30000000","remaining_requests":"9999","remaining_tokens":"30000000","reset_requests_ms":6,"reset_tokens_ms":0},"sequence_number":12}
 
 
         '
     headers:
       CF-RAY:
-      - 9b6c987a6a959d4a-ORD
+      - 9ed58c91bea20006-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:04 GMT
+      - Thu, 16 Apr 2026 19:20:45 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -392,11 +421,21 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       openai-processing-ms:
-      - '62'
+      - '102'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '67'
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '30000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '29999672'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
     status:
       code: 200
       message: OK
@@ -412,7 +451,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -431,52 +470,57 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0586cae45fecaa040169558a6102e881a0a1d481e994fb8fe8","object":"response","created_at":1767213665,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
-        the current date","name":"get_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.created","response":{"id":"resp_0cf9ed2f5ead56230169e1368dcdd081a28e37ef8b9eb7e2c9","object":"response","created_at":1776367245,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
+        the current date","name":"get_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0586cae45fecaa040169558a6102e881a0a1d481e994fb8fe8","object":"response","created_at":1767213665,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
-        the current date","name":"get_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.in_progress","response":{"id":"resp_0cf9ed2f5ead56230169e1368dcdd081a28e37ef8b9eb7e2c9","object":"response","created_at":1776367245,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
+        the current date","name":"get_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_0586cae45fecaa040169558a613a6c81a099d81151095e1d62","type":"function_call","status":"in_progress","arguments":"","call_id":"call_Ubye7prkFfvy2XbYJLtjKWOh","name":"get_date"}}
+        data: {"type":"response.output_item.added","item":{"id":"fc_0cf9ed2f5ead56230169e1368e17f081a28ce9b4521993ea2b","type":"function_call","status":"in_progress","arguments":"","call_id":"call_p9R1PisO4O2xXlifKIZ9NjhY","name":"get_date"},"output_index":0,"sequence_number":2}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_0586cae45fecaa040169558a613a6c81a099d81151095e1d62","output_index":0,"delta":"{}","obfuscation":"K8M8OSyNi5fjyG"}
+        data: {"type":"response.function_call_arguments.delta","delta":"{}","item_id":"fc_0cf9ed2f5ead56230169e1368e17f081a28ce9b4521993ea2b","obfuscation":"8K2HTHPfFF4YDL","output_index":0,"sequence_number":3}
 
 
         event: response.function_call_arguments.done
 
-        data: {"type":"response.function_call_arguments.done","sequence_number":4,"item_id":"fc_0586cae45fecaa040169558a613a6c81a099d81151095e1d62","output_index":0,"arguments":"{}"}
+        data: {"type":"response.function_call_arguments.done","arguments":"{}","item_id":"fc_0cf9ed2f5ead56230169e1368e17f081a28ce9b4521993ea2b","output_index":0,"sequence_number":4}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":5,"output_index":0,"item":{"id":"fc_0586cae45fecaa040169558a613a6c81a099d81151095e1d62","type":"function_call","status":"completed","arguments":"{}","call_id":"call_Ubye7prkFfvy2XbYJLtjKWOh","name":"get_date"}}
+        data: {"type":"response.output_item.done","item":{"id":"fc_0cf9ed2f5ead56230169e1368e17f081a28ce9b4521993ea2b","type":"function_call","status":"completed","arguments":"{}","call_id":"call_p9R1PisO4O2xXlifKIZ9NjhY","name":"get_date"},"output_index":0,"sequence_number":5}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":6,"response":{"id":"resp_0586cae45fecaa040169558a6102e881a0a1d481e994fb8fe8","object":"response","created_at":1767213665,"status":"completed","background":false,"completed_at":1767213665,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"fc_0586cae45fecaa040169558a613a6c81a099d81151095e1d62","type":"function_call","status":"completed","arguments":"{}","call_id":"call_Ubye7prkFfvy2XbYJLtjKWOh","name":"get_date"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
-        the current date","name":"get_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":52,"input_tokens_details":{"cached_tokens":0},"output_tokens":11,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":63},"user":null,"metadata":{}}}
+        data: {"type":"response.completed","response":{"id":"resp_0cf9ed2f5ead56230169e1368dcdd081a28e37ef8b9eb7e2c9","object":"response","created_at":1776367245,"status":"completed","background":false,"completed_at":1776367246,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"fc_0cf9ed2f5ead56230169e1368e17f081a28ce9b4521993ea2b","type":"function_call","status":"completed","arguments":"{}","call_id":"call_p9R1PisO4O2xXlifKIZ9NjhY","name":"get_date"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
+        the current date","name":"get_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":52,"input_tokens_details":{"cached_tokens":0},"output_tokens":11,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":63},"user":null,"metadata":{}},"sequence_number":6}
+
+
+        event: response.rate_limits.updated
+
+        data: {"type":"response.rate_limits.updated","rate_limits":{"limit_requests":"10000","limit_tokens":"30000000","remaining_requests":"9999","remaining_tokens":"30000000","reset_requests_ms":6,"reset_tokens_ms":0},"sequence_number":7}
 
 
         '
     headers:
       CF-RAY:
-      - 9b6c987e0c4de227-ORD
+      - 9ed58c95fba92145-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:05 GMT
+      - Thu, 16 Apr 2026 19:20:45 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -490,11 +534,21 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       openai-processing-ms:
-      - '47'
+      - '104'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '50'
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '30000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '29999731'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
     status:
       code: 200
       message: OK
@@ -502,9 +556,9 @@ interactions:
     body: '{"input": [{"role": "system", "content": [{"type": "input_text", "text":
       "Be very terse, not even punctuation."}]}, {"role": "user", "content": [{"type":
       "input_text", "text": "What''s the current date in YYYY-MM-DD format?"}]}, {"type":
-      "function_call", "call_id": "fc_0586cae45fecaa040169558a613a6c81a099d81151095e1d62",
+      "function_call", "call_id": "fc_0cf9ed2f5ead56230169e1368e17f081a28ce9b4521993ea2b",
       "name": "get_date", "arguments": "{}"}, {"type": "function_call_output", "call_id":
-      "fc_0586cae45fecaa040169558a613a6c81a099d81151095e1d62", "output": "2024-01-01"}],
+      "fc_0cf9ed2f5ead56230169e1368e17f081a28ce9b4521993ea2b", "output": "2024-01-01"}],
       "model": "gpt-4.1", "store": false, "stream": true, "tools": [{"type": "function",
       "name": "get_date", "description": "Gets the current date", "parameters": {"properties":
       {}, "type": "object", "additionalProperties": false, "required": []}, "strict":
@@ -513,7 +567,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -521,8 +575,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - __cf_bm=e0TdXLRYWL92WDgKh0rq8HNl51OajVPojch4oacoUMM-1767213665-1.0.1.1-cCeuU0UmbvyX3ppO2m_T6OGYmBU.hF3Og.lTjKtJWyKSNrUQxWxifXOx4LTx95gkQ2.r_Dt9yRw7aA6ek_fxkXbnxPuIRcpKplVxzsgo9Zc;
-        _cfuvid=S2mMkEpGOjBZ6fH8HJRF0mT5cM8dVbyhCz5_fOv2gfc-1767213665082-0.0.1.1-604800000
+      - __cf_bm=pTWJpFfP1E6wnyjHHZ9DKbMVe3TeyISizR_oDNsXhiQ-1776367245.7564929-1.0.1.1-7sANYHV4hQoTMF435aP6qb5Gieikdk1PNJbD2EwgoeXFRsH_SEf_PyGXnBQFLLqZEcR_9Imu2mmeG1Gk22hZyD5_B4y_ZTrMIONPlUNHDlXwAxlPaqPtfQfdfVcDIpmd
       Host:
       - api.openai.com
       X-Stainless-Async:
@@ -535,87 +588,92 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0d41c582d90426670169558a61c9a8819db26f894fdd1ab4f0","object":"response","created_at":1767213666,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
-        the current date","name":"get_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.created","response":{"id":"resp_0ca2c6d4a1711d630169e1368e627c819dae1a64082b4f0f92","object":"response","created_at":1776367246,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
+        the current date","name":"get_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0d41c582d90426670169558a61c9a8819db26f894fdd1ab4f0","object":"response","created_at":1767213666,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
-        the current date","name":"get_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.in_progress","response":{"id":"resp_0ca2c6d4a1711d630169e1368e627c819dae1a64082b4f0f92","object":"response","created_at":1776367246,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
+        the current date","name":"get_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0d41c582d90426670169558a62b600819da346cc840472af35","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","item":{"id":"msg_0ca2c6d4a1711d630169e1368ee6b4819d93e5de395a5fb9bf","type":"message","status":"in_progress","content":[],"role":"assistant"},"output_index":0,"sequence_number":2}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0d41c582d90426670169558a62b600819da346cc840472af35","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","content_index":0,"item_id":"msg_0ca2c6d4a1711d630169e1368ee6b4819d93e5de395a5fb9bf","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":3}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_0d41c582d90426670169558a62b600819da346cc840472af35","output_index":0,"content_index":0,"delta":"202","logprobs":[],"obfuscation":"UN2FgVtgbToje"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"202","item_id":"msg_0ca2c6d4a1711d630169e1368ee6b4819d93e5de395a5fb9bf","logprobs":[],"obfuscation":"TOJz3oxOwhSTq","output_index":0,"sequence_number":4}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_0d41c582d90426670169558a62b600819da346cc840472af35","output_index":0,"content_index":0,"delta":"4","logprobs":[],"obfuscation":"kaG5S9LsderVhfW"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"4","item_id":"msg_0ca2c6d4a1711d630169e1368ee6b4819d93e5de395a5fb9bf","logprobs":[],"obfuscation":"yPx6CFMNyJt9ABD","output_index":0,"sequence_number":5}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_0d41c582d90426670169558a62b600819da346cc840472af35","output_index":0,"content_index":0,"delta":"-","logprobs":[],"obfuscation":"kMw95Wl6vQgAB2T"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"-","item_id":"msg_0ca2c6d4a1711d630169e1368ee6b4819d93e5de395a5fb9bf","logprobs":[],"obfuscation":"qYvhrf82dDKqvJi","output_index":0,"sequence_number":6}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_0d41c582d90426670169558a62b600819da346cc840472af35","output_index":0,"content_index":0,"delta":"01","logprobs":[],"obfuscation":"XYDWQLGwRwm31d"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"01","item_id":"msg_0ca2c6d4a1711d630169e1368ee6b4819d93e5de395a5fb9bf","logprobs":[],"obfuscation":"SG38nTBX2R9qAe","output_index":0,"sequence_number":7}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_0d41c582d90426670169558a62b600819da346cc840472af35","output_index":0,"content_index":0,"delta":"-","logprobs":[],"obfuscation":"3XXCByXWRmttfhd"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"-","item_id":"msg_0ca2c6d4a1711d630169e1368ee6b4819d93e5de395a5fb9bf","logprobs":[],"obfuscation":"TXk7gH7rkd5KtvJ","output_index":0,"sequence_number":8}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_0d41c582d90426670169558a62b600819da346cc840472af35","output_index":0,"content_index":0,"delta":"01","logprobs":[],"obfuscation":"FJOo1dcVHNTLRE"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"01","item_id":"msg_0ca2c6d4a1711d630169e1368ee6b4819d93e5de395a5fb9bf","logprobs":[],"obfuscation":"HQHjktmmos0Qpz","output_index":0,"sequence_number":9}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":10,"item_id":"msg_0d41c582d90426670169558a62b600819da346cc840472af35","output_index":0,"content_index":0,"text":"2024-01-01","logprobs":[]}
+        data: {"type":"response.output_text.done","content_index":0,"item_id":"msg_0ca2c6d4a1711d630169e1368ee6b4819d93e5de395a5fb9bf","logprobs":[],"output_index":0,"sequence_number":10,"text":"2024-01-01"}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":11,"item_id":"msg_0d41c582d90426670169558a62b600819da346cc840472af35","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"2024-01-01"}}
+        data: {"type":"response.content_part.done","content_index":0,"item_id":"msg_0ca2c6d4a1711d630169e1368ee6b4819d93e5de395a5fb9bf","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"2024-01-01"},"sequence_number":11}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":12,"output_index":0,"item":{"id":"msg_0d41c582d90426670169558a62b600819da346cc840472af35","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"2024-01-01"}],"role":"assistant"}}
+        data: {"type":"response.output_item.done","item":{"id":"msg_0ca2c6d4a1711d630169e1368ee6b4819d93e5de395a5fb9bf","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"2024-01-01"}],"role":"assistant"},"output_index":0,"sequence_number":12}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":13,"response":{"id":"resp_0d41c582d90426670169558a61c9a8819db26f894fdd1ab4f0","object":"response","created_at":1767213666,"status":"completed","background":false,"completed_at":1767213667,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"msg_0d41c582d90426670169558a62b600819da346cc840472af35","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"2024-01-01"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
-        the current date","name":"get_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":74,"input_tokens_details":{"cached_tokens":0},"output_tokens":8,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":82},"user":null,"metadata":{}}}
+        data: {"type":"response.completed","response":{"id":"resp_0ca2c6d4a1711d630169e1368e627c819dae1a64082b4f0f92","object":"response","created_at":1776367246,"status":"completed","background":false,"completed_at":1776367246,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"msg_0ca2c6d4a1711d630169e1368ee6b4819d93e5de395a5fb9bf","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"2024-01-01"}],"role":"assistant"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
+        the current date","name":"get_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":74,"input_tokens_details":{"cached_tokens":0},"output_tokens":8,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":82},"user":null,"metadata":{}},"sequence_number":13}
+
+
+        event: response.rate_limits.updated
+
+        data: {"type":"response.rate_limits.updated","rate_limits":{"limit_requests":"10000","limit_tokens":"30000000","remaining_requests":"9999","remaining_tokens":"30000000","reset_requests_ms":6,"reset_tokens_ms":0},"sequence_number":14}
 
 
         '
     headers:
       CF-RAY:
-      - 9b6c98814b9ce81d-ORD
+      - 9ed58c99ada0f856-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:06 GMT
+      - Thu, 16 Apr 2026 19:20:46 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -629,11 +687,21 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       openai-processing-ms:
-      - '593'
+      - '351'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '671'
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '30000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '29999709'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
     status:
       code: 200
       message: OK
@@ -650,7 +718,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -669,127 +737,77 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0d8d9edcefe2f2990169558a63bd3c819691f3ed9b00bcca02","object":"response","created_at":1767213667,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Returns
-        a person''s favourite colour","name":"favorite_color","parameters":{"properties":{"_person":{"type":"string"}},"required":["_person"],"type":"object","additionalProperties":false},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.created","response":{"id":"resp_069d7141b0a593e50169e1368f3b30819096e0f3a37ed30d0a","object":"response","created_at":1776367247,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Returns
+        a person''s favourite colour","name":"favorite_color","parameters":{"properties":{"_person":{"type":"string"}},"required":["_person"],"type":"object","additionalProperties":false},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0d8d9edcefe2f2990169558a63bd3c819691f3ed9b00bcca02","object":"response","created_at":1767213667,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Returns
-        a person''s favourite colour","name":"favorite_color","parameters":{"properties":{"_person":{"type":"string"}},"required":["_person"],"type":"object","additionalProperties":false},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.in_progress","response":{"id":"resp_069d7141b0a593e50169e1368f3b30819096e0f3a37ed30d0a","object":"response","created_at":1776367247,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Returns
+        a person''s favourite colour","name":"favorite_color","parameters":{"properties":{"_person":{"type":"string"}},"required":["_person"],"type":"object","additionalProperties":false},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_0d8d9edcefe2f2990169558a64367481969c3d5dcf7614b51c","type":"function_call","status":"in_progress","arguments":"","call_id":"call_c9xWOFS85SVfArnKmzhrByLv","name":"favorite_color"}}
+        data: {"type":"response.output_item.added","item":{"id":"fc_069d7141b0a593e50169e136904bcc81908297595c35de536a","type":"function_call","status":"in_progress","arguments":"","call_id":"call_lrHBKv6ZRSwV5ICKlWpJw4n1","name":"favorite_color"},"output_index":0,"sequence_number":2}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_0d8d9edcefe2f2990169558a64367481969c3d5dcf7614b51c","output_index":0,"delta":"{","obfuscation":"ihT6qlI6u6ImLJr"}
-
-
-        event: response.function_call_arguments.delta
-
-        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_0d8d9edcefe2f2990169558a64367481969c3d5dcf7614b51c","output_index":0,"delta":"\"_","obfuscation":"qGcqld9uNEswKk"}
-
-
-        event: response.function_call_arguments.delta
-
-        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_0d8d9edcefe2f2990169558a64367481969c3d5dcf7614b51c","output_index":0,"delta":"person","obfuscation":"jBX6Kspzhr"}
-
-
-        event: response.function_call_arguments.delta
-
-        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_0d8d9edcefe2f2990169558a64367481969c3d5dcf7614b51c","output_index":0,"delta":"\":","obfuscation":"icRH1Cs5MoVKsP"}
-
-
-        event: response.function_call_arguments.delta
-
-        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_0d8d9edcefe2f2990169558a64367481969c3d5dcf7614b51c","output_index":0,"delta":"\"Joe","obfuscation":"IQr6H7Kh7EJ8"}
-
-
-        event: response.function_call_arguments.delta
-
-        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_0d8d9edcefe2f2990169558a64367481969c3d5dcf7614b51c","output_index":0,"delta":"\"}","obfuscation":"1DZzvnQOYtPoap"}
+        data: {"type":"response.function_call_arguments.delta","delta":"{\"_person\":\"Joe\"}","item_id":"fc_069d7141b0a593e50169e136904bcc81908297595c35de536a","obfuscation":"0tNaKmtESJVi2UD","output_index":0,"sequence_number":3}
 
 
         event: response.function_call_arguments.done
 
-        data: {"type":"response.function_call_arguments.done","sequence_number":9,"item_id":"fc_0d8d9edcefe2f2990169558a64367481969c3d5dcf7614b51c","output_index":0,"arguments":"{\"_person\":\"Joe\"}"}
+        data: {"type":"response.function_call_arguments.done","arguments":"{\"_person\":\"Joe\"}","item_id":"fc_069d7141b0a593e50169e136904bcc81908297595c35de536a","output_index":0,"sequence_number":4}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":10,"output_index":0,"item":{"id":"fc_0d8d9edcefe2f2990169558a64367481969c3d5dcf7614b51c","type":"function_call","status":"completed","arguments":"{\"_person\":\"Joe\"}","call_id":"call_c9xWOFS85SVfArnKmzhrByLv","name":"favorite_color"}}
+        data: {"type":"response.output_item.done","item":{"id":"fc_069d7141b0a593e50169e136904bcc81908297595c35de536a","type":"function_call","status":"completed","arguments":"{\"_person\":\"Joe\"}","call_id":"call_lrHBKv6ZRSwV5ICKlWpJw4n1","name":"favorite_color"},"output_index":0,"sequence_number":5}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":11,"output_index":1,"item":{"id":"fc_0d8d9edcefe2f2990169558a64457081968ce73d55407b6f32","type":"function_call","status":"in_progress","arguments":"","call_id":"call_fKugSoVJ3uwJZDS2FBK60n9M","name":"favorite_color"}}
+        data: {"type":"response.output_item.added","item":{"id":"fc_069d7141b0a593e50169e136904bdc819090589ca02d0b4904","type":"function_call","status":"in_progress","arguments":"","call_id":"call_QIOsM69zImQbIbGz1ZtMRBDH","name":"favorite_color"},"output_index":1,"sequence_number":6}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_0d8d9edcefe2f2990169558a64457081968ce73d55407b6f32","output_index":1,"delta":"{","obfuscation":"UdcBfjaBhDNuWVL"}
-
-
-        event: response.function_call_arguments.delta
-
-        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_0d8d9edcefe2f2990169558a64457081968ce73d55407b6f32","output_index":1,"delta":"\"_","obfuscation":"oV4UdDoKo3D5yF"}
-
-
-        event: response.function_call_arguments.delta
-
-        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_0d8d9edcefe2f2990169558a64457081968ce73d55407b6f32","output_index":1,"delta":"person","obfuscation":"dDJYPkTxYD"}
-
-
-        event: response.function_call_arguments.delta
-
-        data: {"type":"response.function_call_arguments.delta","sequence_number":15,"item_id":"fc_0d8d9edcefe2f2990169558a64457081968ce73d55407b6f32","output_index":1,"delta":"\":","obfuscation":"VGSA0ajNIflkDN"}
-
-
-        event: response.function_call_arguments.delta
-
-        data: {"type":"response.function_call_arguments.delta","sequence_number":16,"item_id":"fc_0d8d9edcefe2f2990169558a64457081968ce73d55407b6f32","output_index":1,"delta":"\"Had","obfuscation":"WH7yngL1Yyss"}
-
-
-        event: response.function_call_arguments.delta
-
-        data: {"type":"response.function_call_arguments.delta","sequence_number":17,"item_id":"fc_0d8d9edcefe2f2990169558a64457081968ce73d55407b6f32","output_index":1,"delta":"ley","obfuscation":"0xSEoV08I4qUn"}
-
-
-        event: response.function_call_arguments.delta
-
-        data: {"type":"response.function_call_arguments.delta","sequence_number":18,"item_id":"fc_0d8d9edcefe2f2990169558a64457081968ce73d55407b6f32","output_index":1,"delta":"\"}","obfuscation":"xCRnxRfxpMa1mg"}
+        data: {"type":"response.function_call_arguments.delta","delta":"{\"_person\":\"Hadley\"}","item_id":"fc_069d7141b0a593e50169e136904bdc819090589ca02d0b4904","obfuscation":"36kSW0B6TXZB","output_index":1,"sequence_number":7}
 
 
         event: response.function_call_arguments.done
 
-        data: {"type":"response.function_call_arguments.done","sequence_number":19,"item_id":"fc_0d8d9edcefe2f2990169558a64457081968ce73d55407b6f32","output_index":1,"arguments":"{\"_person\":\"Hadley\"}"}
+        data: {"type":"response.function_call_arguments.done","arguments":"{\"_person\":\"Hadley\"}","item_id":"fc_069d7141b0a593e50169e136904bdc819090589ca02d0b4904","output_index":1,"sequence_number":8}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":20,"output_index":1,"item":{"id":"fc_0d8d9edcefe2f2990169558a64457081968ce73d55407b6f32","type":"function_call","status":"completed","arguments":"{\"_person\":\"Hadley\"}","call_id":"call_fKugSoVJ3uwJZDS2FBK60n9M","name":"favorite_color"}}
+        data: {"type":"response.output_item.done","item":{"id":"fc_069d7141b0a593e50169e136904bdc819090589ca02d0b4904","type":"function_call","status":"completed","arguments":"{\"_person\":\"Hadley\"}","call_id":"call_QIOsM69zImQbIbGz1ZtMRBDH","name":"favorite_color"},"output_index":1,"sequence_number":9}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":21,"response":{"id":"resp_0d8d9edcefe2f2990169558a63bd3c819691f3ed9b00bcca02","object":"response","created_at":1767213667,"status":"completed","background":false,"completed_at":1767213668,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"fc_0d8d9edcefe2f2990169558a64367481969c3d5dcf7614b51c","type":"function_call","status":"completed","arguments":"{\"_person\":\"Joe\"}","call_id":"call_c9xWOFS85SVfArnKmzhrByLv","name":"favorite_color"},{"id":"fc_0d8d9edcefe2f2990169558a64457081968ce73d55407b6f32","type":"function_call","status":"completed","arguments":"{\"_person\":\"Hadley\"}","call_id":"call_fKugSoVJ3uwJZDS2FBK60n9M","name":"favorite_color"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Returns
-        a person''s favourite colour","name":"favorite_color","parameters":{"properties":{"_person":{"type":"string"}},"required":["_person"],"type":"object","additionalProperties":false},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":38,"input_tokens_details":{"cached_tokens":0},"output_tokens":48,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":86},"user":null,"metadata":{}}}
+        data: {"type":"response.completed","response":{"id":"resp_069d7141b0a593e50169e1368f3b30819096e0f3a37ed30d0a","object":"response","created_at":1776367247,"status":"completed","background":false,"completed_at":1776367248,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"fc_069d7141b0a593e50169e136904bcc81908297595c35de536a","type":"function_call","status":"completed","arguments":"{\"_person\":\"Joe\"}","call_id":"call_lrHBKv6ZRSwV5ICKlWpJw4n1","name":"favorite_color"},{"id":"fc_069d7141b0a593e50169e136904bdc819090589ca02d0b4904","type":"function_call","status":"completed","arguments":"{\"_person\":\"Hadley\"}","call_id":"call_QIOsM69zImQbIbGz1ZtMRBDH","name":"favorite_color"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Returns
+        a person''s favourite colour","name":"favorite_color","parameters":{"properties":{"_person":{"type":"string"}},"required":["_person"],"type":"object","additionalProperties":false},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":77,"input_tokens_details":{"cached_tokens":0},"output_tokens":48,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":125},"user":null,"metadata":{}},"sequence_number":10}
+
+
+        event: response.rate_limits.updated
+
+        data: {"type":"response.rate_limits.updated","rate_limits":{"limit_requests":"10000","limit_tokens":"30000000","remaining_requests":"9999","remaining_tokens":"30000000","reset_requests_ms":6,"reset_tokens_ms":0},"sequence_number":11}
 
 
         '
     headers:
       CF-RAY:
-      - 9b6c988f2df00ce1-ORD
+      - 9ed58c9efa2fd240-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:07 GMT
+      - Thu, 16 Apr 2026 19:20:47 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -803,11 +821,21 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       openai-processing-ms:
-      - '56'
+      - '77'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '60'
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '30000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '29999706'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
     status:
       code: 200
       message: OK
@@ -816,12 +844,12 @@ interactions:
       "Be very terse, not even punctuation."}]}, {"role": "user", "content": [{"type":
       "input_text", "text": "\n        What are Joe and Hadley''s favourite colours?\n        Answer
       like name1: colour1, name2: colour2\n    "}]}, {"type": "function_call", "call_id":
-      "fc_0d8d9edcefe2f2990169558a64367481969c3d5dcf7614b51c", "name": "favorite_color",
+      "fc_069d7141b0a593e50169e136904bcc81908297595c35de536a", "name": "favorite_color",
       "arguments": "{\"_person\":\"Joe\"}"}, {"type": "function_call", "call_id":
-      "fc_0d8d9edcefe2f2990169558a64457081968ce73d55407b6f32", "name": "favorite_color",
+      "fc_069d7141b0a593e50169e136904bdc819090589ca02d0b4904", "name": "favorite_color",
       "arguments": "{\"_person\":\"Hadley\"}"}, {"type": "function_call_output", "call_id":
-      "fc_0d8d9edcefe2f2990169558a64367481969c3d5dcf7614b51c", "output": "sage green"},
-      {"type": "function_call_output", "call_id": "fc_0d8d9edcefe2f2990169558a64457081968ce73d55407b6f32",
+      "fc_069d7141b0a593e50169e136904bcc81908297595c35de536a", "output": "sage green"},
+      {"type": "function_call_output", "call_id": "fc_069d7141b0a593e50169e136904bdc819090589ca02d0b4904",
       "output": "red"}], "model": "gpt-4.1", "store": false, "stream": true, "tools":
       [{"type": "function", "name": "favorite_color", "description": "Returns a person''s
       favourite colour", "parameters": {"properties": {"_person": {"type": "string"}},
@@ -831,7 +859,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -839,8 +867,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - __cf_bm=Ds6TJbknij0GSfKFWcE0HhUFAg4YWL.2STx457g3OjA-1767213667-1.0.1.1-gNo.pPAoVu.j99xKN_uCvwVluizQ10sYovcTqDly9zH.g9dmGr_k1gemyBEQwhxaygoBQ.tjAVVK7lXDxjdd81OTxbbSSGo0eCiRo_rIVdI;
-        _cfuvid=w.aCVIYUtUulaux_b3XcQioN_gUSGrXy8sgfQNqcAKM-1767213667794-0.0.1.1-604800000
+      - __cf_bm=2rYR2Rr7lGPZ5HNXtBOcpLp2Ja7tkwJUaKbvoFCpV1Y-1776367247.194765-1.0.1.1-O8cfEaNgijNdUeDBD02hjbuqnI1uAcJ97PCudFH.g5q8yw7eANdWdnXzYLSsFUD0aedj9IiuBAWhLPKIsIbV5FdEHVLIQn3UXG1uwMNBc.W0RwKo83yAekjXi.lCryXU
       Host:
       - api.openai.com
       X-Stainless-Async:
@@ -853,110 +880,111 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_07a694a8784697740169558a64e44c8190973fc2996c854924","object":"response","created_at":1767213668,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Returns
-        a person''s favourite colour","name":"favorite_color","parameters":{"properties":{"_person":{"type":"string"}},"required":["_person"],"type":"object","additionalProperties":false},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.created","response":{"id":"resp_072431a2f58255ee0169e136909fd8819586448285b1fb5ed8","object":"response","created_at":1776367248,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Returns
+        a person''s favourite colour","name":"favorite_color","parameters":{"properties":{"_person":{"type":"string"}},"required":["_person"],"type":"object","additionalProperties":false},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_07a694a8784697740169558a64e44c8190973fc2996c854924","object":"response","created_at":1767213668,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Returns
-        a person''s favourite colour","name":"favorite_color","parameters":{"properties":{"_person":{"type":"string"}},"required":["_person"],"type":"object","additionalProperties":false},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.in_progress","response":{"id":"resp_072431a2f58255ee0169e136909fd8819586448285b1fb5ed8","object":"response","created_at":1776367248,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Returns
+        a person''s favourite colour","name":"favorite_color","parameters":{"properties":{"_person":{"type":"string"}},"required":["_person"],"type":"object","additionalProperties":false},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_07a694a8784697740169558a6554208190ba545647ac434502","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","item":{"id":"msg_072431a2f58255ee0169e136911d8c81958150f26c3472e170","type":"message","status":"in_progress","content":[],"role":"assistant"},"output_index":0,"sequence_number":2}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_07a694a8784697740169558a6554208190ba545647ac434502","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","content_index":0,"item_id":"msg_072431a2f58255ee0169e136911d8c81958150f26c3472e170","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":3}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_07a694a8784697740169558a6554208190ba545647ac434502","output_index":0,"content_index":0,"delta":"Joe","logprobs":[],"obfuscation":"wr32uK7VeeDZr"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"Joe","item_id":"msg_072431a2f58255ee0169e136911d8c81958150f26c3472e170","logprobs":[],"obfuscation":"Pk8hU2tGSh3G3","output_index":0,"sequence_number":4}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_07a694a8784697740169558a6554208190ba545647ac434502","output_index":0,"content_index":0,"delta":":","logprobs":[],"obfuscation":"H7q4i5ttUMIrZqf"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":":","item_id":"msg_072431a2f58255ee0169e136911d8c81958150f26c3472e170","logprobs":[],"obfuscation":"omWCoKq2H9ufCeF","output_index":0,"sequence_number":5}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_07a694a8784697740169558a6554208190ba545647ac434502","output_index":0,"content_index":0,"delta":"
-        sage","logprobs":[],"obfuscation":"9skRGAxmcT8"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" sage","item_id":"msg_072431a2f58255ee0169e136911d8c81958150f26c3472e170","logprobs":[],"obfuscation":"XvzLrfnbLdC","output_index":0,"sequence_number":6}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_07a694a8784697740169558a6554208190ba545647ac434502","output_index":0,"content_index":0,"delta":"
-        green","logprobs":[],"obfuscation":"aJejfNCtdO"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" green","item_id":"msg_072431a2f58255ee0169e136911d8c81958150f26c3472e170","logprobs":[],"obfuscation":"VmEcFK4hkD","output_index":0,"sequence_number":7}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_07a694a8784697740169558a6554208190ba545647ac434502","output_index":0,"content_index":0,"delta":",","logprobs":[],"obfuscation":"AG70kJHg6qPMVf7"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":",","item_id":"msg_072431a2f58255ee0169e136911d8c81958150f26c3472e170","logprobs":[],"obfuscation":"sTICUQ4EosNhYEN","output_index":0,"sequence_number":8}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_07a694a8784697740169558a6554208190ba545647ac434502","output_index":0,"content_index":0,"delta":"
-        Had","logprobs":[],"obfuscation":"Wn81n2UjiRug"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" Had","item_id":"msg_072431a2f58255ee0169e136911d8c81958150f26c3472e170","logprobs":[],"obfuscation":"xD0oK0sMLsD7","output_index":0,"sequence_number":9}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_07a694a8784697740169558a6554208190ba545647ac434502","output_index":0,"content_index":0,"delta":"ley","logprobs":[],"obfuscation":"fYXTxdLIfFylj"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"ley","item_id":"msg_072431a2f58255ee0169e136911d8c81958150f26c3472e170","logprobs":[],"obfuscation":"V56jsQ7bj9poV","output_index":0,"sequence_number":10}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_07a694a8784697740169558a6554208190ba545647ac434502","output_index":0,"content_index":0,"delta":":","logprobs":[],"obfuscation":"S5b88xm0jcaCN9j"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":":","item_id":"msg_072431a2f58255ee0169e136911d8c81958150f26c3472e170","logprobs":[],"obfuscation":"YoZeqRkSCLaCl83","output_index":0,"sequence_number":11}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_07a694a8784697740169558a6554208190ba545647ac434502","output_index":0,"content_index":0,"delta":"
-        red","logprobs":[],"obfuscation":"C5vI7j2K7ovf"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" red","item_id":"msg_072431a2f58255ee0169e136911d8c81958150f26c3472e170","logprobs":[],"obfuscation":"wNkkh2eRaBtT","output_index":0,"sequence_number":12}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":13,"item_id":"msg_07a694a8784697740169558a6554208190ba545647ac434502","output_index":0,"content_index":0,"text":"Joe:
-        sage green, Hadley: red","logprobs":[]}
+        data: {"type":"response.output_text.done","content_index":0,"item_id":"msg_072431a2f58255ee0169e136911d8c81958150f26c3472e170","logprobs":[],"output_index":0,"sequence_number":13,"text":"Joe:
+        sage green, Hadley: red"}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":14,"item_id":"msg_07a694a8784697740169558a6554208190ba545647ac434502","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"Joe:
-        sage green, Hadley: red"}}
+        data: {"type":"response.content_part.done","content_index":0,"item_id":"msg_072431a2f58255ee0169e136911d8c81958150f26c3472e170","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"Joe:
+        sage green, Hadley: red"},"sequence_number":14}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":15,"output_index":0,"item":{"id":"msg_07a694a8784697740169558a6554208190ba545647ac434502","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Joe:
-        sage green, Hadley: red"}],"role":"assistant"}}
+        data: {"type":"response.output_item.done","item":{"id":"msg_072431a2f58255ee0169e136911d8c81958150f26c3472e170","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Joe:
+        sage green, Hadley: red"}],"role":"assistant"},"output_index":0,"sequence_number":15}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":16,"response":{"id":"resp_07a694a8784697740169558a64e44c8190973fc2996c854924","object":"response","created_at":1767213668,"status":"completed","background":false,"completed_at":1767213669,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"msg_07a694a8784697740169558a6554208190ba545647ac434502","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Joe:
-        sage green, Hadley: red"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Returns
-        a person''s favourite colour","name":"favorite_color","parameters":{"properties":{"_person":{"type":"string"}},"required":["_person"],"type":"object","additionalProperties":false},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":123,"input_tokens_details":{"cached_tokens":0},"output_tokens":11,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":134},"user":null,"metadata":{}}}
+        data: {"type":"response.completed","response":{"id":"resp_072431a2f58255ee0169e136909fd8819586448285b1fb5ed8","object":"response","created_at":1776367248,"status":"completed","background":false,"completed_at":1776367249,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"msg_072431a2f58255ee0169e136911d8c81958150f26c3472e170","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Joe:
+        sage green, Hadley: red"}],"role":"assistant"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Returns
+        a person''s favourite colour","name":"favorite_color","parameters":{"properties":{"_person":{"type":"string"}},"required":["_person"],"type":"object","additionalProperties":false},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":123,"input_tokens_details":{"cached_tokens":0},"output_tokens":11,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":134},"user":null,"metadata":{}},"sequence_number":16}
+
+
+        event: response.rate_limits.updated
+
+        data: {"type":"response.rate_limits.updated","rate_limits":{"limit_requests":"10000","limit_tokens":"30000000","remaining_requests":"9999","remaining_tokens":"30000000","reset_requests_ms":6,"reset_tokens_ms":0},"sequence_number":17}
 
 
         '
     headers:
       CF-RAY:
-      - 9b6c98963c2daf01-ORD
+      - 9ed58ca7bdaad7c2-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:08 GMT
+      - Thu, 16 Apr 2026 19:20:48 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -970,11 +998,21 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       openai-processing-ms:
-      - '57'
+      - '118'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '61'
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '30000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '29999660'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
     status:
       code: 200
       message: OK
@@ -995,7 +1033,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -1014,84 +1052,88 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0c46f98386d8d7d70169558a65ab8481a0b51ce2cd59a8cc96","object":"response","created_at":1767213669,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
+        data: {"type":"response.created","response":{"id":"resp_0b89c0fa40cf4b600169e1369185dc8194a29f9a8918db790d","object":"response","created_at":1776367249,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
         the weather forecast for a city","name":"weather_forecast","parameters":{"properties":{"city":{"type":"string"}},"required":["city"],"type":"object","additionalProperties":false},"strict":true},{"type":"function","description":"Gets
-        the equipment needed for a weather condition","name":"equipment","parameters":{"properties":{"weather":{"type":"string"}},"required":["weather"],"type":"object","additionalProperties":false},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        the equipment needed for a weather condition","name":"equipment","parameters":{"properties":{"weather":{"type":"string"}},"required":["weather"],"type":"object","additionalProperties":false},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0c46f98386d8d7d70169558a65ab8481a0b51ce2cd59a8cc96","object":"response","created_at":1767213669,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
+        data: {"type":"response.in_progress","response":{"id":"resp_0b89c0fa40cf4b600169e1369185dc8194a29f9a8918db790d","object":"response","created_at":1776367249,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
         the weather forecast for a city","name":"weather_forecast","parameters":{"properties":{"city":{"type":"string"}},"required":["city"],"type":"object","additionalProperties":false},"strict":true},{"type":"function","description":"Gets
-        the equipment needed for a weather condition","name":"equipment","parameters":{"properties":{"weather":{"type":"string"}},"required":["weather"],"type":"object","additionalProperties":false},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        the equipment needed for a weather condition","name":"equipment","parameters":{"properties":{"weather":{"type":"string"}},"required":["weather"],"type":"object","additionalProperties":false},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_0c46f98386d8d7d70169558a6647dc81a083383ea14b51a840","type":"function_call","status":"in_progress","arguments":"","call_id":"call_Bmzo84yYSOEC0xwp31Qq24eE","name":"weather_forecast"}}
+        data: {"type":"response.output_item.added","item":{"id":"fc_0b89c0fa40cf4b600169e1369201a481948f642fe7a541a3e4","type":"function_call","status":"in_progress","arguments":"","call_id":"call_LQ02UU0ZGv0YM5SDcdhxku80","name":"weather_forecast"},"output_index":0,"sequence_number":2}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_0c46f98386d8d7d70169558a6647dc81a083383ea14b51a840","output_index":0,"delta":"{\"","obfuscation":"w1XaAEiZTlHNfI"}
+        data: {"type":"response.function_call_arguments.delta","delta":"{\"","item_id":"fc_0b89c0fa40cf4b600169e1369201a481948f642fe7a541a3e4","obfuscation":"WBGBbhCZDmy6pE","output_index":0,"sequence_number":3}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_0c46f98386d8d7d70169558a6647dc81a083383ea14b51a840","output_index":0,"delta":"city","obfuscation":"JdyHVN0wXmPo"}
+        data: {"type":"response.function_call_arguments.delta","delta":"city","item_id":"fc_0b89c0fa40cf4b600169e1369201a481948f642fe7a541a3e4","obfuscation":"bOqB1DVE8mgN","output_index":0,"sequence_number":4}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_0c46f98386d8d7d70169558a6647dc81a083383ea14b51a840","output_index":0,"delta":"\":\"","obfuscation":"AW0uUMjKZ4hFi"}
+        data: {"type":"response.function_call_arguments.delta","delta":"\":\"","item_id":"fc_0b89c0fa40cf4b600169e1369201a481948f642fe7a541a3e4","obfuscation":"8tKUpw5sPuvdE","output_index":0,"sequence_number":5}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_0c46f98386d8d7d70169558a6647dc81a083383ea14b51a840","output_index":0,"delta":"New","obfuscation":"pxoVF2GMT2ffa"}
+        data: {"type":"response.function_call_arguments.delta","delta":"New","item_id":"fc_0b89c0fa40cf4b600169e1369201a481948f642fe7a541a3e4","obfuscation":"5QmmMCOju6jza","output_index":0,"sequence_number":6}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_0c46f98386d8d7d70169558a6647dc81a083383ea14b51a840","output_index":0,"delta":"
-        York","obfuscation":"7hbyXIzOzcr"}
+        data: {"type":"response.function_call_arguments.delta","delta":" York","item_id":"fc_0b89c0fa40cf4b600169e1369201a481948f642fe7a541a3e4","obfuscation":"baSFGpfFw5S","output_index":0,"sequence_number":7}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_0c46f98386d8d7d70169558a6647dc81a083383ea14b51a840","output_index":0,"delta":"\"}","obfuscation":"SSwoJDLkYl0Fzy"}
+        data: {"type":"response.function_call_arguments.delta","delta":"\"}","item_id":"fc_0b89c0fa40cf4b600169e1369201a481948f642fe7a541a3e4","obfuscation":"SnIZgqzoqlOZbg","output_index":0,"sequence_number":8}
 
 
         event: response.function_call_arguments.done
 
-        data: {"type":"response.function_call_arguments.done","sequence_number":9,"item_id":"fc_0c46f98386d8d7d70169558a6647dc81a083383ea14b51a840","output_index":0,"arguments":"{\"city\":\"New
-        York\"}"}
+        data: {"type":"response.function_call_arguments.done","arguments":"{\"city\":\"New
+        York\"}","item_id":"fc_0b89c0fa40cf4b600169e1369201a481948f642fe7a541a3e4","output_index":0,"sequence_number":9}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":10,"output_index":0,"item":{"id":"fc_0c46f98386d8d7d70169558a6647dc81a083383ea14b51a840","type":"function_call","status":"completed","arguments":"{\"city\":\"New
-        York\"}","call_id":"call_Bmzo84yYSOEC0xwp31Qq24eE","name":"weather_forecast"}}
+        data: {"type":"response.output_item.done","item":{"id":"fc_0b89c0fa40cf4b600169e1369201a481948f642fe7a541a3e4","type":"function_call","status":"completed","arguments":"{\"city\":\"New
+        York\"}","call_id":"call_LQ02UU0ZGv0YM5SDcdhxku80","name":"weather_forecast"},"output_index":0,"sequence_number":10}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":11,"response":{"id":"resp_0c46f98386d8d7d70169558a65ab8481a0b51ce2cd59a8cc96","object":"response","created_at":1767213669,"status":"completed","background":false,"completed_at":1767213670,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"fc_0c46f98386d8d7d70169558a6647dc81a083383ea14b51a840","type":"function_call","status":"completed","arguments":"{\"city\":\"New
-        York\"}","call_id":"call_Bmzo84yYSOEC0xwp31Qq24eE","name":"weather_forecast"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
+        data: {"type":"response.completed","response":{"id":"resp_0b89c0fa40cf4b600169e1369185dc8194a29f9a8918db790d","object":"response","created_at":1776367249,"status":"completed","background":false,"completed_at":1776367250,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"fc_0b89c0fa40cf4b600169e1369201a481948f642fe7a541a3e4","type":"function_call","status":"completed","arguments":"{\"city\":\"New
+        York\"}","call_id":"call_LQ02UU0ZGv0YM5SDcdhxku80","name":"weather_forecast"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
         the weather forecast for a city","name":"weather_forecast","parameters":{"properties":{"city":{"type":"string"}},"required":["city"],"type":"object","additionalProperties":false},"strict":true},{"type":"function","description":"Gets
-        the equipment needed for a weather condition","name":"equipment","parameters":{"properties":{"weather":{"type":"string"}},"required":["weather"],"type":"object","additionalProperties":false},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":118,"input_tokens_details":{"cached_tokens":0},"output_tokens":17,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":135},"user":null,"metadata":{}}}
+        the equipment needed for a weather condition","name":"equipment","parameters":{"properties":{"weather":{"type":"string"}},"required":["weather"],"type":"object","additionalProperties":false},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":118,"input_tokens_details":{"cached_tokens":0},"output_tokens":17,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":135},"user":null,"metadata":{}},"sequence_number":11}
+
+
+        event: response.rate_limits.updated
+
+        data: {"type":"response.rate_limits.updated","rate_limits":{"limit_requests":"10000","limit_tokens":"30000000","remaining_requests":"9999","remaining_tokens":"30000000","reset_requests_ms":6,"reset_tokens_ms":0},"sequence_number":12}
 
 
         '
     headers:
       CF-RAY:
-      - 9b6c989b2da6606f-ORD
+      - 9ed58cad2bb74e06-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:09 GMT
+      - Thu, 16 Apr 2026 19:20:49 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -1105,11 +1147,21 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       openai-processing-ms:
-      - '54'
+      - '164'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '62'
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '30000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '29999665'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
     status:
       code: 200
       message: OK
@@ -1119,9 +1171,9 @@ interactions:
       use the weather_forecast tool provided to you. Then, use the\n        equipment
       tool provided to you.\n        "}]}, {"role": "user", "content": [{"type": "input_text",
       "text": "What should I pack for New York this weekend?"}]}, {"type": "function_call",
-      "call_id": "fc_0c46f98386d8d7d70169558a6647dc81a083383ea14b51a840", "name":
+      "call_id": "fc_0b89c0fa40cf4b600169e1369201a481948f642fe7a541a3e4", "name":
       "weather_forecast", "arguments": "{\"city\":\"New York\"}"}, {"type": "function_call_output",
-      "call_id": "fc_0c46f98386d8d7d70169558a6647dc81a083383ea14b51a840", "output":
+      "call_id": "fc_0b89c0fa40cf4b600169e1369201a481948f642fe7a541a3e4", "output":
       "rainy"}], "model": "gpt-4.1", "store": false, "stream": true, "tools": [{"type":
       "function", "name": "weather_forecast", "description": "Gets the weather forecast
       for a city", "parameters": {"properties": {"city": {"type": "string"}}, "required":
@@ -1134,7 +1186,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -1142,8 +1194,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - __cf_bm=7QI1CQVhilnkwL_5z7Yp04ak7_Wg1U7lHIZ1MIxdftU-1767213669-1.0.1.1-skj8VZaI_NJE1JKAH2PL9EOeoUzGU5JvCBoYxQYMnaJxHAbMIY7Pv4hQjFw.6I9B4ZpAEwRPVXbVl2ypVRszY0GeignzjzmjdEEENFwU7cc;
-        _cfuvid=90kbtIH_VlyOtVqGesLivMCVp5SwUc0jDFuWoIG9p50-1767213669737-0.0.1.1-604800000
+      - __cf_bm=H_dRJ77NkOkXx0Y5.CPluGlrDlAn2sjeH6IYQZPIer8-1776367249.469687-1.0.1.1-gSOBzn_oNJmoJdeRvJnxS7P8rERT8YUCsdk39SqiDcrhlDx5LDfTVRVxbFTlBvpO0NNUa5D10MoRRf8LBEB6WtV6Yy9UAmSqY9hdiCF3jiOpTeCvuwllyBWkGH.iNsJD
       Host:
       - api.openai.com
       X-Stainless-Async:
@@ -1156,80 +1207,85 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0851dbec20fda5230169558a66b1608195aebf63f43d8774e4","object":"response","created_at":1767213670,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
+        data: {"type":"response.created","response":{"id":"resp_0e781accc488aaa30169e136926d60819fbd97546b9491a2b4","object":"response","created_at":1776367250,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
         the weather forecast for a city","name":"weather_forecast","parameters":{"properties":{"city":{"type":"string"}},"required":["city"],"type":"object","additionalProperties":false},"strict":true},{"type":"function","description":"Gets
-        the equipment needed for a weather condition","name":"equipment","parameters":{"properties":{"weather":{"type":"string"}},"required":["weather"],"type":"object","additionalProperties":false},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        the equipment needed for a weather condition","name":"equipment","parameters":{"properties":{"weather":{"type":"string"}},"required":["weather"],"type":"object","additionalProperties":false},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0851dbec20fda5230169558a66b1608195aebf63f43d8774e4","object":"response","created_at":1767213670,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
+        data: {"type":"response.in_progress","response":{"id":"resp_0e781accc488aaa30169e136926d60819fbd97546b9491a2b4","object":"response","created_at":1776367250,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
         the weather forecast for a city","name":"weather_forecast","parameters":{"properties":{"city":{"type":"string"}},"required":["city"],"type":"object","additionalProperties":false},"strict":true},{"type":"function","description":"Gets
-        the equipment needed for a weather condition","name":"equipment","parameters":{"properties":{"weather":{"type":"string"}},"required":["weather"],"type":"object","additionalProperties":false},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        the equipment needed for a weather condition","name":"equipment","parameters":{"properties":{"weather":{"type":"string"}},"required":["weather"],"type":"object","additionalProperties":false},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_0851dbec20fda5230169558a67170081958e60d2d571d7aeb2","type":"function_call","status":"in_progress","arguments":"","call_id":"call_i2HahuKo2xYWFtSWi6227u5b","name":"equipment"}}
+        data: {"type":"response.output_item.added","item":{"id":"fc_0e781accc488aaa30169e13692f8fc819f81b18f640fac4e93","type":"function_call","status":"in_progress","arguments":"","call_id":"call_jUMhMkT5m8ajfXo3CLzLRIZm","name":"equipment"},"output_index":0,"sequence_number":2}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_0851dbec20fda5230169558a67170081958e60d2d571d7aeb2","output_index":0,"delta":"{\"","obfuscation":"b4FUrUvombtTmX"}
+        data: {"type":"response.function_call_arguments.delta","delta":"{\"","item_id":"fc_0e781accc488aaa30169e13692f8fc819f81b18f640fac4e93","obfuscation":"TWBOo9XEEIPsVD","output_index":0,"sequence_number":3}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_0851dbec20fda5230169558a67170081958e60d2d571d7aeb2","output_index":0,"delta":"weather","obfuscation":"2XM7vILjz"}
+        data: {"type":"response.function_call_arguments.delta","delta":"weather","item_id":"fc_0e781accc488aaa30169e13692f8fc819f81b18f640fac4e93","obfuscation":"uH6sVULJo","output_index":0,"sequence_number":4}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_0851dbec20fda5230169558a67170081958e60d2d571d7aeb2","output_index":0,"delta":"\":\"","obfuscation":"gNbyARk9XD8q0"}
+        data: {"type":"response.function_call_arguments.delta","delta":"\":\"","item_id":"fc_0e781accc488aaa30169e13692f8fc819f81b18f640fac4e93","obfuscation":"WF2cj1xFnwqbY","output_index":0,"sequence_number":5}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_0851dbec20fda5230169558a67170081958e60d2d571d7aeb2","output_index":0,"delta":"rain","obfuscation":"18EPvS6Hb0J4"}
+        data: {"type":"response.function_call_arguments.delta","delta":"rain","item_id":"fc_0e781accc488aaa30169e13692f8fc819f81b18f640fac4e93","obfuscation":"qfYYeWGChDZd","output_index":0,"sequence_number":6}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_0851dbec20fda5230169558a67170081958e60d2d571d7aeb2","output_index":0,"delta":"y","obfuscation":"sN2v3ZQDdtplUIs"}
+        data: {"type":"response.function_call_arguments.delta","delta":"y","item_id":"fc_0e781accc488aaa30169e13692f8fc819f81b18f640fac4e93","obfuscation":"7sjs3enXpP1FWKk","output_index":0,"sequence_number":7}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_0851dbec20fda5230169558a67170081958e60d2d571d7aeb2","output_index":0,"delta":"\"}","obfuscation":"bSoehkUwoeOIq6"}
+        data: {"type":"response.function_call_arguments.delta","delta":"\"}","item_id":"fc_0e781accc488aaa30169e13692f8fc819f81b18f640fac4e93","obfuscation":"MBZYza6cmPsaiU","output_index":0,"sequence_number":8}
 
 
         event: response.function_call_arguments.done
 
-        data: {"type":"response.function_call_arguments.done","sequence_number":9,"item_id":"fc_0851dbec20fda5230169558a67170081958e60d2d571d7aeb2","output_index":0,"arguments":"{\"weather\":\"rainy\"}"}
+        data: {"type":"response.function_call_arguments.done","arguments":"{\"weather\":\"rainy\"}","item_id":"fc_0e781accc488aaa30169e13692f8fc819f81b18f640fac4e93","output_index":0,"sequence_number":9}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":10,"output_index":0,"item":{"id":"fc_0851dbec20fda5230169558a67170081958e60d2d571d7aeb2","type":"function_call","status":"completed","arguments":"{\"weather\":\"rainy\"}","call_id":"call_i2HahuKo2xYWFtSWi6227u5b","name":"equipment"}}
+        data: {"type":"response.output_item.done","item":{"id":"fc_0e781accc488aaa30169e13692f8fc819f81b18f640fac4e93","type":"function_call","status":"completed","arguments":"{\"weather\":\"rainy\"}","call_id":"call_jUMhMkT5m8ajfXo3CLzLRIZm","name":"equipment"},"output_index":0,"sequence_number":10}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":11,"response":{"id":"resp_0851dbec20fda5230169558a66b1608195aebf63f43d8774e4","object":"response","created_at":1767213670,"status":"completed","background":false,"completed_at":1767213671,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"fc_0851dbec20fda5230169558a67170081958e60d2d571d7aeb2","type":"function_call","status":"completed","arguments":"{\"weather\":\"rainy\"}","call_id":"call_i2HahuKo2xYWFtSWi6227u5b","name":"equipment"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
+        data: {"type":"response.completed","response":{"id":"resp_0e781accc488aaa30169e136926d60819fbd97546b9491a2b4","object":"response","created_at":1776367250,"status":"completed","background":false,"completed_at":1776367251,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"fc_0e781accc488aaa30169e13692f8fc819f81b18f640fac4e93","type":"function_call","status":"completed","arguments":"{\"weather\":\"rainy\"}","call_id":"call_jUMhMkT5m8ajfXo3CLzLRIZm","name":"equipment"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
         the weather forecast for a city","name":"weather_forecast","parameters":{"properties":{"city":{"type":"string"}},"required":["city"],"type":"object","additionalProperties":false},"strict":true},{"type":"function","description":"Gets
-        the equipment needed for a weather condition","name":"equipment","parameters":{"properties":{"weather":{"type":"string"}},"required":["weather"],"type":"object","additionalProperties":false},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":143,"input_tokens_details":{"cached_tokens":0},"output_tokens":16,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":159},"user":null,"metadata":{}}}
+        the equipment needed for a weather condition","name":"equipment","parameters":{"properties":{"weather":{"type":"string"}},"required":["weather"],"type":"object","additionalProperties":false},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":143,"input_tokens_details":{"cached_tokens":0},"output_tokens":16,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":159},"user":null,"metadata":{}},"sequence_number":11}
+
+
+        event: response.rate_limits.updated
+
+        data: {"type":"response.rate_limits.updated","rate_limits":{"limit_requests":"10000","limit_tokens":"30000000","remaining_requests":"9999","remaining_tokens":"30000000","reset_requests_ms":6,"reset_tokens_ms":0},"sequence_number":12}
 
 
         '
     headers:
       CF-RAY:
-      - 9b6c98a19d5b338f-ORD
+      - 9ed58cb2eaaa7d03-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:10 GMT
+      - Thu, 16 Apr 2026 19:20:50 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -1243,11 +1299,21 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       openai-processing-ms:
-      - '76'
+      - '81'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '81'
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '30000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '29999640'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
     status:
       code: 200
       message: OK
@@ -1257,12 +1323,12 @@ interactions:
       use the weather_forecast tool provided to you. Then, use the\n        equipment
       tool provided to you.\n        "}]}, {"role": "user", "content": [{"type": "input_text",
       "text": "What should I pack for New York this weekend?"}]}, {"type": "function_call",
-      "call_id": "fc_0c46f98386d8d7d70169558a6647dc81a083383ea14b51a840", "name":
+      "call_id": "fc_0b89c0fa40cf4b600169e1369201a481948f642fe7a541a3e4", "name":
       "weather_forecast", "arguments": "{\"city\":\"New York\"}"}, {"type": "function_call_output",
-      "call_id": "fc_0c46f98386d8d7d70169558a6647dc81a083383ea14b51a840", "output":
-      "rainy"}, {"type": "function_call", "call_id": "fc_0851dbec20fda5230169558a67170081958e60d2d571d7aeb2",
+      "call_id": "fc_0b89c0fa40cf4b600169e1369201a481948f642fe7a541a3e4", "output":
+      "rainy"}, {"type": "function_call", "call_id": "fc_0e781accc488aaa30169e13692f8fc819f81b18f640fac4e93",
       "name": "equipment", "arguments": "{\"weather\":\"rainy\"}"}, {"type": "function_call_output",
-      "call_id": "fc_0851dbec20fda5230169558a67170081958e60d2d571d7aeb2", "output":
+      "call_id": "fc_0e781accc488aaa30169e13692f8fc819f81b18f640fac4e93", "output":
       "umbrella"}], "model": "gpt-4.1", "store": false, "stream": true, "tools": [{"type":
       "function", "name": "weather_forecast", "description": "Gets the weather forecast
       for a city", "parameters": {"properties": {"city": {"type": "string"}}, "required":
@@ -1275,7 +1341,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -1283,8 +1349,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - __cf_bm=7QI1CQVhilnkwL_5z7Yp04ak7_Wg1U7lHIZ1MIxdftU-1767213669-1.0.1.1-skj8VZaI_NJE1JKAH2PL9EOeoUzGU5JvCBoYxQYMnaJxHAbMIY7Pv4hQjFw.6I9B4ZpAEwRPVXbVl2ypVRszY0GeignzjzmjdEEENFwU7cc;
-        _cfuvid=90kbtIH_VlyOtVqGesLivMCVp5SwUc0jDFuWoIG9p50-1767213669737-0.0.1.1-604800000
+      - __cf_bm=H_dRJ77NkOkXx0Y5.CPluGlrDlAn2sjeH6IYQZPIer8-1776367249.469687-1.0.1.1-gSOBzn_oNJmoJdeRvJnxS7P8rERT8YUCsdk39SqiDcrhlDx5LDfTVRVxbFTlBvpO0NNUa5D10MoRRf8LBEB6WtV6Yy9UAmSqY9hdiCF3jiOpTeCvuwllyBWkGH.iNsJD
       Host:
       - api.openai.com
       X-Stainless-Async:
@@ -1297,70 +1362,75 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0c7f86c340210d070169558a677424819fb140beeb1b0eaca8","object":"response","created_at":1767213671,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
+        data: {"type":"response.created","response":{"id":"resp_035f25946ee60fe70169e13693508c8191837cb1f750b504bf","object":"response","created_at":1776367251,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
         the weather forecast for a city","name":"weather_forecast","parameters":{"properties":{"city":{"type":"string"}},"required":["city"],"type":"object","additionalProperties":false},"strict":true},{"type":"function","description":"Gets
-        the equipment needed for a weather condition","name":"equipment","parameters":{"properties":{"weather":{"type":"string"}},"required":["weather"],"type":"object","additionalProperties":false},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        the equipment needed for a weather condition","name":"equipment","parameters":{"properties":{"weather":{"type":"string"}},"required":["weather"],"type":"object","additionalProperties":false},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0c7f86c340210d070169558a677424819fb140beeb1b0eaca8","object":"response","created_at":1767213671,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
+        data: {"type":"response.in_progress","response":{"id":"resp_035f25946ee60fe70169e13693508c8191837cb1f750b504bf","object":"response","created_at":1776367251,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
         the weather forecast for a city","name":"weather_forecast","parameters":{"properties":{"city":{"type":"string"}},"required":["city"],"type":"object","additionalProperties":false},"strict":true},{"type":"function","description":"Gets
-        the equipment needed for a weather condition","name":"equipment","parameters":{"properties":{"weather":{"type":"string"}},"required":["weather"],"type":"object","additionalProperties":false},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        the equipment needed for a weather condition","name":"equipment","parameters":{"properties":{"weather":{"type":"string"}},"required":["weather"],"type":"object","additionalProperties":false},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0c7f86c340210d070169558a680ab8819f8a1e02f89c2be7cb","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","item":{"id":"msg_035f25946ee60fe70169e13693ad348191acdc9b7917d33543","type":"message","status":"in_progress","content":[],"role":"assistant"},"output_index":0,"sequence_number":2}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0c7f86c340210d070169558a680ab8819f8a1e02f89c2be7cb","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","content_index":0,"item_id":"msg_035f25946ee60fe70169e13693ad348191acdc9b7917d33543","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":3}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_0c7f86c340210d070169558a680ab8819f8a1e02f89c2be7cb","output_index":0,"content_index":0,"delta":"umbre","logprobs":[],"obfuscation":"DkpWFElaY1k"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"umbre","item_id":"msg_035f25946ee60fe70169e13693ad348191acdc9b7917d33543","logprobs":[],"obfuscation":"ZosBbmqBcax","output_index":0,"sequence_number":4}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_0c7f86c340210d070169558a680ab8819f8a1e02f89c2be7cb","output_index":0,"content_index":0,"delta":"lla","logprobs":[],"obfuscation":"VK3ciqeSML0Bz"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"lla","item_id":"msg_035f25946ee60fe70169e13693ad348191acdc9b7917d33543","logprobs":[],"obfuscation":"uvnlFjYNCyNZs","output_index":0,"sequence_number":5}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":6,"item_id":"msg_0c7f86c340210d070169558a680ab8819f8a1e02f89c2be7cb","output_index":0,"content_index":0,"text":"umbrella","logprobs":[]}
+        data: {"type":"response.output_text.done","content_index":0,"item_id":"msg_035f25946ee60fe70169e13693ad348191acdc9b7917d33543","logprobs":[],"output_index":0,"sequence_number":6,"text":"umbrella"}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":7,"item_id":"msg_0c7f86c340210d070169558a680ab8819f8a1e02f89c2be7cb","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"umbrella"}}
+        data: {"type":"response.content_part.done","content_index":0,"item_id":"msg_035f25946ee60fe70169e13693ad348191acdc9b7917d33543","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"umbrella"},"sequence_number":7}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":8,"output_index":0,"item":{"id":"msg_0c7f86c340210d070169558a680ab8819f8a1e02f89c2be7cb","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"umbrella"}],"role":"assistant"}}
+        data: {"type":"response.output_item.done","item":{"id":"msg_035f25946ee60fe70169e13693ad348191acdc9b7917d33543","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"umbrella"}],"role":"assistant"},"output_index":0,"sequence_number":8}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":9,"response":{"id":"resp_0c7f86c340210d070169558a677424819fb140beeb1b0eaca8","object":"response","created_at":1767213671,"status":"completed","background":false,"completed_at":1767213672,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"msg_0c7f86c340210d070169558a680ab8819f8a1e02f89c2be7cb","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"umbrella"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
+        data: {"type":"response.completed","response":{"id":"resp_035f25946ee60fe70169e13693508c8191837cb1f750b504bf","object":"response","created_at":1776367251,"status":"completed","background":false,"completed_at":1776367251,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"msg_035f25946ee60fe70169e13693ad348191acdc9b7917d33543","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"umbrella"}],"role":"assistant"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
         the weather forecast for a city","name":"weather_forecast","parameters":{"properties":{"city":{"type":"string"}},"required":["city"],"type":"object","additionalProperties":false},"strict":true},{"type":"function","description":"Gets
-        the equipment needed for a weather condition","name":"equipment","parameters":{"properties":{"weather":{"type":"string"}},"required":["weather"],"type":"object","additionalProperties":false},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":166,"input_tokens_details":{"cached_tokens":0},"output_tokens":4,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":170},"user":null,"metadata":{}}}
+        the equipment needed for a weather condition","name":"equipment","parameters":{"properties":{"weather":{"type":"string"}},"required":["weather"],"type":"object","additionalProperties":false},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":166,"input_tokens_details":{"cached_tokens":0},"output_tokens":4,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":170},"user":null,"metadata":{}},"sequence_number":9}
+
+
+        event: response.rate_limits.updated
+
+        data: {"type":"response.rate_limits.updated","rate_limits":{"limit_requests":"10000","limit_tokens":"30000000","remaining_requests":"9999","remaining_tokens":"30000000","reset_requests_ms":6,"reset_tokens_ms":0},"sequence_number":10}
 
 
         '
     headers:
       CF-RAY:
-      - 9b6c98a63f4d1251-ORD
+      - 9ed58cb86a7cb266-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:11 GMT
+      - Thu, 16 Apr 2026 19:20:51 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -1374,11 +1444,21 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       openai-processing-ms:
-      - '38'
+      - '152'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '41'
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '30000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '29999617'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
     status:
       code: 200
       message: OK

--- a/tests/_vcr/test_provider_openai/test_openai_tool_variations_async.yaml
+++ b/tests/_vcr/test_provider_openai/test_openai_tool_variations_async.yaml
@@ -11,7 +11,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -30,52 +30,57 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0fc63731473854bb0169558a686aa0819186679e463a7056de","object":"response","created_at":1767213672,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
-        the current date","name":"get_current_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.created","response":{"id":"resp_027df290c5f23c780169e1369410d08192a3a76f17389dfb1e","object":"response","created_at":1776367252,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
+        the current date","name":"get_current_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0fc63731473854bb0169558a686aa0819186679e463a7056de","object":"response","created_at":1767213672,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
-        the current date","name":"get_current_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.in_progress","response":{"id":"resp_027df290c5f23c780169e1369410d08192a3a76f17389dfb1e","object":"response","created_at":1776367252,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
+        the current date","name":"get_current_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_0fc63731473854bb0169558a68ad0c81919159f180236403d5","type":"function_call","status":"in_progress","arguments":"","call_id":"call_AUen9xM6D3iL2gPYSUAXex3j","name":"get_current_date"}}
+        data: {"type":"response.output_item.added","item":{"id":"fc_027df290c5f23c780169e136945f4c8192abe44f1d172c433f","type":"function_call","status":"in_progress","arguments":"","call_id":"call_su6ebAC3ga69MurjZXE8eamv","name":"get_current_date"},"output_index":0,"sequence_number":2}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_0fc63731473854bb0169558a68ad0c81919159f180236403d5","output_index":0,"delta":"{}","obfuscation":"aXiyQtVx5hRIUk"}
+        data: {"type":"response.function_call_arguments.delta","delta":"{}","item_id":"fc_027df290c5f23c780169e136945f4c8192abe44f1d172c433f","obfuscation":"faIuZYBhL6xOp4","output_index":0,"sequence_number":3}
 
 
         event: response.function_call_arguments.done
 
-        data: {"type":"response.function_call_arguments.done","sequence_number":4,"item_id":"fc_0fc63731473854bb0169558a68ad0c81919159f180236403d5","output_index":0,"arguments":"{}"}
+        data: {"type":"response.function_call_arguments.done","arguments":"{}","item_id":"fc_027df290c5f23c780169e136945f4c8192abe44f1d172c433f","output_index":0,"sequence_number":4}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":5,"output_index":0,"item":{"id":"fc_0fc63731473854bb0169558a68ad0c81919159f180236403d5","type":"function_call","status":"completed","arguments":"{}","call_id":"call_AUen9xM6D3iL2gPYSUAXex3j","name":"get_current_date"}}
+        data: {"type":"response.output_item.done","item":{"id":"fc_027df290c5f23c780169e136945f4c8192abe44f1d172c433f","type":"function_call","status":"completed","arguments":"{}","call_id":"call_su6ebAC3ga69MurjZXE8eamv","name":"get_current_date"},"output_index":0,"sequence_number":5}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":6,"response":{"id":"resp_0fc63731473854bb0169558a686aa0819186679e463a7056de","object":"response","created_at":1767213672,"status":"completed","background":false,"completed_at":1767213672,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"fc_0fc63731473854bb0169558a68ad0c81919159f180236403d5","type":"function_call","status":"completed","arguments":"{}","call_id":"call_AUen9xM6D3iL2gPYSUAXex3j","name":"get_current_date"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
-        the current date","name":"get_current_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":53,"input_tokens_details":{"cached_tokens":0},"output_tokens":12,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":65},"user":null,"metadata":{}}}
+        data: {"type":"response.completed","response":{"id":"resp_027df290c5f23c780169e1369410d08192a3a76f17389dfb1e","object":"response","created_at":1776367252,"status":"completed","background":false,"completed_at":1776367252,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"fc_027df290c5f23c780169e136945f4c8192abe44f1d172c433f","type":"function_call","status":"completed","arguments":"{}","call_id":"call_su6ebAC3ga69MurjZXE8eamv","name":"get_current_date"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
+        the current date","name":"get_current_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":53,"input_tokens_details":{"cached_tokens":0},"output_tokens":12,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":65},"user":null,"metadata":{}},"sequence_number":6}
+
+
+        event: response.rate_limits.updated
+
+        data: {"type":"response.rate_limits.updated","rate_limits":{"limit_requests":"10000","limit_tokens":"30000000","remaining_requests":"9999","remaining_tokens":"30000000","reset_requests_ms":6,"reset_tokens_ms":0},"sequence_number":7}
 
 
         '
     headers:
       CF-RAY:
-      - 9b6c98ac5afa72e4-ORD
+      - 9ed58cbd1c901042-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:12 GMT
+      - Thu, 16 Apr 2026 19:20:52 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -89,11 +94,21 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       openai-processing-ms:
-      - '47'
+      - '104'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '50'
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '30000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '29999730'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
     status:
       code: 200
       message: OK
@@ -101,9 +116,9 @@ interactions:
     body: '{"input": [{"role": "system", "content": [{"type": "input_text", "text":
       "Be very terse, not even punctuation."}]}, {"role": "user", "content": [{"type":
       "input_text", "text": "What''s the current date in YYYY-MM-DD format?"}]}, {"type":
-      "function_call", "call_id": "fc_0fc63731473854bb0169558a68ad0c81919159f180236403d5",
+      "function_call", "call_id": "fc_027df290c5f23c780169e136945f4c8192abe44f1d172c433f",
       "name": "get_current_date", "arguments": "{}"}, {"type": "function_call_output",
-      "call_id": "fc_0fc63731473854bb0169558a68ad0c81919159f180236403d5", "output":
+      "call_id": "fc_027df290c5f23c780169e136945f4c8192abe44f1d172c433f", "output":
       "2024-01-01"}], "model": "gpt-4.1", "store": false, "stream": true, "tools":
       [{"type": "function", "name": "get_current_date", "description": "Gets the current
       date", "parameters": {"properties": {}, "type": "object", "additionalProperties":
@@ -112,7 +127,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -120,8 +135,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - __cf_bm=8hbnlC27rXktLrOGc3sz.W7hcnVLz7Lw0Z0khytq1do-1767213672-1.0.1.1-psRi6UEVMoscq_iWj.7GPmGVuj.HYR6D7G8Xp5UIDjUDI6Mf6oxvi418h2yvv65ac8FZYoxXI_SSerHnHhJGLKtOOrZkFTV6bFXzlwI1XOk;
-        _cfuvid=vohZjoh4dNu7gZTD1kiDHidXdztOaJYjZUxbBfTZ2cU-1767213672475-0.0.1.1-604800000
+      - __cf_bm=QtYOFOg1oLmnIXkAgHZXl16JsYDjQt_5yiCFk6KqHgg-1776367252.0155787-1.0.1.1-cgidGByvHxPWKrJU4iNJC5I1PJlvg924BMcnqu8vSNMPzrkt4s8lUdqxatjsymWfrARKnvwwCG.fMjl40W7KJ0R.DsuFA5glaCEG3_oD7wvxiRcHCJMTY6yPIk0PbR3D
       Host:
       - api.openai.com
       X-Stainless-Async:
@@ -134,87 +148,92 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0b2e7d7895ba360a0169558a69092c8195962e8641dfb6cad0","object":"response","created_at":1767213673,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
-        the current date","name":"get_current_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.created","response":{"id":"resp_098e3d94fae087f10169e1369504148194be0204de0a6320a5","object":"response","created_at":1776367253,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
+        the current date","name":"get_current_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0b2e7d7895ba360a0169558a69092c8195962e8641dfb6cad0","object":"response","created_at":1767213673,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
-        the current date","name":"get_current_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.in_progress","response":{"id":"resp_098e3d94fae087f10169e1369504148194be0204de0a6320a5","object":"response","created_at":1776367253,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
+        the current date","name":"get_current_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0b2e7d7895ba360a0169558a695a1c8195bb69f65275d8d330","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","item":{"id":"msg_098e3d94fae087f10169e13696217c819489330f24f9b36f64","type":"message","status":"in_progress","content":[],"role":"assistant"},"output_index":0,"sequence_number":2}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0b2e7d7895ba360a0169558a695a1c8195bb69f65275d8d330","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","content_index":0,"item_id":"msg_098e3d94fae087f10169e13696217c819489330f24f9b36f64","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":3}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_0b2e7d7895ba360a0169558a695a1c8195bb69f65275d8d330","output_index":0,"content_index":0,"delta":"202","logprobs":[],"obfuscation":"JLPGowIzQXO5v"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"202","item_id":"msg_098e3d94fae087f10169e13696217c819489330f24f9b36f64","logprobs":[],"obfuscation":"KVI99pJc5n21M","output_index":0,"sequence_number":4}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_0b2e7d7895ba360a0169558a695a1c8195bb69f65275d8d330","output_index":0,"content_index":0,"delta":"4","logprobs":[],"obfuscation":"gFy1ivtxEdJBCqB"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"4","item_id":"msg_098e3d94fae087f10169e13696217c819489330f24f9b36f64","logprobs":[],"obfuscation":"PZ1WMl0SwTVBS2w","output_index":0,"sequence_number":5}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_0b2e7d7895ba360a0169558a695a1c8195bb69f65275d8d330","output_index":0,"content_index":0,"delta":"-","logprobs":[],"obfuscation":"zd64EorjABrQ5mJ"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"-","item_id":"msg_098e3d94fae087f10169e13696217c819489330f24f9b36f64","logprobs":[],"obfuscation":"IiwfXZEHUGs9b0e","output_index":0,"sequence_number":6}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_0b2e7d7895ba360a0169558a695a1c8195bb69f65275d8d330","output_index":0,"content_index":0,"delta":"01","logprobs":[],"obfuscation":"6D4V47JofbIK2z"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"01","item_id":"msg_098e3d94fae087f10169e13696217c819489330f24f9b36f64","logprobs":[],"obfuscation":"cRKy4ddfwY5tWa","output_index":0,"sequence_number":7}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_0b2e7d7895ba360a0169558a695a1c8195bb69f65275d8d330","output_index":0,"content_index":0,"delta":"-","logprobs":[],"obfuscation":"Vnw594u0F5Axmjx"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"-","item_id":"msg_098e3d94fae087f10169e13696217c819489330f24f9b36f64","logprobs":[],"obfuscation":"l3s8qzpisuLKfkO","output_index":0,"sequence_number":8}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_0b2e7d7895ba360a0169558a695a1c8195bb69f65275d8d330","output_index":0,"content_index":0,"delta":"01","logprobs":[],"obfuscation":"jCgvdxEq5h4Oqh"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"01","item_id":"msg_098e3d94fae087f10169e13696217c819489330f24f9b36f64","logprobs":[],"obfuscation":"DonZbV3DdsQZ0x","output_index":0,"sequence_number":9}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":10,"item_id":"msg_0b2e7d7895ba360a0169558a695a1c8195bb69f65275d8d330","output_index":0,"content_index":0,"text":"2024-01-01","logprobs":[]}
+        data: {"type":"response.output_text.done","content_index":0,"item_id":"msg_098e3d94fae087f10169e13696217c819489330f24f9b36f64","logprobs":[],"output_index":0,"sequence_number":10,"text":"2024-01-01"}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":11,"item_id":"msg_0b2e7d7895ba360a0169558a695a1c8195bb69f65275d8d330","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"2024-01-01"}}
+        data: {"type":"response.content_part.done","content_index":0,"item_id":"msg_098e3d94fae087f10169e13696217c819489330f24f9b36f64","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"2024-01-01"},"sequence_number":11}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":12,"output_index":0,"item":{"id":"msg_0b2e7d7895ba360a0169558a695a1c8195bb69f65275d8d330","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"2024-01-01"}],"role":"assistant"}}
+        data: {"type":"response.output_item.done","item":{"id":"msg_098e3d94fae087f10169e13696217c819489330f24f9b36f64","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"2024-01-01"}],"role":"assistant"},"output_index":0,"sequence_number":12}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":13,"response":{"id":"resp_0b2e7d7895ba360a0169558a69092c8195962e8641dfb6cad0","object":"response","created_at":1767213673,"status":"completed","background":false,"completed_at":1767213673,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"msg_0b2e7d7895ba360a0169558a695a1c8195bb69f65275d8d330","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"2024-01-01"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
-        the current date","name":"get_current_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":77,"input_tokens_details":{"cached_tokens":0},"output_tokens":8,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":85},"user":null,"metadata":{}}}
+        data: {"type":"response.completed","response":{"id":"resp_098e3d94fae087f10169e1369504148194be0204de0a6320a5","object":"response","created_at":1776367253,"status":"completed","background":false,"completed_at":1776367254,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"msg_098e3d94fae087f10169e13696217c819489330f24f9b36f64","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"2024-01-01"}],"role":"assistant"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
+        the current date","name":"get_current_date","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":77,"input_tokens_details":{"cached_tokens":0},"output_tokens":8,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":85},"user":null,"metadata":{}},"sequence_number":13}
+
+
+        event: response.rate_limits.updated
+
+        data: {"type":"response.rate_limits.updated","rate_limits":{"limit_requests":"10000","limit_tokens":"30000000","remaining_requests":"9999","remaining_tokens":"30000000","reset_requests_ms":6,"reset_tokens_ms":0},"sequence_number":14}
 
 
         '
     headers:
       CF-RAY:
-      - 9b6c98b03ee680ba-ORD
+      - 9ed58cc1bda1f60e-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:13 GMT
+      - Thu, 16 Apr 2026 19:20:53 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -228,11 +247,21 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       openai-processing-ms:
-      - '61'
+      - '689'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '65'
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '30000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '29999706'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
     status:
       code: 200
       message: OK
@@ -248,7 +277,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -267,52 +296,57 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_02c12dbf63cbfa2f0169558a69b99c819290d4d0d1e3de3808","object":"response","created_at":1767213673,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
-        the current date","name":"get_current_date2","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.created","response":{"id":"resp_025fe13cdb604a640169e13696f2dc81a0869db0b686fbc647","object":"response","created_at":1776367254,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
+        the current date","name":"get_current_date2","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_02c12dbf63cbfa2f0169558a69b99c819290d4d0d1e3de3808","object":"response","created_at":1767213673,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
-        the current date","name":"get_current_date2","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.in_progress","response":{"id":"resp_025fe13cdb604a640169e13696f2dc81a0869db0b686fbc647","object":"response","created_at":1776367254,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
+        the current date","name":"get_current_date2","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_02c12dbf63cbfa2f0169558a6a34148192b84d370607c9d059","type":"function_call","status":"in_progress","arguments":"","call_id":"call_iruCfjhoxitisY6REvfp50XE","name":"get_current_date2"}}
+        data: {"type":"response.output_item.added","item":{"id":"fc_025fe13cdb604a640169e136977a2081a097746806d25708e0","type":"function_call","status":"in_progress","arguments":"","call_id":"call_ZrXmrRhMOTiAbmD5xfVkCBcP","name":"get_current_date2"},"output_index":0,"sequence_number":2}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_02c12dbf63cbfa2f0169558a6a34148192b84d370607c9d059","output_index":0,"delta":"{}","obfuscation":"nBKIOhe6yXlg1X"}
+        data: {"type":"response.function_call_arguments.delta","delta":"{}","item_id":"fc_025fe13cdb604a640169e136977a2081a097746806d25708e0","obfuscation":"MuFAB2rTqDZLHy","output_index":0,"sequence_number":3}
 
 
         event: response.function_call_arguments.done
 
-        data: {"type":"response.function_call_arguments.done","sequence_number":4,"item_id":"fc_02c12dbf63cbfa2f0169558a6a34148192b84d370607c9d059","output_index":0,"arguments":"{}"}
+        data: {"type":"response.function_call_arguments.done","arguments":"{}","item_id":"fc_025fe13cdb604a640169e136977a2081a097746806d25708e0","output_index":0,"sequence_number":4}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":5,"output_index":0,"item":{"id":"fc_02c12dbf63cbfa2f0169558a6a34148192b84d370607c9d059","type":"function_call","status":"completed","arguments":"{}","call_id":"call_iruCfjhoxitisY6REvfp50XE","name":"get_current_date2"}}
+        data: {"type":"response.output_item.done","item":{"id":"fc_025fe13cdb604a640169e136977a2081a097746806d25708e0","type":"function_call","status":"completed","arguments":"{}","call_id":"call_ZrXmrRhMOTiAbmD5xfVkCBcP","name":"get_current_date2"},"output_index":0,"sequence_number":5}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":6,"response":{"id":"resp_02c12dbf63cbfa2f0169558a69b99c819290d4d0d1e3de3808","object":"response","created_at":1767213673,"status":"completed","background":false,"completed_at":1767213674,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"fc_02c12dbf63cbfa2f0169558a6a34148192b84d370607c9d059","type":"function_call","status":"completed","arguments":"{}","call_id":"call_iruCfjhoxitisY6REvfp50XE","name":"get_current_date2"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
-        the current date","name":"get_current_date2","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":54,"input_tokens_details":{"cached_tokens":0},"output_tokens":13,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":67},"user":null,"metadata":{}}}
+        data: {"type":"response.completed","response":{"id":"resp_025fe13cdb604a640169e13696f2dc81a0869db0b686fbc647","object":"response","created_at":1776367254,"status":"completed","background":false,"completed_at":1776367255,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"fc_025fe13cdb604a640169e136977a2081a097746806d25708e0","type":"function_call","status":"completed","arguments":"{}","call_id":"call_ZrXmrRhMOTiAbmD5xfVkCBcP","name":"get_current_date2"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
+        the current date","name":"get_current_date2","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":54,"input_tokens_details":{"cached_tokens":0},"output_tokens":13,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":67},"user":null,"metadata":{}},"sequence_number":6}
+
+
+        event: response.rate_limits.updated
+
+        data: {"type":"response.rate_limits.updated","rate_limits":{"limit_requests":"10000","limit_tokens":"30000000","remaining_requests":"9999","remaining_tokens":"30000000","reset_requests_ms":6,"reset_tokens_ms":0},"sequence_number":7}
 
 
         '
     headers:
       CF-RAY:
-      - 9b6c98b48ce0ead2-ORD
+      - 9ed58ccf2b02226a-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:13 GMT
+      - Thu, 16 Apr 2026 19:20:55 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -326,11 +360,21 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       openai-processing-ms:
-      - '47'
+      - '109'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '50'
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '30000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '29999729'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
     status:
       code: 200
       message: OK
@@ -338,9 +382,9 @@ interactions:
     body: '{"input": [{"role": "system", "content": [{"type": "input_text", "text":
       "Be very terse, not even punctuation."}]}, {"role": "user", "content": [{"type":
       "input_text", "text": "What''s the current date in YYYY-MM-DD format?"}]}, {"type":
-      "function_call", "call_id": "fc_02c12dbf63cbfa2f0169558a6a34148192b84d370607c9d059",
+      "function_call", "call_id": "fc_025fe13cdb604a640169e136977a2081a097746806d25708e0",
       "name": "get_current_date2", "arguments": "{}"}, {"type": "function_call_output",
-      "call_id": "fc_02c12dbf63cbfa2f0169558a6a34148192b84d370607c9d059", "output":
+      "call_id": "fc_025fe13cdb604a640169e136977a2081a097746806d25708e0", "output":
       "2024-01-01"}], "model": "gpt-4.1", "store": false, "stream": true, "tools":
       [{"type": "function", "name": "get_current_date2", "description": "Gets the
       current date", "parameters": {"properties": {}, "type": "object", "additionalProperties":
@@ -349,7 +393,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -357,8 +401,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - __cf_bm=hIffyUy3Dg9ecmwTP3ZsNI8QvQHVtRmWI1k.EQga31U-1767213673-1.0.1.1-5z068cwBQZx7N7ViI8gY6bE9dQr6y.aH1omBUrVYiGUEPmgwMILkTI3RePqPPm5LzqvP9I6OBv6.RE2l6Qqb2KQmteqdLtFVPzZmAf370L4;
-        _cfuvid=NWSsRGBaQ9xsrLjWrQGeSY0xzWDbXsBi3igcWBybMYo-1767213673796-0.0.1.1-604800000
+      - __cf_bm=a2LO_zCGPxaZzCSyqTRXeG1l8f4GV3oMRh5S5nMUQEQ-1776367254.905633-1.0.1.1-k81c3_YmpCxYM9s2iuhEo07j01jp.jIsbXQNDlJ103KEbOWry9dtVRrqBQgMd5E0YDCmCWQycb.etH.uEaYjB0mtkF4QDoYMknlAA9.AlJRUm.N6F.gmfzcOt0oNvQCX
       Host:
       - api.openai.com
       X-Stainless-Async:
@@ -371,87 +414,92 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_088c79db22882bc10169558a6a8a0081a1882af9eaf83fc530","object":"response","created_at":1767213674,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
-        the current date","name":"get_current_date2","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.created","response":{"id":"resp_0fc65b265465ec840169e13697ca4c819d9c2de39651511f2e","object":"response","created_at":1776367255,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
+        the current date","name":"get_current_date2","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_088c79db22882bc10169558a6a8a0081a1882af9eaf83fc530","object":"response","created_at":1767213674,"status":"in_progress","background":false,"completed_at":null,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
-        the current date","name":"get_current_date2","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.in_progress","response":{"id":"resp_0fc65b265465ec840169e13697ca4c819d9c2de39651511f2e","object":"response","created_at":1776367255,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
+        the current date","name":"get_current_date2","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_088c79db22882bc10169558a6ad18881a1b9b06499961d94db","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","item":{"id":"msg_0fc65b265465ec840169e1369821a4819db4d87950e1dcf878","type":"message","status":"in_progress","content":[],"role":"assistant"},"output_index":0,"sequence_number":2}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_088c79db22882bc10169558a6ad18881a1b9b06499961d94db","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","content_index":0,"item_id":"msg_0fc65b265465ec840169e1369821a4819db4d87950e1dcf878","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":3}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_088c79db22882bc10169558a6ad18881a1b9b06499961d94db","output_index":0,"content_index":0,"delta":"202","logprobs":[],"obfuscation":"xP717u7D8U8z7"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"202","item_id":"msg_0fc65b265465ec840169e1369821a4819db4d87950e1dcf878","logprobs":[],"obfuscation":"Td7NqTIgKRzbF","output_index":0,"sequence_number":4}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_088c79db22882bc10169558a6ad18881a1b9b06499961d94db","output_index":0,"content_index":0,"delta":"4","logprobs":[],"obfuscation":"klfgeKF5JoLnX3R"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"4","item_id":"msg_0fc65b265465ec840169e1369821a4819db4d87950e1dcf878","logprobs":[],"obfuscation":"0ODMzFHktGvNVm9","output_index":0,"sequence_number":5}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_088c79db22882bc10169558a6ad18881a1b9b06499961d94db","output_index":0,"content_index":0,"delta":"-","logprobs":[],"obfuscation":"L4UfR8F8itt3F0k"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"-","item_id":"msg_0fc65b265465ec840169e1369821a4819db4d87950e1dcf878","logprobs":[],"obfuscation":"nBdLs2e5Ho41ziO","output_index":0,"sequence_number":6}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_088c79db22882bc10169558a6ad18881a1b9b06499961d94db","output_index":0,"content_index":0,"delta":"01","logprobs":[],"obfuscation":"nttehZDk67QhBD"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"01","item_id":"msg_0fc65b265465ec840169e1369821a4819db4d87950e1dcf878","logprobs":[],"obfuscation":"XYBSHue8JzR3Za","output_index":0,"sequence_number":7}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_088c79db22882bc10169558a6ad18881a1b9b06499961d94db","output_index":0,"content_index":0,"delta":"-","logprobs":[],"obfuscation":"jkht54mi5HXMf1b"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"-","item_id":"msg_0fc65b265465ec840169e1369821a4819db4d87950e1dcf878","logprobs":[],"obfuscation":"FLpZI14YA26YLJD","output_index":0,"sequence_number":8}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_088c79db22882bc10169558a6ad18881a1b9b06499961d94db","output_index":0,"content_index":0,"delta":"01","logprobs":[],"obfuscation":"fXqKtsaSvtQ3NE"}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"01","item_id":"msg_0fc65b265465ec840169e1369821a4819db4d87950e1dcf878","logprobs":[],"obfuscation":"sVjSSzlEreYdHI","output_index":0,"sequence_number":9}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":10,"item_id":"msg_088c79db22882bc10169558a6ad18881a1b9b06499961d94db","output_index":0,"content_index":0,"text":"2024-01-01","logprobs":[]}
+        data: {"type":"response.output_text.done","content_index":0,"item_id":"msg_0fc65b265465ec840169e1369821a4819db4d87950e1dcf878","logprobs":[],"output_index":0,"sequence_number":10,"text":"2024-01-01"}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":11,"item_id":"msg_088c79db22882bc10169558a6ad18881a1b9b06499961d94db","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"2024-01-01"}}
+        data: {"type":"response.content_part.done","content_index":0,"item_id":"msg_0fc65b265465ec840169e1369821a4819db4d87950e1dcf878","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"2024-01-01"},"sequence_number":11}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":12,"output_index":0,"item":{"id":"msg_088c79db22882bc10169558a6ad18881a1b9b06499961d94db","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"2024-01-01"}],"role":"assistant"}}
+        data: {"type":"response.output_item.done","item":{"id":"msg_0fc65b265465ec840169e1369821a4819db4d87950e1dcf878","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"2024-01-01"}],"role":"assistant"},"output_index":0,"sequence_number":12}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":13,"response":{"id":"resp_088c79db22882bc10169558a6a8a0081a1882af9eaf83fc530","object":"response","created_at":1767213674,"status":"completed","background":false,"completed_at":1767213674,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"msg_088c79db22882bc10169558a6ad18881a1b9b06499961d94db","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"2024-01-01"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
-        the current date","name":"get_current_date2","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":80,"input_tokens_details":{"cached_tokens":0},"output_tokens":8,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":88},"user":null,"metadata":{}}}
+        data: {"type":"response.completed","response":{"id":"resp_0fc65b265465ec840169e13697ca4c819d9c2de39651511f2e","object":"response","created_at":1776367255,"status":"completed","background":false,"completed_at":1776367256,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"msg_0fc65b265465ec840169e1369821a4819db4d87950e1dcf878","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"2024-01-01"}],"role":"assistant"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Gets
+        the current date","name":"get_current_date2","parameters":{"properties":{},"type":"object","additionalProperties":false,"required":[]},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":80,"input_tokens_details":{"cached_tokens":0},"output_tokens":8,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":88},"user":null,"metadata":{}},"sequence_number":13}
+
+
+        event: response.rate_limits.updated
+
+        data: {"type":"response.rate_limits.updated","rate_limits":{"limit_requests":"10000","limit_tokens":"30000000","remaining_requests":"9999","remaining_tokens":"30000000","reset_requests_ms":6,"reset_tokens_ms":0},"sequence_number":14}
 
 
         '
     headers:
       CF-RAY:
-      - 9b6c98b99fe2eadf-ORD
+      - 9ed58cd458ed8764-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:14 GMT
+      - Thu, 16 Apr 2026 19:20:55 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -465,11 +513,21 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       openai-processing-ms:
-      - '56'
+      - '96'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '59'
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '30000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '29999703'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
     status:
       code: 200
       message: OK

--- a/tests/_vcr/test_provider_openai/test_openai_web_search.yaml
+++ b/tests/_vcr/test_provider_openai/test_openai_web_search.yaml
@@ -8,7 +8,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -25,61 +25,101 @@ interactions:
     uri: https://api.openai.com/v1/responses
   response:
     body:
-      string: "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_096378a2c1e6695d016972a7c316d08195ad0a9ba89f12d93f\",\"object\":\"response\",\"created_at\":1769121731,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4.1-2025-04-14\",\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":false,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"web_search\",\"filters\":null,\"search_context_size\":\"medium\",\"user_location\":{\"type\":\"approximate\",\"city\":null,\"country\":\"US\",\"region\":null,\"timezone\":null}}],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":0}\n\nevent:
-        response.in_progress\ndata: {\"type\":\"response.in_progress\",\"response\":{\"id\":\"resp_096378a2c1e6695d016972a7c316d08195ad0a9ba89f12d93f\",\"object\":\"response\",\"created_at\":1769121731,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4.1-2025-04-14\",\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":false,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"web_search\",\"filters\":null,\"search_context_size\":\"medium\",\"user_location\":{\"type\":\"approximate\",\"city\":null,\"country\":\"US\",\"region\":null,\"timezone\":null}}],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":1}\n\nevent:
-        response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"ws_096378a2c1e6695d016972a7c41c648195af6b7f17d807a05c\",\"type\":\"web_search_call\",\"status\":\"in_progress\",\"action\":{\"type\":\"search\"}},\"output_index\":0,\"sequence_number\":2}\n\nevent:
-        response.web_search_call.in_progress\ndata: {\"type\":\"response.web_search_call.in_progress\",\"item_id\":\"ws_096378a2c1e6695d016972a7c41c648195af6b7f17d807a05c\",\"output_index\":0,\"sequence_number\":3}\n\nevent:
-        response.web_search_call.searching\ndata: {\"type\":\"response.web_search_call.searching\",\"item_id\":\"ws_096378a2c1e6695d016972a7c41c648195af6b7f17d807a05c\",\"output_index\":0,\"sequence_number\":4}\n\nevent:
-        response.web_search_call.completed\ndata: {\"type\":\"response.web_search_call.completed\",\"item_id\":\"ws_096378a2c1e6695d016972a7c41c648195af6b7f17d807a05c\",\"output_index\":0,\"sequence_number\":5}\n\nevent:
-        response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"ws_096378a2c1e6695d016972a7c41c648195af6b7f17d807a05c\",\"type\":\"web_search_call\",\"status\":\"completed\",\"action\":{\"type\":\"search\",\"queries\":[\"ggplot2
-        1.0.0 release date CRAN archive\"],\"query\":\"ggplot2 1.0.0 release date
-        CRAN archive\"}},\"output_index\":0,\"sequence_number\":6}\n\nevent: response.output_item.added\ndata:
-        {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"msg_096378a2c1e6695d016972a7c5da008195a75cdfef88e531de\",\"type\":\"message\",\"status\":\"in_progress\",\"content\":[],\"role\":\"assistant\"},\"output_index\":1,\"sequence_number\":7}\n\nevent:
-        response.content_part.added\ndata: {\"type\":\"response.content_part.added\",\"content_index\":0,\"item_id\":\"msg_096378a2c1e6695d016972a7c5da008195a75cdfef88e531de\",\"output_index\":1,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"\"},\"sequence_number\":8}\n\nevent:
+      string: "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_020e5a0c669809940169e1369b8898819080b92efc96f0334b\",\"object\":\"response\",\"created_at\":1776367259,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4.1-2025-04-14\",\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":false,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"web_search\",\"search_context_size\":\"medium\",\"user_location\":{\"type\":\"approximate\",\"city\":null,\"country\":\"US\",\"region\":null,\"timezone\":null}}],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":0}\n\nevent:
+        response.in_progress\ndata: {\"type\":\"response.in_progress\",\"response\":{\"id\":\"resp_020e5a0c669809940169e1369b8898819080b92efc96f0334b\",\"object\":\"response\",\"created_at\":1776367259,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4.1-2025-04-14\",\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":false,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"web_search\",\"search_context_size\":\"medium\",\"user_location\":{\"type\":\"approximate\",\"city\":null,\"country\":\"US\",\"region\":null,\"timezone\":null}}],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":1}\n\nevent:
+        response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"ws_020e5a0c669809940169e1369c2e488190928cc8159f3c1d2f\",\"type\":\"web_search_call\",\"status\":\"in_progress\",\"action\":{\"type\":\"search\"}},\"output_index\":0,\"sequence_number\":2}\n\nevent:
+        response.web_search_call.in_progress\ndata: {\"type\":\"response.web_search_call.in_progress\",\"item_id\":\"ws_020e5a0c669809940169e1369c2e488190928cc8159f3c1d2f\",\"output_index\":0,\"sequence_number\":3}\n\nevent:
+        response.web_search_call.searching\ndata: {\"type\":\"response.web_search_call.searching\",\"item_id\":\"ws_020e5a0c669809940169e1369c2e488190928cc8159f3c1d2f\",\"output_index\":0,\"sequence_number\":4}\n\nevent:
+        response.web_search_call.completed\ndata: {\"type\":\"response.web_search_call.completed\",\"item_id\":\"ws_020e5a0c669809940169e1369c2e488190928cc8159f3c1d2f\",\"output_index\":0,\"sequence_number\":5}\n\nevent:
+        response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"ws_020e5a0c669809940169e1369c2e488190928cc8159f3c1d2f\",\"type\":\"web_search_call\",\"status\":\"completed\",\"action\":{\"type\":\"search\",\"queries\":[\"ggplot2
+        1.0.0 CRAN archive release date\"],\"query\":\"ggplot2 1.0.0 CRAN archive
+        release date\"}},\"output_index\":0,\"sequence_number\":6}\n\nevent: response.output_item.added\ndata:
+        {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"msg_020e5a0c669809940169e1369d9ba08190801f483e144606ac\",\"type\":\"message\",\"status\":\"in_progress\",\"content\":[],\"role\":\"assistant\"},\"output_index\":1,\"sequence_number\":7}\n\nevent:
+        response.content_part.added\ndata: {\"type\":\"response.content_part.added\",\"content_index\":0,\"item_id\":\"msg_020e5a0c669809940169e1369d9ba08190801f483e144606ac\",\"output_index\":1,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"\"},\"sequence_number\":8}\n\nevent:
         response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"The
-        version **ggplot2\u202F1.0.0**\",\"item_id\":\"msg_096378a2c1e6695d016972a7c5da008195a75cdfef88e531de\",\"logprobs\":[],\"obfuscation\":\"NII\",\"output_index\":1,\"sequence_number\":9}\n\nevent:
+        release date of **ggplot2 version 1.\",\"item_id\":\"msg_020e5a0c669809940169e1369d9ba08190801f483e144606ac\",\"logprobs\":[],\"obfuscation\":\"qFwXNA8k\",\"output_index\":1,\"sequence_number\":9}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"0.0**
+        on CRAN is **\",\"item_id\":\"msg_020e5a0c669809940169e1369d9ba08190801f483e144606ac\",\"logprobs\":[],\"obfuscation\":\"XhphxeqNrT316\",\"output_index\":1,\"sequence_number\":10}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"2014\u201105\u201121**.\\n\\nThis
+        is confirmed by:\\n\\n\u2022 The CRAN archive index,\",\"item_id\":\"msg_020e5a0c669809940169e1369d9ba08190801f483e144606ac\",\"logprobs\":[],\"obfuscation\":\"P\",\"output_index\":1,\"sequence_number\":11}\n\nevent:
         response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"
-        was released on CRAN on **2014\u201105\u201121\",\"item_id\":\"msg_096378a2c1e6695d016972a7c5da008195a75cdfef88e531de\",\"logprobs\":[],\"obfuscation\":\"ZJ0Wcp2yt1x\",\"output_index\":1,\"sequence_number\":10}\n\nevent:
-        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"**,
-        according to the CRAN archive listing for that package version\",\"item_id\":\"msg_096378a2c1e6695d016972a7c5da008195a75cdfef88e531de\",\"logprobs\":[],\"obfuscation\":\"YW6EDIxjMacV5A\",\"output_index\":1,\"sequence_number\":11}\n\nevent:
+        which lists `ggplot2_1.0.\",\"item_id\":\"msg_020e5a0c669809940169e1369d9ba08190801f483e144606ac\",\"logprobs\":[],\"obfuscation\":\"u3rwB4\",\"output_index\":1,\"sequence_number\":12}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"0.tar.gz`
+        with the timestamp **2014\u201105\u201121\_15:36\u202FUTC** \",\"item_id\":\"msg_020e5a0c669809940169e1369d9ba08190801f483e144606ac\",\"logprobs\":[],\"obfuscation\":\"5iV7f3RMsy\",\"output_index\":1,\"sequence_number\":13}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"([stat.ethz.ch](https://stat.ethz.ch/CRAN/src/contrib/Archive/ggplot2/?utm_source=openai)).
+        \ \\n\u2022 A releases summary page showing version\_1.\",\"item_id\":\"msg_020e5a0c669809940169e1369d9ba08190801f483e144606ac\",\"logprobs\":[],\"obfuscation\":\"h5Ehrg\",\"output_index\":1,\"sequence_number\":14}\n\nevent:
+        response.output_text.annotation.added\ndata: {\"type\":\"response.output_text.annotation.added\",\"annotation\":{\"type\":\"url_citation\",\"end_index\":292,\"start_index\":202,\"title\":\"Index
+        of /CRAN/src/contrib/Archive/ggplot2\",\"url\":\"https://stat.ethz.ch/CRAN/src/contrib/Archive/ggplot2/?utm_source=openai\"},\"annotation_index\":0,\"content_index\":0,\"item_id\":\"msg_020e5a0c669809940169e1369d9ba08190801f483e144606ac\",\"output_index\":1,\"sequence_number\":15}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"0.0
+        released on **May\_21st,\_\",\"item_id\":\"msg_020e5a0c669809940169e1369d9ba08190801f483e144606ac\",\"logprobs\":[],\"obfuscation\":\"KHmC\",\"output_index\":1,\"sequence_number\":16}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"2014**
+        \",\"item_id\":\"msg_020e5a0c669809940169e1369d9ba08190801f483e144606ac\",\"logprobs\":[],\"obfuscation\":\"2hiU9TGQ2\",\"output_index\":1,\"sequence_number\":17}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"([libraries.io](https://libraries.io/cran/ggplot2/versions?utm_source=openai)).\\n\\nTherefore,
+        in YYYY\u2011MM\u2011DD format,\",\"item_id\":\"msg_020e5a0c669809940169e1369d9ba08190801f483e144606ac\",\"logprobs\":[],\"obfuscation\":\"U7BCT66oMD9GWT6\",\"output_index\":1,\"sequence_number\":18}\n\nevent:
+        response.output_text.annotation.added\ndata: {\"type\":\"response.output_text.annotation.added\",\"annotation\":{\"type\":\"url_citation\",\"end_index\":453,\"start_index\":375,\"title\":\"ggplot2
+        published releases on CRAN - Libraries.io - security & maintenance data for
+        open source software\",\"url\":\"https://libraries.io/cran/ggplot2/versions?utm_source=openai\"},\"annotation_index\":1,\"content_index\":0,\"item_id\":\"msg_020e5a0c669809940169e1369d9ba08190801f483e144606ac\",\"output_index\":1,\"sequence_number\":19}\n\nevent:
         response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"
-        ([stat.ethz.ch](https://stat.ethz.ch/CRAN/src/contrib/Archive/ggplot2/?utm_source=openai))\",\"item_id\":\"msg_096378a2c1e6695d016972a7c5da008195a75cdfef88e531de\",\"logprobs\":[],\"obfuscation\":\"YLYyT\",\"output_index\":1,\"sequence_number\":12}\n\nevent:
-        response.output_text.annotation.added\ndata: {\"type\":\"response.output_text.annotation.added\",\"annotation\":{\"type\":\"url_citation\",\"end_index\":223,\"start_index\":133,\"title\":\"Index
-        of /CRAN/src/contrib/Archive/ggplot2\",\"url\":\"https://stat.ethz.ch/CRAN/src/contrib/Archive/ggplot2/?utm_source=openai\"},\"annotation_index\":0,\"content_index\":0,\"item_id\":\"msg_096378a2c1e6695d016972a7c5da008195a75cdfef88e531de\",\"output_index\":1,\"sequence_number\":13}\n\nevent:
-        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\".\\n\\nTherefore,
-        the release date in YYYY\u2011MM\u2011DD format\",\"item_id\":\"msg_096378a2c1e6695d016972a7c5da008195a75cdfef88e531de\",\"logprobs\":[],\"obfuscation\":\"jyMvueQDORA28\",\"output_index\":1,\"sequence_number\":14}\n\nevent:
-        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"
-        is:\\n\\n**2014\u201105\u201121**\",\"item_id\":\"msg_096378a2c1e6695d016972a7c5da008195a75cdfef88e531de\",\"logprobs\":[],\"obfuscation\":\"3MHDYPeyGaSu\",\"output_index\":1,\"sequence_number\":15}\n\nevent:
-        response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\"content_index\":0,\"item_id\":\"msg_096378a2c1e6695d016972a7c5da008195a75cdfef88e531de\",\"logprobs\":[],\"output_index\":1,\"sequence_number\":16,\"text\":\"The
-        version **ggplot2\u202F1.0.0** was released on CRAN on **2014\u201105\u201121**,
-        according to the CRAN archive listing for that package version ([stat.ethz.ch](https://stat.ethz.ch/CRAN/src/contrib/Archive/ggplot2/?utm_source=openai)).\\n\\nTherefore,
-        the release date in YYYY\u2011MM\u2011DD format is:\\n\\n**2014\u201105\u201121**\"}\n\nevent:
-        response.content_part.done\ndata: {\"type\":\"response.content_part.done\",\"content_index\":0,\"item_id\":\"msg_096378a2c1e6695d016972a7c5da008195a75cdfef88e531de\",\"output_index\":1,\"part\":{\"type\":\"output_text\",\"annotations\":[{\"type\":\"url_citation\",\"end_index\":223,\"start_index\":133,\"title\":\"Index
-        of /CRAN/src/contrib/Archive/ggplot2\",\"url\":\"https://stat.ethz.ch/CRAN/src/contrib/Archive/ggplot2/?utm_source=openai\"}],\"logprobs\":[],\"text\":\"The
-        version **ggplot2\u202F1.0.0** was released on CRAN on **2014\u201105\u201121**,
-        according to the CRAN archive listing for that package version ([stat.ethz.ch](https://stat.ethz.ch/CRAN/src/contrib/Archive/ggplot2/?utm_source=openai)).\\n\\nTherefore,
-        the release date in YYYY\u2011MM\u2011DD format is:\\n\\n**2014\u201105\u201121**\"},\"sequence_number\":17}\n\nevent:
-        response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"msg_096378a2c1e6695d016972a7c5da008195a75cdfef88e531de\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[{\"type\":\"url_citation\",\"end_index\":223,\"start_index\":133,\"title\":\"Index
-        of /CRAN/src/contrib/Archive/ggplot2\",\"url\":\"https://stat.ethz.ch/CRAN/src/contrib/Archive/ggplot2/?utm_source=openai\"}],\"logprobs\":[],\"text\":\"The
-        version **ggplot2\u202F1.0.0** was released on CRAN on **2014\u201105\u201121**,
-        according to the CRAN archive listing for that package version ([stat.ethz.ch](https://stat.ethz.ch/CRAN/src/contrib/Archive/ggplot2/?utm_source=openai)).\\n\\nTherefore,
-        the release date in YYYY\u2011MM\u2011DD format is:\\n\\n**2014\u201105\u201121**\"}],\"role\":\"assistant\"},\"output_index\":1,\"sequence_number\":18}\n\nevent:
-        response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_096378a2c1e6695d016972a7c316d08195ad0a9ba89f12d93f\",\"object\":\"response\",\"created_at\":1769121731,\"status\":\"completed\",\"background\":false,\"completed_at\":1769121734,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4.1-2025-04-14\",\"output\":[{\"id\":\"ws_096378a2c1e6695d016972a7c41c648195af6b7f17d807a05c\",\"type\":\"web_search_call\",\"status\":\"completed\",\"action\":{\"type\":\"search\",\"queries\":[\"ggplot2
-        1.0.0 release date CRAN archive\"],\"query\":\"ggplot2 1.0.0 release date
-        CRAN archive\"}},{\"id\":\"msg_096378a2c1e6695d016972a7c5da008195a75cdfef88e531de\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[{\"type\":\"url_citation\",\"end_index\":223,\"start_index\":133,\"title\":\"Index
-        of /CRAN/src/contrib/Archive/ggplot2\",\"url\":\"https://stat.ethz.ch/CRAN/src/contrib/Archive/ggplot2/?utm_source=openai\"}],\"logprobs\":[],\"text\":\"The
-        version **ggplot2\u202F1.0.0** was released on CRAN on **2014\u201105\u201121**,
-        according to the CRAN archive listing for that package version ([stat.ethz.ch](https://stat.ethz.ch/CRAN/src/contrib/Archive/ggplot2/?utm_source=openai)).\\n\\nTherefore,
-        the release date in YYYY\u2011MM\u2011DD format is:\\n\\n**2014\u201105\u201121**\"}],\"role\":\"assistant\"}],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":false,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"web_search\",\"filters\":null,\"search_context_size\":\"medium\",\"user_location\":{\"type\":\"approximate\",\"city\":null,\"country\":\"US\",\"region\":null,\"timezone\":null}}],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":16725,\"input_tokens_details\":{\"cached_tokens\":0},\"output_tokens\":114,\"output_tokens_details\":{\"reasoning_tokens\":0},\"total_tokens\":16839},\"user\":null,\"metadata\":{}},\"sequence_number\":19}\n\n"
+        the release date is:\\n\\n**\",\"item_id\":\"msg_020e5a0c669809940169e1369d9ba08190801f483e144606ac\",\"logprobs\":[],\"obfuscation\":\"LIPAkmX\",\"output_index\":1,\"sequence_number\":20}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"2014\u201105\u201121**\\n\\nLet
+        me know if you\u2019d like more details on that release (such as feature changes
+        or context)!\",\"item_id\":\"msg_020e5a0c669809940169e1369d9ba08190801f483e144606ac\",\"logprobs\":[],\"obfuscation\":\"7e0SIR\",\"output_index\":1,\"sequence_number\":21}\n\nevent:
+        response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\"content_index\":0,\"item_id\":\"msg_020e5a0c669809940169e1369d9ba08190801f483e144606ac\",\"logprobs\":[],\"output_index\":1,\"sequence_number\":22,\"text\":\"The
+        release date of **ggplot2 version 1.0.0** on CRAN is **2014\u201105\u201121**.\\n\\nThis
+        is confirmed by:\\n\\n\u2022 The CRAN archive index, which lists `ggplot2_1.0.0.tar.gz`
+        with the timestamp **2014\u201105\u201121\_15:36\u202FUTC** ([stat.ethz.ch](https://stat.ethz.ch/CRAN/src/contrib/Archive/ggplot2/?utm_source=openai)).
+        \ \\n\u2022 A releases summary page showing version\_1.0.0 released on **May\_21st,\_2014**
+        ([libraries.io](https://libraries.io/cran/ggplot2/versions?utm_source=openai)).\\n\\nTherefore,
+        in YYYY\u2011MM\u2011DD format, the release date is:\\n\\n**2014\u201105\u201121**\\n\\nLet
+        me know if you\u2019d like more details on that release (such as feature changes
+        or context)!\"}\n\nevent: response.content_part.done\ndata: {\"type\":\"response.content_part.done\",\"content_index\":0,\"item_id\":\"msg_020e5a0c669809940169e1369d9ba08190801f483e144606ac\",\"output_index\":1,\"part\":{\"type\":\"output_text\",\"annotations\":[{\"type\":\"url_citation\",\"end_index\":292,\"start_index\":202,\"title\":\"Index
+        of /CRAN/src/contrib/Archive/ggplot2\",\"url\":\"https://stat.ethz.ch/CRAN/src/contrib/Archive/ggplot2/?utm_source=openai\"},{\"type\":\"url_citation\",\"end_index\":453,\"start_index\":375,\"title\":\"ggplot2
+        published releases on CRAN - Libraries.io - security & maintenance data for
+        open source software\",\"url\":\"https://libraries.io/cran/ggplot2/versions?utm_source=openai\"}],\"logprobs\":[],\"text\":\"The
+        release date of **ggplot2 version 1.0.0** on CRAN is **2014\u201105\u201121**.\\n\\nThis
+        is confirmed by:\\n\\n\u2022 The CRAN archive index, which lists `ggplot2_1.0.0.tar.gz`
+        with the timestamp **2014\u201105\u201121\_15:36\u202FUTC** ([stat.ethz.ch](https://stat.ethz.ch/CRAN/src/contrib/Archive/ggplot2/?utm_source=openai)).
+        \ \\n\u2022 A releases summary page showing version\_1.0.0 released on **May\_21st,\_2014**
+        ([libraries.io](https://libraries.io/cran/ggplot2/versions?utm_source=openai)).\\n\\nTherefore,
+        in YYYY\u2011MM\u2011DD format, the release date is:\\n\\n**2014\u201105\u201121**\\n\\nLet
+        me know if you\u2019d like more details on that release (such as feature changes
+        or context)!\"},\"sequence_number\":23}\n\nevent: response.output_item.done\ndata:
+        {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"msg_020e5a0c669809940169e1369d9ba08190801f483e144606ac\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[{\"type\":\"url_citation\",\"end_index\":292,\"start_index\":202,\"title\":\"Index
+        of /CRAN/src/contrib/Archive/ggplot2\",\"url\":\"https://stat.ethz.ch/CRAN/src/contrib/Archive/ggplot2/?utm_source=openai\"},{\"type\":\"url_citation\",\"end_index\":453,\"start_index\":375,\"title\":\"ggplot2
+        published releases on CRAN - Libraries.io - security & maintenance data for
+        open source software\",\"url\":\"https://libraries.io/cran/ggplot2/versions?utm_source=openai\"}],\"logprobs\":[],\"text\":\"The
+        release date of **ggplot2 version 1.0.0** on CRAN is **2014\u201105\u201121**.\\n\\nThis
+        is confirmed by:\\n\\n\u2022 The CRAN archive index, which lists `ggplot2_1.0.0.tar.gz`
+        with the timestamp **2014\u201105\u201121\_15:36\u202FUTC** ([stat.ethz.ch](https://stat.ethz.ch/CRAN/src/contrib/Archive/ggplot2/?utm_source=openai)).
+        \ \\n\u2022 A releases summary page showing version\_1.0.0 released on **May\_21st,\_2014**
+        ([libraries.io](https://libraries.io/cran/ggplot2/versions?utm_source=openai)).\\n\\nTherefore,
+        in YYYY\u2011MM\u2011DD format, the release date is:\\n\\n**2014\u201105\u201121**\\n\\nLet
+        me know if you\u2019d like more details on that release (such as feature changes
+        or context)!\"}],\"role\":\"assistant\"},\"output_index\":1,\"sequence_number\":24}\n\nevent:
+        response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_020e5a0c669809940169e1369b8898819080b92efc96f0334b\",\"object\":\"response\",\"created_at\":1776367259,\"status\":\"completed\",\"background\":false,\"completed_at\":1776367262,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4.1-2025-04-14\",\"output\":[{\"id\":\"ws_020e5a0c669809940169e1369c2e488190928cc8159f3c1d2f\",\"type\":\"web_search_call\",\"status\":\"completed\",\"action\":{\"type\":\"search\",\"queries\":[\"ggplot2
+        1.0.0 CRAN archive release date\"],\"query\":\"ggplot2 1.0.0 CRAN archive
+        release date\"}},{\"id\":\"msg_020e5a0c669809940169e1369d9ba08190801f483e144606ac\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[{\"type\":\"url_citation\",\"end_index\":292,\"start_index\":202,\"title\":\"Index
+        of /CRAN/src/contrib/Archive/ggplot2\",\"url\":\"https://stat.ethz.ch/CRAN/src/contrib/Archive/ggplot2/?utm_source=openai\"},{\"type\":\"url_citation\",\"end_index\":453,\"start_index\":375,\"title\":\"ggplot2
+        published releases on CRAN - Libraries.io - security & maintenance data for
+        open source software\",\"url\":\"https://libraries.io/cran/ggplot2/versions?utm_source=openai\"}],\"logprobs\":[],\"text\":\"The
+        release date of **ggplot2 version 1.0.0** on CRAN is **2014\u201105\u201121**.\\n\\nThis
+        is confirmed by:\\n\\n\u2022 The CRAN archive index, which lists `ggplot2_1.0.0.tar.gz`
+        with the timestamp **2014\u201105\u201121\_15:36\u202FUTC** ([stat.ethz.ch](https://stat.ethz.ch/CRAN/src/contrib/Archive/ggplot2/?utm_source=openai)).
+        \ \\n\u2022 A releases summary page showing version\_1.0.0 released on **May\_21st,\_2014**
+        ([libraries.io](https://libraries.io/cran/ggplot2/versions?utm_source=openai)).\\n\\nTherefore,
+        in YYYY\u2011MM\u2011DD format, the release date is:\\n\\n**2014\u201105\u201121**\\n\\nLet
+        me know if you\u2019d like more details on that release (such as feature changes
+        or context)!\"}],\"role\":\"assistant\"}],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":false,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[{\"type\":\"web_search\",\"search_context_size\":\"medium\",\"user_location\":{\"type\":\"approximate\",\"city\":null,\"country\":\"US\",\"region\":null,\"timezone\":null}}],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":17088,\"input_tokens_details\":{\"cached_tokens\":0},\"output_tokens\":211,\"output_tokens_details\":{\"reasoning_tokens\":0},\"total_tokens\":17299},\"user\":null,\"metadata\":{}},\"sequence_number\":25}\n\nevent:
+        response.rate_limits.updated\ndata: {\"type\":\"response.rate_limits.updated\",\"rate_limits\":{\"limit_requests\":\"10000\",\"limit_tokens\":\"30000000\",\"remaining_requests\":\"9999\",\"remaining_tokens\":\"29983053\",\"reset_requests_ms\":6,\"reset_tokens_ms\":33},\"sequence_number\":26}\n\n"
     headers:
       CF-RAY:
-      - 9c2290230b7c60a0-ORD
+      - 9ed58cebdd8010db-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Thu, 22 Jan 2026 22:42:11 GMT
+      - Thu, 16 Apr 2026 19:20:59 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -93,43 +133,56 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       openai-processing-ms:
-      - '204'
+      - '332'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '209'
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '30000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '29999648'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
     status:
       code: 200
       message: OK
 - request:
     body: '{"input": [{"role": "user", "content": [{"type": "input_text", "text":
       "When was ggplot2 1.0.0 released to CRAN? Answer in YYYY-MM-DD format. The CRAN
-      archive page has this info."}]}, {"id": "ws_096378a2c1e6695d016972a7c41c648195af6b7f17d807a05c",
-      "action": {"query": "ggplot2 1.0.0 release date CRAN archive", "type": "search",
-      "sources": null, "queries": ["ggplot2 1.0.0 release date CRAN archive"]}, "status":
+      archive page has this info."}]}, {"id": "ws_020e5a0c669809940169e1369c2e488190928cc8159f3c1d2f",
+      "action": {"query": "ggplot2 1.0.0 CRAN archive release date", "type": "search",
+      "queries": ["ggplot2 1.0.0 CRAN archive release date"], "sources": null}, "status":
       "completed", "type": "web_search_call"}, {"role": "assistant", "content": [{"type":
-      "output_text", "text": "The version **ggplot2\u202f1.0.0** was released on CRAN
-      on **2014\u201105\u201121**, according to the CRAN archive listing for that
-      package version ([stat.ethz.ch](https://stat.ethz.ch/CRAN/src/contrib/Archive/ggplot2/?utm_source=openai)).\n\nTherefore,
-      the release date in YYYY\u2011MM\u2011DD format is:\n\n**2014\u201105\u201121**",
-      "annotations": []}], "status": "completed", "type": "message", "id": "msg_missing_id"},
-      {"role": "user", "content": [{"type": "input_text", "text": "What month was
-      that?"}]}], "model": "gpt-4.1", "store": false, "stream": true, "tools": [{"type":
-      "web_search"}]}'
+      "output_text", "text": "The release date of **ggplot2 version 1.0.0** on CRAN
+      is **2014\u201105\u201121**.\n\nThis is confirmed by:\n\n\u2022 The CRAN archive
+      index, which lists `ggplot2_1.0.0.tar.gz` with the timestamp **2014\u201105\u201121\u00a015:36\u202fUTC**
+      ([stat.ethz.ch](https://stat.ethz.ch/CRAN/src/contrib/Archive/ggplot2/?utm_source=openai)).  \n\u2022
+      A releases summary page showing version\u00a01.0.0 released on **May\u00a021st,\u00a02014**
+      ([libraries.io](https://libraries.io/cran/ggplot2/versions?utm_source=openai)).\n\nTherefore,
+      in YYYY\u2011MM\u2011DD format, the release date is:\n\n**2014\u201105\u201121**\n\nLet
+      me know if you\u2019d like more details on that release (such as feature changes
+      or context)!", "annotations": []}], "status": "completed", "type": "message",
+      "id": "msg_missing_id"}, {"role": "user", "content": [{"type": "input_text",
+      "text": "What month was that?"}]}], "model": "gpt-4.1", "store": false, "stream":
+      true, "tools": [{"type": "web_search"}]}'
     headers:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
-      - '1045'
+      - '1391'
       Content-Type:
       - application/json
       Cookie:
-      - __cf_bm=z7u9sf23AD0ycYUz_fTEKVEg7183d0zlNPsZHw8Ec_k-1769121731-1.0.1.1-Z7Wk1QB0b4cJbvlXMGOk_14nWr73gG8O55BdpgJwxHRMAgKQj.fbccVDM0kpQo7LQw0nFSB2_sYiLeEpvMCVp34Vua.8CbsMIiwBi7exdSc;
-        _cfuvid=wc454JxpEmQ8NI0rbEpQNisIbdrXnlThJgt3KowN78A-1769121731295-0.0.1.1-604800000
+      - __cf_bm=F3EYY2gz.033OPzgG_vbPc7v39Dm1_finOVq6fj2ArQ-1776367259.499698-1.0.1.1-HKNK1w3ywRLnEYONbGkYqCh4xKXumSqT0CqOjS2S_qBFGB5G93OwI0Wz6_SzWE2ywCCiQ308Rv_jkFI36g0dvk4CQuTl6I9HscobVsjv_uASKYnRqewUp0egMGBykU87
       Host:
       - api.openai.com
       X-Stainless-Async:
@@ -142,93 +195,158 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","response":{"id":"resp_096378a2c1e6695d016972a7c710888195a45529f4d5245de6","object":"response","created_at":1769121735,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"web_search","filters":null,"search_context_size":"medium","user_location":{"type":"approximate","city":null,"country":"US","region":null,"timezone":null}}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
+        data: {"type":"response.created","response":{"id":"resp_020e5a0c669809940169e1369ee2608190b359b09b80d4148c","object":"response","created_at":1776367262,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"web_search","search_context_size":"medium","user_location":{"type":"approximate","city":null,"country":"US","region":null,"timezone":null}}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":0}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","response":{"id":"resp_096378a2c1e6695d016972a7c710888195a45529f4d5245de6","object":"response","created_at":1769121735,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"web_search","filters":null,"search_context_size":"medium","user_location":{"type":"approximate","city":null,"country":"US","region":null,"timezone":null}}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
+        data: {"type":"response.in_progress","response":{"id":"resp_020e5a0c669809940169e1369ee2608190b359b09b80d4148c","object":"response","created_at":1776367262,"status":"in_progress","background":false,"completed_at":null,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"web_search","search_context_size":"medium","user_location":{"type":"approximate","city":null,"country":"US","region":null,"timezone":null}}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}},"sequence_number":1}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","item":{"id":"msg_096378a2c1e6695d016972a7c7bed48195b8344742aab85b79","type":"message","status":"in_progress","content":[],"role":"assistant"},"output_index":0,"sequence_number":2}
+        data: {"type":"response.output_item.added","item":{"id":"msg_020e5a0c669809940169e1369f63288190bc08344b269fd398","type":"message","status":"in_progress","content":[],"role":"assistant"},"output_index":0,"sequence_number":2}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","content_index":0,"item_id":"msg_096378a2c1e6695d016972a7c7bed48195b8344742aab85b79","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":3}
+        data: {"type":"response.content_part.added","content_index":0,"item_id":"msg_020e5a0c669809940169e1369f63288190bc08344b269fd398","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""},"sequence_number":3}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","content_index":0,"delta":"The","item_id":"msg_096378a2c1e6695d016972a7c7bed48195b8344742aab85b79","logprobs":[],"obfuscation":"HRW0KslxPt9Ho","output_index":0,"sequence_number":4}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"The","item_id":"msg_020e5a0c669809940169e1369f63288190bc08344b269fd398","logprobs":[],"obfuscation":"BQLNe1iG4KgI9","output_index":0,"sequence_number":4}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","content_index":0,"delta":" month","item_id":"msg_096378a2c1e6695d016972a7c7bed48195b8344742aab85b79","logprobs":[],"obfuscation":"Y06UadDzvd","output_index":0,"sequence_number":5}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" month","item_id":"msg_020e5a0c669809940169e1369f63288190bc08344b269fd398","logprobs":[],"obfuscation":"tYDps8NtHL","output_index":0,"sequence_number":5}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","content_index":0,"delta":" was","item_id":"msg_096378a2c1e6695d016972a7c7bed48195b8344742aab85b79","logprobs":[],"obfuscation":"iLWlzQvODUXh","output_index":0,"sequence_number":6}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" of","item_id":"msg_020e5a0c669809940169e1369f63288190bc08344b269fd398","logprobs":[],"obfuscation":"tyLCext0e2rZH","output_index":0,"sequence_number":6}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","content_index":0,"delta":" **","item_id":"msg_096378a2c1e6695d016972a7c7bed48195b8344742aab85b79","logprobs":[],"obfuscation":"XDZRROnzUkQec","output_index":0,"sequence_number":7}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" the","item_id":"msg_020e5a0c669809940169e1369f63288190bc08344b269fd398","logprobs":[],"obfuscation":"iNKTDkwV6a4K","output_index":0,"sequence_number":7}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","content_index":0,"delta":"May","item_id":"msg_096378a2c1e6695d016972a7c7bed48195b8344742aab85b79","logprobs":[],"obfuscation":"XUq0SxrRgIQlJ","output_index":0,"sequence_number":8}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" release","item_id":"msg_020e5a0c669809940169e1369f63288190bc08344b269fd398","logprobs":[],"obfuscation":"EVZ3M7Fo","output_index":0,"sequence_number":8}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","content_index":0,"delta":"**","item_id":"msg_096378a2c1e6695d016972a7c7bed48195b8344742aab85b79","logprobs":[],"obfuscation":"i0sEcBptKkU3tQ","output_index":0,"sequence_number":9}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" date","item_id":"msg_020e5a0c669809940169e1369f63288190bc08344b269fd398","logprobs":[],"obfuscation":"A7821N7ELGy","output_index":0,"sequence_number":9}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_096378a2c1e6695d016972a7c7bed48195b8344742aab85b79","logprobs":[],"obfuscation":"dMKznGI1enG5lNb","output_index":0,"sequence_number":10}
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" **","item_id":"msg_020e5a0c669809940169e1369f63288190bc08344b269fd398","logprobs":[],"obfuscation":"Jp99R3ud1PKVu","output_index":0,"sequence_number":10}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"201","item_id":"msg_020e5a0c669809940169e1369f63288190bc08344b269fd398","logprobs":[],"obfuscation":"0dfDlTmKQxCRi","output_index":0,"sequence_number":11}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"4","item_id":"msg_020e5a0c669809940169e1369f63288190bc08344b269fd398","logprobs":[],"obfuscation":"nsei6nxKgGlCVz6","output_index":0,"sequence_number":12}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"-","item_id":"msg_020e5a0c669809940169e1369f63288190bc08344b269fd398","logprobs":[],"obfuscation":"Enb1JYMfSOSIs7v","output_index":0,"sequence_number":13}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"05","item_id":"msg_020e5a0c669809940169e1369f63288190bc08344b269fd398","logprobs":[],"obfuscation":"gQag4jMANzcR91","output_index":0,"sequence_number":14}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"-","item_id":"msg_020e5a0c669809940169e1369f63288190bc08344b269fd398","logprobs":[],"obfuscation":"PazX26Qd2uD6mQn","output_index":0,"sequence_number":15}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"21","item_id":"msg_020e5a0c669809940169e1369f63288190bc08344b269fd398","logprobs":[],"obfuscation":"Ou2HnN3XNUllvN","output_index":0,"sequence_number":16}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"**","item_id":"msg_020e5a0c669809940169e1369f63288190bc08344b269fd398","logprobs":[],"obfuscation":"iRucju5BREHm2x","output_index":0,"sequence_number":17}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" is","item_id":"msg_020e5a0c669809940169e1369f63288190bc08344b269fd398","logprobs":[],"obfuscation":"wuV7zn0zVyeXs","output_index":0,"sequence_number":18}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":" **","item_id":"msg_020e5a0c669809940169e1369f63288190bc08344b269fd398","logprobs":[],"obfuscation":"GxztG07iT1hMm","output_index":0,"sequence_number":19}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"May","item_id":"msg_020e5a0c669809940169e1369f63288190bc08344b269fd398","logprobs":[],"obfuscation":"kxNv4oNB8A0DY","output_index":0,"sequence_number":20}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":"**","item_id":"msg_020e5a0c669809940169e1369f63288190bc08344b269fd398","logprobs":[],"obfuscation":"RIht89HSDLQT76","output_index":0,"sequence_number":21}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","content_index":0,"delta":".","item_id":"msg_020e5a0c669809940169e1369f63288190bc08344b269fd398","logprobs":[],"obfuscation":"oRCTY5qMc6pR45s","output_index":0,"sequence_number":22}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","content_index":0,"item_id":"msg_096378a2c1e6695d016972a7c7bed48195b8344742aab85b79","logprobs":[],"output_index":0,"sequence_number":11,"text":"The
-        month was **May**."}
+        data: {"type":"response.output_text.done","content_index":0,"item_id":"msg_020e5a0c669809940169e1369f63288190bc08344b269fd398","logprobs":[],"output_index":0,"sequence_number":23,"text":"The
+        month of the release date **2014-05-21** is **May**."}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","content_index":0,"item_id":"msg_096378a2c1e6695d016972a7c7bed48195b8344742aab85b79","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"The
-        month was **May**."},"sequence_number":12}
+        data: {"type":"response.content_part.done","content_index":0,"item_id":"msg_020e5a0c669809940169e1369f63288190bc08344b269fd398","output_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"The
+        month of the release date **2014-05-21** is **May**."},"sequence_number":24}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","item":{"id":"msg_096378a2c1e6695d016972a7c7bed48195b8344742aab85b79","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"The
-        month was **May**."}],"role":"assistant"},"output_index":0,"sequence_number":13}
+        data: {"type":"response.output_item.done","item":{"id":"msg_020e5a0c669809940169e1369f63288190bc08344b269fd398","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"The
+        month of the release date **2014-05-21** is **May**."}],"role":"assistant"},"output_index":0,"sequence_number":25}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","response":{"id":"resp_096378a2c1e6695d016972a7c710888195a45529f4d5245de6","object":"response","created_at":1769121735,"status":"completed","background":false,"completed_at":1769121735,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"msg_096378a2c1e6695d016972a7c7bed48195b8344742aab85b79","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"The
-        month was **May**."}],"role":"assistant"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"web_search","filters":null,"search_context_size":"medium","user_location":{"type":"approximate","city":null,"country":"US","region":null,"timezone":null}}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":437,"input_tokens_details":{"cached_tokens":0},"output_tokens":9,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":446},"user":null,"metadata":{}},"sequence_number":14}
+        data: {"type":"response.completed","response":{"id":"resp_020e5a0c669809940169e1369ee2608190b359b09b80d4148c","object":"response","created_at":1776367262,"status":"completed","background":false,"completed_at":1776367263,"error":null,"frequency_penalty":0.0,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4.1-2025-04-14","output":[{"id":"msg_020e5a0c669809940169e1369f63288190bc08344b269fd398","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"The
+        month of the release date **2014-05-21** is **May**."}],"role":"assistant"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"web_search","search_context_size":"medium","user_location":{"type":"approximate","city":null,"country":"US","region":null,"timezone":null}}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":574,"input_tokens_details":{"cached_tokens":0},"output_tokens":21,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":595},"user":null,"metadata":{}},"sequence_number":26}
+
+
+        event: response.rate_limits.updated
+
+        data: {"type":"response.rate_limits.updated","rate_limits":{"limit_requests":"10000","limit_tokens":"30000000","remaining_requests":"9999","remaining_tokens":"29999998","reset_requests_ms":6,"reset_tokens_ms":0},"sequence_number":27}
 
 
         '
     headers:
       CF-RAY:
-      - 9c2290395849e273-ORD
+      - 9ed58d00dc43d2ec-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Thu, 22 Jan 2026 22:42:15 GMT
+      - Thu, 16 Apr 2026 19:21:03 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -242,11 +360,21 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       openai-processing-ms:
-      - '114'
+      - '226'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '118'
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '30000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '29999407'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 1ms
     status:
       code: 200
       message: OK

--- a/tests/_vcr/test_provider_openai_completions/test_data_extraction.yaml
+++ b/tests/_vcr/test_provider_openai_completions/test_data_extraction.yaml
@@ -12,7 +12,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -29,8 +29,8 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: "{\n  \"id\": \"chatcmpl-CsxImN3LNJ3W9SCQI5oZhYYnBOzJ0\",\n  \"object\":
-        \"chat.completion\",\n  \"created\": 1767213704,\n  \"model\": \"gpt-4.1-2025-04-14\",\n
+      string: "{\n  \"id\": \"chatcmpl-DVMZLlgVM5ljxyNhySWYF9QpHu6Yy\",\n  \"object\":
+        \"chat.completion\",\n  \"created\": 1776367295,\n  \"model\": \"gpt-4.1-2025-04-14\",\n
         \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
         \"assistant\",\n        \"content\": \"{\\\"title\\\":\\\"Apples are tasty\\\",\\\"author\\\":\\\"Hadley
         Wickham\\\"}\",\n        \"refusal\": null,\n        \"annotations\": []\n
@@ -40,16 +40,18 @@ interactions:
         0,\n      \"audio_tokens\": 0\n    },\n    \"completion_tokens_details\":
         {\n      \"reasoning_tokens\": 0,\n      \"audio_tokens\": 0,\n      \"accepted_prediction_tokens\":
         0,\n      \"rejected_prediction_tokens\": 0\n    }\n  },\n  \"service_tier\":
-        \"default\",\n  \"system_fingerprint\": \"fp_1a2c4a5ede\"\n}\n"
+        \"default\",\n  \"system_fingerprint\": \"fp_0551618383\"\n}\n"
     headers:
-      CF-RAY:
-      - 9b6c9975a8997815-ORD
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9ed58dccbc163443-ORD
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Wed, 31 Dec 2025 20:41:44 GMT
+      - Thu, 16 Apr 2026 19:21:36 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -62,16 +64,12 @@ interactions:
       - X-Request-ID
       alt-svc:
       - h3=":443"; ma=86400
-      cf-cache-status:
-      - DYNAMIC
       content-length:
       - '866'
       openai-processing-ms:
-      - '273'
+      - '377'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '297'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -106,7 +104,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -114,8 +112,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - __cf_bm=81iyVdKUXqmNCjJCB2IBLImU3wXlUHZUvQWNEQb5uS4-1767213704-1.0.1.1-MDuf13G3boFpPc6DHXVVQ.8RmopnEgpFi415hTmpcZGKmt62LSUkIk1AAv8U7rmciw1nCAT4.S2CtruwM9Aufhg.4.egvnHNCI74FCjbIto;
-        _cfuvid=KwmRrTnVKjpU6aNyR8l2x_JXM4Spkjbv.U3nT0KPv5s-1767213704939-0.0.1.1-604800000
+      - __cf_bm=vY8RWNmkBUeCRfZe8YRYMvsYx.rITugRVXC_t4LJET0-1776367295.4797728-1.0.1.1-dflpveJQyyAV8uCURb8Zc2MKX_OlFcvrAgNGa79MvySn5HZifBLv5W2fZj9pJtfJM.tTW_x6yd7c65x1Ni4vU5ColLZ.ji..vsSZ6Vrt32Vm9hX3IgXGBA_D0JUVicOV
       Host:
       - api.openai.com
       X-Stainless-Async:
@@ -126,8 +123,8 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: "{\n  \"id\": \"chatcmpl-CsxInBpnylaEhvXX0SFpw7T6pJItL\",\n  \"object\":
-        \"chat.completion\",\n  \"created\": 1767213705,\n  \"model\": \"gpt-4.1-2025-04-14\",\n
+      string: "{\n  \"id\": \"chatcmpl-DVMZMUeMNOKX2KsYALuDO38mqQoG1\",\n  \"object\":
+        \"chat.completion\",\n  \"created\": 1776367296,\n  \"model\": \"gpt-4.1-2025-04-14\",\n
         \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
         \"assistant\",\n        \"content\": \"{\\\"title\\\":\\\"Apples are tasty\\\",\\\"author\\\":\\\"Hadley
         Wickham\\\"}\",\n        \"refusal\": null,\n        \"annotations\": []\n
@@ -137,16 +134,18 @@ interactions:
         0,\n      \"audio_tokens\": 0\n    },\n    \"completion_tokens_details\":
         {\n      \"reasoning_tokens\": 0,\n      \"audio_tokens\": 0,\n      \"accepted_prediction_tokens\":
         0,\n      \"rejected_prediction_tokens\": 0\n    }\n  },\n  \"service_tier\":
-        \"default\",\n  \"system_fingerprint\": \"fp_1a2c4a5ede\"\n}\n"
+        \"default\",\n  \"system_fingerprint\": \"fp_b87589b009\"\n}\n"
     headers:
-      CF-RAY:
-      - 9b6c997918f19bf6-ORD
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9ed58dd23a01e7f4-ORD
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Wed, 31 Dec 2025 20:41:45 GMT
+      - Thu, 16 Apr 2026 19:21:36 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -159,16 +158,12 @@ interactions:
       - X-Request-ID
       alt-svc:
       - h3=":443"; ma=86400
-      cf-cache-status:
-      - DYNAMIC
       content-length:
       - '867'
       openai-processing-ms:
-      - '302'
+      - '272'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '315'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -205,7 +200,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -213,8 +208,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - __cf_bm=81iyVdKUXqmNCjJCB2IBLImU3wXlUHZUvQWNEQb5uS4-1767213704-1.0.1.1-MDuf13G3boFpPc6DHXVVQ.8RmopnEgpFi415hTmpcZGKmt62LSUkIk1AAv8U7rmciw1nCAT4.S2CtruwM9Aufhg.4.egvnHNCI74FCjbIto;
-        _cfuvid=KwmRrTnVKjpU6aNyR8l2x_JXM4Spkjbv.U3nT0KPv5s-1767213704939-0.0.1.1-604800000
+      - __cf_bm=vY8RWNmkBUeCRfZe8YRYMvsYx.rITugRVXC_t4LJET0-1776367295.4797728-1.0.1.1-dflpveJQyyAV8uCURb8Zc2MKX_OlFcvrAgNGa79MvySn5HZifBLv5W2fZj9pJtfJM.tTW_x6yd7c65x1Ni4vU5ColLZ.ji..vsSZ6Vrt32Vm9hX3IgXGBA_D0JUVicOV
       Host:
       - api.openai.com
       X-Stainless-Async:
@@ -225,8 +219,8 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: "{\n  \"id\": \"chatcmpl-CsxInjNMcC8uFSfEIzgWwyeywg28y\",\n  \"object\":
-        \"chat.completion\",\n  \"created\": 1767213705,\n  \"model\": \"gpt-4.1-2025-04-14\",\n
+      string: "{\n  \"id\": \"chatcmpl-DVMZNJfXGJlb2NwFi9aiOOI4YUthE\",\n  \"object\":
+        \"chat.completion\",\n  \"created\": 1776367297,\n  \"model\": \"gpt-4.1-2025-04-14\",\n
         \ \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\":
         \"assistant\",\n        \"content\": \"{\\\"name\\\":\\\"Sarah Lin\\\",\\\"age\\\":29}\",\n
         \       \"refusal\": null,\n        \"annotations\": []\n      },\n      \"logprobs\":
@@ -235,38 +229,38 @@ interactions:
         {\n      \"cached_tokens\": 0,\n      \"audio_tokens\": 0\n    },\n    \"completion_tokens_details\":
         {\n      \"reasoning_tokens\": 0,\n      \"audio_tokens\": 0,\n      \"accepted_prediction_tokens\":
         0,\n      \"rejected_prediction_tokens\": 0\n    }\n  },\n  \"service_tier\":
-        \"default\",\n  \"system_fingerprint\": \"fp_1a2c4a5ede\"\n}\n"
+        \"default\",\n  \"system_fingerprint\": \"fp_a900d24d78\"\n}\n"
     headers:
-      CF-RAY:
-      - 9b6c997caacf9e4c-ORD
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9ed58dd6ba8e1142-ORD
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Wed, 31 Dec 2025 20:41:46 GMT
+      - Thu, 16 Apr 2026 19:21:37 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
       - chunked
+      Vary:
+      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       access-control-expose-headers:
       - X-Request-ID
       alt-svc:
       - h3=":443"; ma=86400
-      cf-cache-status:
-      - DYNAMIC
       content-length:
       - '840'
       openai-processing-ms:
-      - '298'
+      - '340'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '313'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -303,7 +297,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -311,8 +305,8 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - __cf_bm=81iyVdKUXqmNCjJCB2IBLImU3wXlUHZUvQWNEQb5uS4-1767213704-1.0.1.1-MDuf13G3boFpPc6DHXVVQ.8RmopnEgpFi415hTmpcZGKmt62LSUkIk1AAv8U7rmciw1nCAT4.S2CtruwM9Aufhg.4.egvnHNCI74FCjbIto;
-        _cfuvid=KwmRrTnVKjpU6aNyR8l2x_JXM4Spkjbv.U3nT0KPv5s-1767213704939-0.0.1.1-604800000
+      - __cf_bm=qm.Ds9DWmQHsznXLP66Yg5Il_.LVE.08WLgB7JABjH4-1776367297-1.0.1.1-aBVjq74M9RNruJoT3PlUxLiWFFNjcB8pMdfc7dj_VKRGhJnjGlP5MbQvBSpJujV0u33teXUkiO.NwZN_zJrlFfLctkMMrV3WFn7hXViXBRc;
+        _cfuvid=8e7Mkyb8ebQQr6AlRPv8pKUQYiB8cwfAOps4FB6MJNs-1776367297559-0.0.1.1-604800000
       Host:
       - api.openai.com
       X-Stainless-Async:
@@ -323,20 +317,20 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CsxIp9MMQUMCNP0Lz4ssyWBN1MxbS","object":"chat.completion.chunk","created":1767213707,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"2rojCM3dKWbMB"}
+      string: 'data: {"id":"chatcmpl-DVMZNk1UDYcusoDBzs8CaKRqvRLIr","object":"chat.completion.chunk","created":1776367297,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_464203d4c6","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"RvFeKmjTwrD0e"}
 
 
-        data: {"id":"chatcmpl-CsxIp9MMQUMCNP0Lz4ssyWBN1MxbS","object":"chat.completion.chunk","created":1767213707,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"Sarah"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"4aKvImUtz6"}
+        data: {"id":"chatcmpl-DVMZNk1UDYcusoDBzs8CaKRqvRLIr","object":"chat.completion.chunk","created":1776367297,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_464203d4c6","choices":[{"index":0,"delta":{"content":"Sarah"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"BW5vcuwbZf"}
 
 
-        data: {"id":"chatcmpl-CsxIp9MMQUMCNP0Lz4ssyWBN1MxbS","object":"chat.completion.chunk","created":1767213707,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        Lin"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"TDd5kKYxBVv"}
+        data: {"id":"chatcmpl-DVMZNk1UDYcusoDBzs8CaKRqvRLIr","object":"chat.completion.chunk","created":1776367297,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_464203d4c6","choices":[{"index":0,"delta":{"content":"
+        Lin"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"S9eAjUW02Ln"}
 
 
-        data: {"id":"chatcmpl-CsxIp9MMQUMCNP0Lz4ssyWBN1MxbS","object":"chat.completion.chunk","created":1767213707,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"JEJurzNCm"}
+        data: {"id":"chatcmpl-DVMZNk1UDYcusoDBzs8CaKRqvRLIr","object":"chat.completion.chunk","created":1776367297,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_464203d4c6","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"ZDwIuiRQc"}
 
 
-        data: {"id":"chatcmpl-CsxIp9MMQUMCNP0Lz4ssyWBN1MxbS","object":"chat.completion.chunk","created":1767213707,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[],"usage":{"prompt_tokens":165,"completion_tokens":2,"total_tokens":167,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"ZLp2dWLoTQIew"}
+        data: {"id":"chatcmpl-DVMZNk1UDYcusoDBzs8CaKRqvRLIr","object":"chat.completion.chunk","created":1776367297,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_464203d4c6","choices":[],"usage":{"prompt_tokens":165,"completion_tokens":2,"total_tokens":167,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"p7K6J7Xz38ZGc"}
 
 
         data: [DONE]
@@ -344,14 +338,16 @@ interactions:
 
         '
     headers:
-      CF-RAY:
-      - 9b6c998008cee277-ORD
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9ed58ddb5bd30558-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:47 GMT
+      - Thu, 16 Apr 2026 19:21:38 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -364,14 +360,10 @@ interactions:
       - X-Request-ID
       alt-svc:
       - h3=":443"; ma=86400
-      cf-cache-status:
-      - DYNAMIC
       openai-processing-ms:
-      - '328'
+      - '439'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '674'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -381,7 +373,7 @@ interactions:
       x-ratelimit-remaining-requests:
       - '9999'
       x-ratelimit-remaining-tokens:
-      - '29999861'
+      - '29999862'
       x-ratelimit-reset-requests:
       - 6ms
       x-ratelimit-reset-tokens:

--- a/tests/_vcr/test_provider_openai_completions/test_openai_images.yaml
+++ b/tests/_vcr/test_provider_openai_completions/test_openai_images.yaml
@@ -8,7 +8,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -25,123 +25,84 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CsxIqggubxek8TxGxCl2rjqLUj0bA","object":"chat.completion.chunk","created":1767213708,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"HB7GB41nE5oMj"}
+      string: 'data: {"id":"chatcmpl-DVMZOBMfwmemkVrfpejRs68Vskn7j","object":"chat.completion.chunk","created":1776367298,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"1uNbOiXQNvMPh"}
 
 
-        data: {"id":"chatcmpl-CsxIqggubxek8TxGxCl2rjqLUj0bA","object":"chat.completion.chunk","created":1767213708,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"This"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"C1LFpSZ3Kgp"}
+        data: {"id":"chatcmpl-DVMZOBMfwmemkVrfpejRs68Vskn7j","object":"chat.completion.chunk","created":1776367298,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"This"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"CRubQyoryoT"}
 
 
-        data: {"id":"chatcmpl-CsxIqggubxek8TxGxCl2rjqLUj0bA","object":"chat.completion.chunk","created":1767213708,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        image"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"KDG46ubtM"}
+        data: {"id":"chatcmpl-DVMZOBMfwmemkVrfpejRs68Vskn7j","object":"chat.completion.chunk","created":1776367298,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        image"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"ve7mT1a9l"}
 
 
-        data: {"id":"chatcmpl-CsxIqggubxek8TxGxCl2rjqLUj0bA","object":"chat.completion.chunk","created":1767213708,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        is"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"ulhLo20alC67"}
+        data: {"id":"chatcmpl-DVMZOBMfwmemkVrfpejRs68Vskn7j","object":"chat.completion.chunk","created":1776367298,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        is"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Zc6teMLh5F6v"}
 
 
-        data: {"id":"chatcmpl-CsxIqggubxek8TxGxCl2rjqLUj0bA","object":"chat.completion.chunk","created":1767213708,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        a"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"zMgAWpFSOrPA9"}
+        data: {"id":"chatcmpl-DVMZOBMfwmemkVrfpejRs68Vskn7j","object":"chat.completion.chunk","created":1776367298,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        a"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"0uzQtfHfDZZr2"}
 
 
-        data: {"id":"chatcmpl-CsxIqggubxek8TxGxCl2rjqLUj0bA","object":"chat.completion.chunk","created":1767213708,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        solid"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"E1cBwPK8y"}
+        data: {"id":"chatcmpl-DVMZOBMfwmemkVrfpejRs68Vskn7j","object":"chat.completion.chunk","created":1776367298,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        solid"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"7ud5G0tww"}
 
 
-        data: {"id":"chatcmpl-CsxIqggubxek8TxGxCl2rjqLUj0bA","object":"chat.completion.chunk","created":1767213708,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        red"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"m8NelQBakyG"}
+        data: {"id":"chatcmpl-DVMZOBMfwmemkVrfpejRs68Vskn7j","object":"chat.completion.chunk","created":1776367298,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        red"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"5Pi86Csp37I"}
 
 
-        data: {"id":"chatcmpl-CsxIqggubxek8TxGxCl2rjqLUj0bA","object":"chat.completion.chunk","created":1767213708,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        rectangle"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"6BBn0"}
+        data: {"id":"chatcmpl-DVMZOBMfwmemkVrfpejRs68Vskn7j","object":"chat.completion.chunk","created":1776367298,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        rectangle"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"osbJH"}
 
 
-        data: {"id":"chatcmpl-CsxIqggubxek8TxGxCl2rjqLUj0bA","object":"chat.completion.chunk","created":1767213708,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        with"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"fDiauF25Zn"}
+        data: {"id":"chatcmpl-DVMZOBMfwmemkVrfpejRs68Vskn7j","object":"chat.completion.chunk","created":1776367298,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        with"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"l82hzo15pr"}
 
 
-        data: {"id":"chatcmpl-CsxIqggubxek8TxGxCl2rjqLUj0bA","object":"chat.completion.chunk","created":1767213708,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        no"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"gT4vD5G3qGoK"}
+        data: {"id":"chatcmpl-DVMZOBMfwmemkVrfpejRs68Vskn7j","object":"chat.completion.chunk","created":1776367298,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        no"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"tUa8n3PdmUur"}
 
 
-        data: {"id":"chatcmpl-CsxIqggubxek8TxGxCl2rjqLUj0bA","object":"chat.completion.chunk","created":1767213708,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        discern"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"SizbuQE"}
+        data: {"id":"chatcmpl-DVMZOBMfwmemkVrfpejRs68Vskn7j","object":"chat.completion.chunk","created":1776367298,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        discern"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"a3YdR4D"}
 
 
-        data: {"id":"chatcmpl-CsxIqggubxek8TxGxCl2rjqLUj0bA","object":"chat.completion.chunk","created":1767213708,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"ible"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Igsfk1VEmn9"}
+        data: {"id":"chatcmpl-DVMZOBMfwmemkVrfpejRs68Vskn7j","object":"chat.completion.chunk","created":1776367298,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"ible"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"pf2YtgIEkcH"}
 
 
-        data: {"id":"chatcmpl-CsxIqggubxek8TxGxCl2rjqLUj0bA","object":"chat.completion.chunk","created":1767213708,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        objects"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"xGCSfEz"}
+        data: {"id":"chatcmpl-DVMZOBMfwmemkVrfpejRs68Vskn7j","object":"chat.completion.chunk","created":1776367298,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        objects"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Bm8bW3v"}
 
 
-        data: {"id":"chatcmpl-CsxIqggubxek8TxGxCl2rjqLUj0bA","object":"chat.completion.chunk","created":1767213708,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"yrf6EZgsC2OaIm"}
+        data: {"id":"chatcmpl-DVMZOBMfwmemkVrfpejRs68Vskn7j","object":"chat.completion.chunk","created":1776367298,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"y8JyFxvjhOIvs7"}
 
 
-        data: {"id":"chatcmpl-CsxIqggubxek8TxGxCl2rjqLUj0bA","object":"chat.completion.chunk","created":1767213708,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        text"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Wt9s99iWnx"}
+        data: {"id":"chatcmpl-DVMZOBMfwmemkVrfpejRs68Vskn7j","object":"chat.completion.chunk","created":1776367298,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        text"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Zc5AN65tBS"}
 
 
-        data: {"id":"chatcmpl-CsxIqggubxek8TxGxCl2rjqLUj0bA","object":"chat.completion.chunk","created":1767213708,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"97Ta9yCT1LDxzS"}
+        data: {"id":"chatcmpl-DVMZOBMfwmemkVrfpejRs68Vskn7j","object":"chat.completion.chunk","created":1776367298,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"U7Zvcq4Csm91QD"}
 
 
-        data: {"id":"chatcmpl-CsxIqggubxek8TxGxCl2rjqLUj0bA","object":"chat.completion.chunk","created":1767213708,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        or"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Y8fT95Z0w32m"}
+        data: {"id":"chatcmpl-DVMZOBMfwmemkVrfpejRs68Vskn7j","object":"chat.completion.chunk","created":1776367298,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        or"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"kRZOhxVI8rRa"}
 
 
-        data: {"id":"chatcmpl-CsxIqggubxek8TxGxCl2rjqLUj0bA","object":"chat.completion.chunk","created":1767213708,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        patterns"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"NZtyJD"}
+        data: {"id":"chatcmpl-DVMZOBMfwmemkVrfpejRs68Vskn7j","object":"chat.completion.chunk","created":1776367298,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        patterns"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"hKKy8x"}
 
 
-        data: {"id":"chatcmpl-CsxIqggubxek8TxGxCl2rjqLUj0bA","object":"chat.completion.chunk","created":1767213708,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        visible"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"ewKdWdn"}
+        data: {"id":"chatcmpl-DVMZOBMfwmemkVrfpejRs68Vskn7j","object":"chat.completion.chunk","created":1776367298,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        visible"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"RPVKhp0"}
 
 
-        data: {"id":"chatcmpl-CsxIqggubxek8TxGxCl2rjqLUj0bA","object":"chat.completion.chunk","created":1767213708,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"sSWIFG3SkmMJxh"}
+        data: {"id":"chatcmpl-DVMZOBMfwmemkVrfpejRs68Vskn7j","object":"chat.completion.chunk","created":1776367298,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"jim4fa9UnhF5P5"}
 
 
-        data: {"id":"chatcmpl-CsxIqggubxek8TxGxCl2rjqLUj0bA","object":"chat.completion.chunk","created":1767213708,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        It"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"zVBkGozoGr4C"}
+        data: {"id":"chatcmpl-DVMZOBMfwmemkVrfpejRs68Vskn7j","object":"chat.completion.chunk","created":1776367298,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"qNidley1f"}
 
 
-        data: {"id":"chatcmpl-CsxIqggubxek8TxGxCl2rjqLUj0bA","object":"chat.completion.chunk","created":1767213708,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        appears"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"secKX5Y"}
-
-
-        data: {"id":"chatcmpl-CsxIqggubxek8TxGxCl2rjqLUj0bA","object":"chat.completion.chunk","created":1767213708,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        to"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"P1zsE6qaERwR"}
-
-
-        data: {"id":"chatcmpl-CsxIqggubxek8TxGxCl2rjqLUj0bA","object":"chat.completion.chunk","created":1767213708,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        be"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"LzxGlyZlFB4d"}
-
-
-        data: {"id":"chatcmpl-CsxIqggubxek8TxGxCl2rjqLUj0bA","object":"chat.completion.chunk","created":1767213708,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        a"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"DP0hb2sHOztGQ"}
-
-
-        data: {"id":"chatcmpl-CsxIqggubxek8TxGxCl2rjqLUj0bA","object":"chat.completion.chunk","created":1767213708,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        plain"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Wow88dHLS"}
-
-
-        data: {"id":"chatcmpl-CsxIqggubxek8TxGxCl2rjqLUj0bA","object":"chat.completion.chunk","created":1767213708,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        red"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"rIXS2XNkoAu"}
-
-
-        data: {"id":"chatcmpl-CsxIqggubxek8TxGxCl2rjqLUj0bA","object":"chat.completion.chunk","created":1767213708,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        color"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"jcJwgXTxo"}
-
-
-        data: {"id":"chatcmpl-CsxIqggubxek8TxGxCl2rjqLUj0bA","object":"chat.completion.chunk","created":1767213708,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        fill"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"BCTHmwYZME"}
-
-
-        data: {"id":"chatcmpl-CsxIqggubxek8TxGxCl2rjqLUj0bA","object":"chat.completion.chunk","created":1767213708,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"ETWHHuQAJl0Sps"}
-
-
-        data: {"id":"chatcmpl-CsxIqggubxek8TxGxCl2rjqLUj0bA","object":"chat.completion.chunk","created":1767213708,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"Nlns4KrsS"}
-
-
-        data: {"id":"chatcmpl-CsxIqggubxek8TxGxCl2rjqLUj0bA","object":"chat.completion.chunk","created":1767213708,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[],"usage":{"prompt_tokens":267,"completion_tokens":29,"total_tokens":296,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"n1P5rytSP4Cr"}
+        data: {"id":"chatcmpl-DVMZOBMfwmemkVrfpejRs68Vskn7j","object":"chat.completion.chunk","created":1776367298,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[],"usage":{"prompt_tokens":267,"completion_tokens":19,"total_tokens":286,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"wAcwIqGhiX1l"}
 
 
         data: [DONE]
@@ -149,14 +110,16 @@ interactions:
 
         '
     headers:
-      CF-RAY:
-      - 9b6c998b5e75eadf-ORD
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9ed58de0df73c034-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:48 GMT
+      - Thu, 16 Apr 2026 19:21:39 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -169,14 +132,10 @@ interactions:
       - X-Request-ID
       alt-svc:
       - h3=":443"; ma=86400
-      cf-cache-status:
-      - DYNAMIC
       openai-processing-ms:
-      - '465'
+      - '744'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '485'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-input-images:
@@ -210,7 +169,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -227,172 +186,340 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: "data: {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\",\"refusal\":null},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"2GrPWRvtnpRfJ\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"This\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"fqvJzLWu2vr\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        image\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"cmCu9W8rr\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        has\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"xYX3H2hVT92\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        a\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"ePoeBJDUpSCJf\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        hex\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"i6f9fxU2pKa\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"agonal\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"MihtVw3z4\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        (\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"mafQ2bkHd48ex\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"six\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"kUIuPHc5cUA0\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"-sided\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"qDwIlmsQn\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\")\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"x5uVFXll6gtRI5\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        outer\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"Es20Di7Bq\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        shape\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"bs5JDblpL\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\".\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"rl23pmqEaFb9XK\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        Inside\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"Oxgf8DFI\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\",\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"BbevSusARzeaBl\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        it\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"RU0Ar5KIgmvU\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        features\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"7CEzUd\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        a\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"DRsG6rSoSMQjz\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        styl\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"0OcJqax1s8\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"ized\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"FafHRHRiFKH\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        illustration\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"3I\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        of\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"uqqiLEhvw6FI\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        a\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"T5jrC2LYcbQJH\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        baseball\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"JkVMpg\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        player\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"2bFosk7b\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        in\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"1AxD2ZMElTLJ\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        red\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"zO56VTrd2f5\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        swinging\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"YScgu3\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        a\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"Lg7d6otZkQXx6\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        bat\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"hcbTA6gCjie\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\".\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"eA0kASteoI8QOv\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        Above\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"lykm4Me3i\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        the\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"M0Htk46UvAu\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        player\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"R8IAVsk0\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\",\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"TONHmum6P5Fw0i\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        there\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"lPkRD0egD\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        is\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"9osBLMdsEHRE\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        white\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"EUhYAMqsy\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        script\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"k1h6iiY5\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"-style\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"pDiM4h4IS\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        text\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"6jERzOLSxW\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        that\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"f2WBxohcUS\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        reads\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"m1dQ4QIsh\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        \u201C\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"52HcuBV7MDzNw\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"ht\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"UC8k9VjQTb89i\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"tr\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"2f4uhrHCpnGBA\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"2\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"oNd2zOqRYZeBA5\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"\u201D\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"WatMhtGnoD6hLc\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        with\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"FbjwRkGlVO\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        a\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"lpuE3JplH6XDt\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        swo\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"oCITyYQLiX5\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"osh\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"kp8ww0Uq42YZ\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        underneath\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"2g75\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\",\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"L9xHIYFx77Vv4g\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        reminiscent\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"L8U\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        of\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"tL7mC9ubjB1m\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        classic\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"B856LbZ\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        baseball\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"Xcy63G\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        logos\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"WUuFQ7mQ0\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\".\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"Pa9UvC2F5Opf37\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        There\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"mL5MAcI3m\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        is\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"fNojjtoRE3Ge\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        also\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"3kLmQTDnk1\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        a\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"1nkrYcIgOKRYf\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        small\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"NhML5fvIR\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        round\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"yFJoLqlBB\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        logo\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"Jm0Nn3C6Vx\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        containing\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"6Mpk\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        \\\"\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"24CGXdKuuoEq\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"www\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"iYVDfhPZhfZ6\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"\\\"\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"Ktq4cunYbqfeK\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        on\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"yuKCgD1l0kZL\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        the\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"ypY0Bmm2wo2\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        left\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"UMi0GJSvep\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        side\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"GUeqW7OB36\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\",\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"7lqFj36xNjuBPt\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        near\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"tFIc1LNSzJ\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        the\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"11qI5xZYruq\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        bat\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"ltNp6lWHSjJ\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\".\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"jcJNs7xbLjRfby\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        The\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"mNmo2vAKdVq\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        background\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"7JBe\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        color\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"k14zI7h6w\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        is\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"eaVYvpE6t2Ml\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        a\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"2IhzVyycwYybO\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        dark\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"J30ce0XKae\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        blue\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"WhhGkLFJT6\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\".\"},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"cLN4f4eafyyJdq\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{},\"logprobs\":null,\"finish_reason\":\"stop\"}],\"usage\":null,\"obfuscation\":\"WVkVkNrHN\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIs16Ljag0Tfz7EItwb0sokuudP\",\"object\":\"chat.completion.chunk\",\"created\":1767213710,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[],\"usage\":{\"prompt_tokens\":276,\"completion_tokens\":88,\"total_tokens\":364,\"prompt_tokens_details\":{\"cached_tokens\":0,\"audio_tokens\":0},\"completion_tokens_details\":{\"reasoning_tokens\":0,\"audio_tokens\":0,\"accepted_prediction_tokens\":0,\"rejected_prediction_tokens\":0}},\"obfuscation\":\"mmVYaYDpTB79\"}\n\ndata:
-        [DONE]\n\n"
+      string: 'data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"d7N3ffzNTOL7X"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"This"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"ei8xjnlgRNv"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        image"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"ci17qI526"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        has"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"3X1uBsLhEe9"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        a"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"SHukuB6nOLHKY"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        hex"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"r5FuK86LR19"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"agonal"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"SrByY3R4B"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        ("},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"QratR6j5XeXxM"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"six"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"S35AN2Lu6HQ7"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"-sided"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"FcWbt0iWl"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":")"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Bh8BoGnpObaRtp"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        outer"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Q4cRpqvTJ"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        shape"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Uxx3XRORE"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Cdi88i5cKQ0AAG"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        Inside"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"0kDM09Yq"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        the"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Sz3jQUi3eTW"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        hex"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"7X9FI4v4zTM"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"agon"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Uk9TwzcSRhl"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"UDZoWv2yCcQEQi"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        there"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"DVEQsSBju"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        is"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"JQZ6CI5jxuP4"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        an"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"pwHwOhvMWamy"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        illustration"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Ly"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        of"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"fEUmGgC2Unts"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        a"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"xUD4lXnnpxad0"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        baseball"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"vRZafa"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        player"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"HUVqgVx5"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        in"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"ut40B3euGMy6"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        red"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"ckH6XMYOxbq"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        swinging"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"p8Rlj0"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        a"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"nEnZKfRBaOAWE"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        bat"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"CZFgQn7bqVr"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Ls1OnHzmzYQNeQ"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        Above"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"DSOtrtSPf"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        the"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"HgOGRCpVFXS"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        player"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"g2usMNxb"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"tEnDH7nTWxOwsI"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        the"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Afcw5fzVwoV"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        text"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"pj59RnOSS5"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"9ZNOlF5sKCak"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"ht"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"4238L9duoVn1o"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"tr"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"cvQt1vycT7euV"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"2"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"ZTYpxSIg43Ubt3"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"\""},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"dn8Mhg0Yibxnr"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        is"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"2NRfTXAlBSiK"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        written"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"p5prF5G"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        in"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"fyQ6I5gcpaiW"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        a"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"JVNrS3R7KzTVA"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        white"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"TN3sphBRb"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"otF0OiGDfDyB9b"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        styl"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"HkDLNSXdrN"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"ized"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"m1EFxh5e5bl"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        font"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"SW0PQ6g9OV"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Ifa3qrBeEcRZTh"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        There"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"JXhhgZD1t"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        is"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"5Y8lvEhKvd3q"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        also"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"6ZoDf9U3qI"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        a"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"yVrPUTfmLyEv1"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        small"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"uBla3hvoL"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        red"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"UxopT7JZPQC"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        circle"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"pAE8z5cf"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        with"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"dG5WpC7odc"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"8aJtUptYc6fo"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"www"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"t9SmWAkv6Tmy"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"\""},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"ixnAgoa3kUIK9"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        written"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"akfHc7V"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        inside"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"m6pKnZG3"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        it"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"KdjVz1BcHnR4"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        near"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"RBwZgu6XBZ"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        the"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"xnjcyo0W30U"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        center"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"h4pK2LgJ"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"-left"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"5kMnPCENJP"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        of"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"jBpXDQJnd8Jp"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        the"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"K5A5vIXam3E"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        image"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"5ZNaYoOkD"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"mcFVhyzXac9tOp"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        The"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"aamantIxsO4"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        background"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"FR8g"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        is"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"1sWrDzZUXbLy"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        a"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"LK6rCDHmdRMOU"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        dark"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"AzQXZLf0H9"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        blue"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Dtvr2flmCd"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        color"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"5V2wxfOBd"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"dvLeXnG3KAmrZr"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"FB9F7ez0E"}
+
+
+        data: {"id":"chatcmpl-DVMZQNhjntLijyWhNkPaA3JfuBIX6","object":"chat.completion.chunk","created":1776367300,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[],"usage":{"prompt_tokens":276,"completion_tokens":83,"total_tokens":359,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"0hQURFksfhj2"}
+
+
+        data: [DONE]
+
+
+        '
     headers:
-      CF-RAY:
-      - 9b6c99930e8a86d2-ORD
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9ed58de9597132fd-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:51 GMT
+      - Thu, 16 Apr 2026 19:21:40 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -405,14 +532,10 @@ interactions:
       - X-Request-ID
       alt-svc:
       - h3=":443"; ma=86400
-      cf-cache-status:
-      - DYNAMIC
       openai-processing-ms:
-      - '1850'
+      - '867'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '1869'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-input-images:

--- a/tests/_vcr/test_provider_openai_completions/test_openai_list_models.yaml
+++ b/tests/_vcr/test_provider_openai_completions/test_openai_list_models.yaml
@@ -5,7 +5,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Host:
@@ -24,30 +24,27 @@ interactions:
         \     \"created\": 1687882411,\n      \"owned_by\": \"openai\"\n    },\n    {\n
         \     \"id\": \"gpt-3.5-turbo\",\n      \"object\": \"model\",\n      \"created\":
         1677610602,\n      \"owned_by\": \"openai\"\n    },\n    {\n      \"id\":
-        \"chatgpt-image-latest\",\n      \"object\": \"model\",\n      \"created\":
-        1765925279,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"gpt-4o-mini-tts-2025-03-20\",\n      \"object\": \"model\",\n      \"created\":
-        1765610731,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"gpt-4o-mini-tts-2025-12-15\",\n      \"object\": \"model\",\n      \"created\":
-        1765610837,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"gpt-realtime-mini-2025-12-15\",\n      \"object\": \"model\",\n      \"created\":
-        1765612007,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"gpt-audio-mini-2025-12-15\",\n      \"object\": \"model\",\n      \"created\":
-        1765760008,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"davinci-002\",\n      \"object\": \"model\",\n      \"created\": 1692634301,\n
-        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"babbage-002\",\n
-        \     \"object\": \"model\",\n      \"created\": 1692634615,\n      \"owned_by\":
-        \"system\"\n    },\n    {\n      \"id\": \"gpt-3.5-turbo-instruct\",\n      \"object\":
-        \"model\",\n      \"created\": 1692901427,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"gpt-3.5-turbo-instruct-0914\",\n      \"object\":
-        \"model\",\n      \"created\": 1694122472,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"dall-e-3\",\n      \"object\": \"model\",\n
-        \     \"created\": 1698785189,\n      \"owned_by\": \"system\"\n    },\n    {\n
-        \     \"id\": \"dall-e-2\",\n      \"object\": \"model\",\n      \"created\":
-        1698798177,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"gpt-4-1106-preview\",\n      \"object\": \"model\",\n      \"created\":
-        1698957206,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"gpt-3.5-turbo-1106\",\n      \"object\": \"model\",\n      \"created\":
+        \"gpt-5.4-mini\",\n      \"object\": \"model\",\n      \"created\": 1773451123,\n
+        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"gpt-5.4\",\n
+        \     \"object\": \"model\",\n      \"created\": 1772691852,\n      \"owned_by\":
+        \"system\"\n    },\n    {\n      \"id\": \"gpt-5.4-nano-2026-03-17\",\n      \"object\":
+        \"model\",\n      \"created\": 1773450837,\n      \"owned_by\": \"system\"\n
+        \   },\n    {\n      \"id\": \"gpt-5.4-nano\",\n      \"object\": \"model\",\n
+        \     \"created\": 1773450870,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"gpt-5.4-mini-2026-03-17\",\n      \"object\": \"model\",\n
+        \     \"created\": 1773451076,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"davinci-002\",\n      \"object\": \"model\",\n      \"created\":
+        1692634301,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"babbage-002\",\n      \"object\": \"model\",\n      \"created\": 1692634615,\n
+        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"gpt-3.5-turbo-instruct\",\n
+        \     \"object\": \"model\",\n      \"created\": 1692901427,\n      \"owned_by\":
+        \"system\"\n    },\n    {\n      \"id\": \"gpt-3.5-turbo-instruct-0914\",\n
+        \     \"object\": \"model\",\n      \"created\": 1694122472,\n      \"owned_by\":
+        \"system\"\n    },\n    {\n      \"id\": \"dall-e-3\",\n      \"object\":
+        \"model\",\n      \"created\": 1698785189,\n      \"owned_by\": \"system\"\n
+        \   },\n    {\n      \"id\": \"dall-e-2\",\n      \"object\": \"model\",\n
+        \     \"created\": 1698798177,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"gpt-3.5-turbo-1106\",\n      \"object\": \"model\",\n      \"created\":
         1698959748,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
         \"tts-1-hd\",\n      \"object\": \"model\",\n      \"created\": 1699046015,\n
         \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"tts-1-1106\",\n
@@ -58,64 +55,54 @@ interactions:
         \"model\",\n      \"created\": 1705948997,\n      \"owned_by\": \"system\"\n
         \   },\n    {\n      \"id\": \"text-embedding-3-large\",\n      \"object\":
         \"model\",\n      \"created\": 1705953180,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"gpt-4-0125-preview\",\n      \"object\": \"model\",\n
-        \     \"created\": 1706037612,\n      \"owned_by\": \"system\"\n    },\n    {\n
-        \     \"id\": \"gpt-4-turbo-preview\",\n      \"object\": \"model\",\n      \"created\":
-        1706037777,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"gpt-3.5-turbo-0125\",\n      \"object\": \"model\",\n      \"created\":
-        1706048358,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"gpt-4-turbo\",\n      \"object\": \"model\",\n      \"created\": 1712361441,\n
-        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"gpt-4-turbo-2024-04-09\",\n
-        \     \"object\": \"model\",\n      \"created\": 1712601677,\n      \"owned_by\":
-        \"system\"\n    },\n    {\n      \"id\": \"gpt-4o\",\n      \"object\": \"model\",\n
-        \     \"created\": 1715367049,\n      \"owned_by\": \"system\"\n    },\n    {\n
-        \     \"id\": \"gpt-4o-2024-05-13\",\n      \"object\": \"model\",\n      \"created\":
-        1715368132,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"gpt-4o-mini-2024-07-18\",\n      \"object\": \"model\",\n      \"created\":
-        1721172717,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"gpt-4o-mini\",\n      \"object\": \"model\",\n      \"created\": 1721172741,\n
-        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"gpt-4o-2024-08-06\",\n
-        \     \"object\": \"model\",\n      \"created\": 1722814719,\n      \"owned_by\":
-        \"system\"\n    },\n    {\n      \"id\": \"chatgpt-4o-latest\",\n      \"object\":
-        \"model\",\n      \"created\": 1723515131,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"gpt-4o-audio-preview\",\n      \"object\":
-        \"model\",\n      \"created\": 1727460443,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"gpt-4o-realtime-preview\",\n      \"object\":
-        \"model\",\n      \"created\": 1727659998,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"omni-moderation-latest\",\n      \"object\":
-        \"model\",\n      \"created\": 1731689265,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"omni-moderation-2024-09-26\",\n      \"object\":
-        \"model\",\n      \"created\": 1732734466,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"gpt-4o-realtime-preview-2024-12-17\",\n      \"object\":
-        \"model\",\n      \"created\": 1733945430,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"gpt-4o-audio-preview-2024-12-17\",\n      \"object\":
-        \"model\",\n      \"created\": 1734034239,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"gpt-4o-mini-realtime-preview-2024-12-17\",\n
-        \     \"object\": \"model\",\n      \"created\": 1734112601,\n      \"owned_by\":
-        \"system\"\n    },\n    {\n      \"id\": \"gpt-4o-mini-audio-preview-2024-12-17\",\n
-        \     \"object\": \"model\",\n      \"created\": 1734115920,\n      \"owned_by\":
-        \"system\"\n    },\n    {\n      \"id\": \"o1-2024-12-17\",\n      \"object\":
-        \"model\",\n      \"created\": 1734326976,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"o1\",\n      \"object\": \"model\",\n      \"created\":
-        1734375816,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"gpt-4o-mini-realtime-preview\",\n      \"object\": \"model\",\n      \"created\":
-        1734387380,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"gpt-4o-mini-audio-preview\",\n      \"object\": \"model\",\n      \"created\":
-        1734387424,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"computer-use-preview\",\n      \"object\": \"model\",\n      \"created\":
-        1734655677,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"o3-mini\",\n      \"object\": \"model\",\n      \"created\": 1737146383,\n
-        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"o3-mini-2025-01-31\",\n
-        \     \"object\": \"model\",\n      \"created\": 1738010200,\n      \"owned_by\":
-        \"system\"\n    },\n    {\n      \"id\": \"gpt-4o-2024-11-20\",\n      \"object\":
-        \"model\",\n      \"created\": 1739331543,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"computer-use-preview-2025-03-11\",\n      \"object\":
-        \"model\",\n      \"created\": 1741377021,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"gpt-4o-search-preview-2025-03-11\",\n      \"object\":
-        \"model\",\n      \"created\": 1741388170,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"gpt-4o-search-preview\",\n      \"object\":
-        \"model\",\n      \"created\": 1741388720,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"gpt-4o-mini-search-preview-2025-03-11\",\n
+        \   },\n    {\n      \"id\": \"gpt-3.5-turbo-0125\",\n      \"object\": \"model\",\n
+        \     \"created\": 1706048358,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"gpt-4-turbo\",\n      \"object\": \"model\",\n      \"created\":
+        1712361441,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-4-turbo-2024-04-09\",\n      \"object\": \"model\",\n      \"created\":
+        1712601677,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-4o\",\n      \"object\": \"model\",\n      \"created\": 1715367049,\n
+        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"gpt-4o-2024-05-13\",\n
+        \     \"object\": \"model\",\n      \"created\": 1715368132,\n      \"owned_by\":
+        \"system\"\n    },\n    {\n      \"id\": \"gpt-4o-mini-2024-07-18\",\n      \"object\":
+        \"model\",\n      \"created\": 1721172717,\n      \"owned_by\": \"system\"\n
+        \   },\n    {\n      \"id\": \"gpt-4o-mini\",\n      \"object\": \"model\",\n
+        \     \"created\": 1721172741,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"gpt-4o-2024-08-06\",\n      \"object\": \"model\",\n      \"created\":
+        1722814719,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-4o-audio-preview\",\n      \"object\": \"model\",\n      \"created\":
+        1727460443,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-4o-realtime-preview\",\n      \"object\": \"model\",\n      \"created\":
+        1727659998,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"omni-moderation-latest\",\n      \"object\": \"model\",\n      \"created\":
+        1731689265,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"omni-moderation-2024-09-26\",\n      \"object\": \"model\",\n      \"created\":
+        1732734466,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-4o-realtime-preview-2024-12-17\",\n      \"object\": \"model\",\n      \"created\":
+        1733945430,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-4o-audio-preview-2024-12-17\",\n      \"object\": \"model\",\n      \"created\":
+        1734034239,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-4o-mini-realtime-preview-2024-12-17\",\n      \"object\": \"model\",\n
+        \     \"created\": 1734112601,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"gpt-4o-mini-audio-preview-2024-12-17\",\n      \"object\":
+        \"model\",\n      \"created\": 1734115920,\n      \"owned_by\": \"system\"\n
+        \   },\n    {\n      \"id\": \"o1-2024-12-17\",\n      \"object\": \"model\",\n
+        \     \"created\": 1734326976,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"o1\",\n      \"object\": \"model\",\n      \"created\": 1734375816,\n
+        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"gpt-4o-mini-realtime-preview\",\n
+        \     \"object\": \"model\",\n      \"created\": 1734387380,\n      \"owned_by\":
+        \"system\"\n    },\n    {\n      \"id\": \"gpt-4o-mini-audio-preview\",\n
+        \     \"object\": \"model\",\n      \"created\": 1734387424,\n      \"owned_by\":
+        \"system\"\n    },\n    {\n      \"id\": \"computer-use-preview\",\n      \"object\":
+        \"model\",\n      \"created\": 1734655677,\n      \"owned_by\": \"system\"\n
+        \   },\n    {\n      \"id\": \"o3-mini\",\n      \"object\": \"model\",\n
+        \     \"created\": 1737146383,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"o3-mini-2025-01-31\",\n      \"object\": \"model\",\n      \"created\":
+        1738010200,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-4o-2024-11-20\",\n      \"object\": \"model\",\n      \"created\": 1739331543,\n
+        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"computer-use-preview-2025-03-11\",\n
+        \     \"object\": \"model\",\n      \"created\": 1741377021,\n      \"owned_by\":
+        \"system\"\n    },\n    {\n      \"id\": \"gpt-4o-mini-search-preview-2025-03-11\",\n
         \     \"object\": \"model\",\n      \"created\": 1741390858,\n      \"owned_by\":
         \"system\"\n    },\n    {\n      \"id\": \"gpt-4o-mini-search-preview\",\n
         \     \"object\": \"model\",\n      \"created\": 1741391161,\n      \"owned_by\":
@@ -148,81 +135,80 @@ interactions:
         \"gpt-4.1-nano\",\n      \"object\": \"model\",\n      \"created\": 1744321707,\n
         \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"gpt-image-1\",\n
         \     \"object\": \"model\",\n      \"created\": 1745517030,\n      \"owned_by\":
-        \"system\"\n    },\n    {\n      \"id\": \"codex-mini-latest\",\n      \"object\":
-        \"model\",\n      \"created\": 1746673257,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"o3-pro\",\n      \"object\": \"model\",\n      \"created\":
-        1748475349,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"gpt-4o-realtime-preview-2025-06-03\",\n      \"object\": \"model\",\n      \"created\":
-        1748907838,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"gpt-4o-audio-preview-2025-06-03\",\n      \"object\": \"model\",\n      \"created\":
-        1748908498,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"o3-pro-2025-06-10\",\n      \"object\": \"model\",\n      \"created\": 1749166761,\n
-        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"o4-mini-deep-research\",\n
-        \     \"object\": \"model\",\n      \"created\": 1749685485,\n      \"owned_by\":
-        \"system\"\n    },\n    {\n      \"id\": \"o3-deep-research\",\n      \"object\":
-        \"model\",\n      \"created\": 1749840121,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"gpt-4o-transcribe-diarize\",\n      \"object\":
-        \"model\",\n      \"created\": 1750798887,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"o3-deep-research-2025-06-26\",\n      \"object\":
-        \"model\",\n      \"created\": 1750865219,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"o4-mini-deep-research-2025-06-26\",\n      \"object\":
-        \"model\",\n      \"created\": 1750866121,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"gpt-5-chat-latest\",\n      \"object\": \"model\",\n
-        \     \"created\": 1754073306,\n      \"owned_by\": \"system\"\n    },\n    {\n
-        \     \"id\": \"gpt-5-2025-08-07\",\n      \"object\": \"model\",\n      \"created\":
-        1754075360,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"gpt-5\",\n      \"object\": \"model\",\n      \"created\": 1754425777,\n
-        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"gpt-5-mini-2025-08-07\",\n
-        \     \"object\": \"model\",\n      \"created\": 1754425867,\n      \"owned_by\":
-        \"system\"\n    },\n    {\n      \"id\": \"gpt-5-mini\",\n      \"object\":
-        \"model\",\n      \"created\": 1754425928,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"gpt-5-nano-2025-08-07\",\n      \"object\":
-        \"model\",\n      \"created\": 1754426303,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"gpt-5-nano\",\n      \"object\": \"model\",\n
-        \     \"created\": 1754426384,\n      \"owned_by\": \"system\"\n    },\n    {\n
-        \     \"id\": \"gpt-audio-2025-08-28\",\n      \"object\": \"model\",\n      \"created\":
-        1756256146,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"gpt-realtime\",\n      \"object\": \"model\",\n      \"created\": 1756271701,\n
-        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"gpt-realtime-2025-08-28\",\n
-        \     \"object\": \"model\",\n      \"created\": 1756271773,\n      \"owned_by\":
-        \"system\"\n    },\n    {\n      \"id\": \"gpt-audio\",\n      \"object\":
-        \"model\",\n      \"created\": 1756339249,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"gpt-5-codex\",\n      \"object\": \"model\",\n
-        \     \"created\": 1757527818,\n      \"owned_by\": \"system\"\n    },\n    {\n
-        \     \"id\": \"gpt-image-1-mini\",\n      \"object\": \"model\",\n      \"created\":
-        1758845821,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"gpt-5-pro-2025-10-06\",\n      \"object\": \"model\",\n      \"created\":
-        1759469707,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"gpt-5-pro\",\n      \"object\": \"model\",\n      \"created\": 1759469822,\n
-        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"gpt-audio-mini\",\n
-        \     \"object\": \"model\",\n      \"created\": 1759512027,\n      \"owned_by\":
-        \"system\"\n    },\n    {\n      \"id\": \"gpt-audio-mini-2025-10-06\",\n
-        \     \"object\": \"model\",\n      \"created\": 1759512137,\n      \"owned_by\":
-        \"system\"\n    },\n    {\n      \"id\": \"gpt-5-search-api\",\n      \"object\":
-        \"model\",\n      \"created\": 1759514629,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"gpt-realtime-mini\",\n      \"object\": \"model\",\n
-        \     \"created\": 1759517133,\n      \"owned_by\": \"system\"\n    },\n    {\n
-        \     \"id\": \"gpt-realtime-mini-2025-10-06\",\n      \"object\": \"model\",\n
-        \     \"created\": 1759517175,\n      \"owned_by\": \"system\"\n    },\n    {\n
-        \     \"id\": \"sora-2\",\n      \"object\": \"model\",\n      \"created\":
-        1759708615,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"sora-2-pro\",\n      \"object\": \"model\",\n      \"created\": 1759708663,\n
-        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"gpt-5-search-api-2025-10-14\",\n
-        \     \"object\": \"model\",\n      \"created\": 1760043960,\n      \"owned_by\":
-        \"system\"\n    },\n    {\n      \"id\": \"gpt-5.1-chat-latest\",\n      \"object\":
-        \"model\",\n      \"created\": 1762547951,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"gpt-5.1-2025-11-13\",\n      \"object\": \"model\",\n
-        \     \"created\": 1762800353,\n      \"owned_by\": \"system\"\n    },\n    {\n
-        \     \"id\": \"gpt-5.1\",\n      \"object\": \"model\",\n      \"created\":
-        1762800673,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
-        \"gpt-5.1-codex\",\n      \"object\": \"model\",\n      \"created\": 1762988221,\n
-        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"gpt-5.1-codex-mini\",\n
-        \     \"object\": \"model\",\n      \"created\": 1763007109,\n      \"owned_by\":
-        \"system\"\n    },\n    {\n      \"id\": \"gpt-5.1-codex-max\",\n      \"object\":
-        \"model\",\n      \"created\": 1763671532,\n      \"owned_by\": \"system\"\n
-        \   },\n    {\n      \"id\": \"gpt-image-1.5\",\n      \"object\": \"model\",\n
-        \     \"created\": 1764030620,\n      \"owned_by\": \"system\"\n    },\n    {\n
-        \     \"id\": \"gpt-5.2-2025-12-11\",\n      \"object\": \"model\",\n      \"created\":
+        \"system\"\n    },\n    {\n      \"id\": \"o3-pro\",\n      \"object\": \"model\",\n
+        \     \"created\": 1748475349,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"gpt-4o-realtime-preview-2025-06-03\",\n      \"object\": \"model\",\n
+        \     \"created\": 1748907838,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"gpt-4o-audio-preview-2025-06-03\",\n      \"object\": \"model\",\n
+        \     \"created\": 1748908498,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"o3-pro-2025-06-10\",\n      \"object\": \"model\",\n      \"created\":
+        1749166761,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"o4-mini-deep-research\",\n      \"object\": \"model\",\n      \"created\":
+        1749685485,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"o3-deep-research\",\n      \"object\": \"model\",\n      \"created\": 1749840121,\n
+        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"gpt-4o-transcribe-diarize\",\n
+        \     \"object\": \"model\",\n      \"created\": 1750798887,\n      \"owned_by\":
+        \"system\"\n    },\n    {\n      \"id\": \"o3-deep-research-2025-06-26\",\n
+        \     \"object\": \"model\",\n      \"created\": 1750865219,\n      \"owned_by\":
+        \"system\"\n    },\n    {\n      \"id\": \"o4-mini-deep-research-2025-06-26\",\n
+        \     \"object\": \"model\",\n      \"created\": 1750866121,\n      \"owned_by\":
+        \"system\"\n    },\n    {\n      \"id\": \"gpt-5-chat-latest\",\n      \"object\":
+        \"model\",\n      \"created\": 1754073306,\n      \"owned_by\": \"system\"\n
+        \   },\n    {\n      \"id\": \"gpt-5-2025-08-07\",\n      \"object\": \"model\",\n
+        \     \"created\": 1754075360,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"gpt-5\",\n      \"object\": \"model\",\n      \"created\":
+        1754425777,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-5-mini-2025-08-07\",\n      \"object\": \"model\",\n      \"created\":
+        1754425867,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-5-mini\",\n      \"object\": \"model\",\n      \"created\": 1754425928,\n
+        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"gpt-5-nano-2025-08-07\",\n
+        \     \"object\": \"model\",\n      \"created\": 1754426303,\n      \"owned_by\":
+        \"system\"\n    },\n    {\n      \"id\": \"gpt-5-nano\",\n      \"object\":
+        \"model\",\n      \"created\": 1754426384,\n      \"owned_by\": \"system\"\n
+        \   },\n    {\n      \"id\": \"gpt-audio-2025-08-28\",\n      \"object\":
+        \"model\",\n      \"created\": 1756256146,\n      \"owned_by\": \"system\"\n
+        \   },\n    {\n      \"id\": \"gpt-realtime\",\n      \"object\": \"model\",\n
+        \     \"created\": 1756271701,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"gpt-realtime-2025-08-28\",\n      \"object\": \"model\",\n
+        \     \"created\": 1756271773,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"gpt-audio\",\n      \"object\": \"model\",\n      \"created\":
+        1756339249,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-5-codex\",\n      \"object\": \"model\",\n      \"created\": 1757527818,\n
+        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"gpt-image-1-mini\",\n
+        \     \"object\": \"model\",\n      \"created\": 1758845821,\n      \"owned_by\":
+        \"system\"\n    },\n    {\n      \"id\": \"gpt-5-pro-2025-10-06\",\n      \"object\":
+        \"model\",\n      \"created\": 1759469707,\n      \"owned_by\": \"system\"\n
+        \   },\n    {\n      \"id\": \"gpt-5-pro\",\n      \"object\": \"model\",\n
+        \     \"created\": 1759469822,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"gpt-audio-mini\",\n      \"object\": \"model\",\n      \"created\":
+        1759512027,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-audio-mini-2025-10-06\",\n      \"object\": \"model\",\n      \"created\":
+        1759512137,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-5-search-api\",\n      \"object\": \"model\",\n      \"created\": 1759514629,\n
+        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"gpt-realtime-mini\",\n
+        \     \"object\": \"model\",\n      \"created\": 1759517133,\n      \"owned_by\":
+        \"system\"\n    },\n    {\n      \"id\": \"gpt-realtime-mini-2025-10-06\",\n
+        \     \"object\": \"model\",\n      \"created\": 1759517175,\n      \"owned_by\":
+        \"system\"\n    },\n    {\n      \"id\": \"sora-2\",\n      \"object\": \"model\",\n
+        \     \"created\": 1759708615,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"sora-2-pro\",\n      \"object\": \"model\",\n      \"created\":
+        1759708663,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-5-search-api-2025-10-14\",\n      \"object\": \"model\",\n      \"created\":
+        1760043960,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-5.1-chat-latest\",\n      \"object\": \"model\",\n      \"created\":
+        1762547951,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-5.1-2025-11-13\",\n      \"object\": \"model\",\n      \"created\":
+        1762800353,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-5.1\",\n      \"object\": \"model\",\n      \"created\": 1762800673,\n
+        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"gpt-5.1-codex\",\n
+        \     \"object\": \"model\",\n      \"created\": 1762988221,\n      \"owned_by\":
+        \"system\"\n    },\n    {\n      \"id\": \"gpt-5.1-codex-mini\",\n      \"object\":
+        \"model\",\n      \"created\": 1763007109,\n      \"owned_by\": \"system\"\n
+        \   },\n    {\n      \"id\": \"gpt-5.1-codex-max\",\n      \"object\": \"model\",\n
+        \     \"created\": 1763671532,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"gpt-image-1.5\",\n      \"object\": \"model\",\n      \"created\":
+        1764030620,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-5.2-2025-12-11\",\n      \"object\": \"model\",\n      \"created\":
         1765313028,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
         \"gpt-5.2\",\n      \"object\": \"model\",\n      \"created\": 1765313051,\n
         \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"gpt-5.2-pro-2025-12-11\",\n
@@ -235,25 +221,55 @@ interactions:
         \     \"created\": 1765610407,\n      \"owned_by\": \"system\"\n    },\n    {\n
         \     \"id\": \"gpt-4o-mini-transcribe-2025-03-20\",\n      \"object\": \"model\",\n
         \     \"created\": 1765610545,\n      \"owned_by\": \"system\"\n    },\n    {\n
-        \     \"id\": \"gpt-3.5-turbo-16k\",\n      \"object\": \"model\",\n      \"created\":
-        1683758102,\n      \"owned_by\": \"openai-internal\"\n    },\n    {\n      \"id\":
-        \"tts-1\",\n      \"object\": \"model\",\n      \"created\": 1681940951,\n
-        \     \"owned_by\": \"openai-internal\"\n    },\n    {\n      \"id\": \"whisper-1\",\n
-        \     \"object\": \"model\",\n      \"created\": 1677532384,\n      \"owned_by\":
-        \"openai-internal\"\n    },\n    {\n      \"id\": \"text-embedding-ada-002\",\n
+        \     \"id\": \"gpt-4o-mini-tts-2025-03-20\",\n      \"object\": \"model\",\n
+        \     \"created\": 1765610731,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"gpt-4o-mini-tts-2025-12-15\",\n      \"object\": \"model\",\n
+        \     \"created\": 1765610837,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"gpt-realtime-mini-2025-12-15\",\n      \"object\": \"model\",\n
+        \     \"created\": 1765612007,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"gpt-audio-mini-2025-12-15\",\n      \"object\": \"model\",\n
+        \     \"created\": 1765760008,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"chatgpt-image-latest\",\n      \"object\": \"model\",\n      \"created\":
+        1765925279,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-5.2-codex\",\n      \"object\": \"model\",\n      \"created\": 1766164985,\n
+        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"gpt-5.3-codex\",\n
+        \     \"object\": \"model\",\n      \"created\": 1770537915,\n      \"owned_by\":
+        \"system\"\n    },\n    {\n      \"id\": \"gpt-realtime-1.5\",\n      \"object\":
+        \"model\",\n      \"created\": 1771461469,\n      \"owned_by\": \"system\"\n
+        \   },\n    {\n      \"id\": \"gpt-audio-1.5\",\n      \"object\": \"model\",\n
+        \     \"created\": 1771550885,\n      \"owned_by\": \"system\"\n    },\n    {\n
+        \     \"id\": \"gpt-4o-search-preview\",\n      \"object\": \"model\",\n      \"created\":
+        1771905534,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-4o-search-preview-2025-03-11\",\n      \"object\": \"model\",\n      \"created\":
+        1771905621,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-5.3-chat-latest\",\n      \"object\": \"model\",\n      \"created\":
+        1772236571,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-5.4-2026-03-05\",\n      \"object\": \"model\",\n      \"created\":
+        1772654062,\n      \"owned_by\": \"system\"\n    },\n    {\n      \"id\":
+        \"gpt-5.4-pro\",\n      \"object\": \"model\",\n      \"created\": 1772659601,\n
+        \     \"owned_by\": \"system\"\n    },\n    {\n      \"id\": \"gpt-5.4-pro-2026-03-05\",\n
+        \     \"object\": \"model\",\n      \"created\": 1772659657,\n      \"owned_by\":
+        \"system\"\n    },\n    {\n      \"id\": \"gpt-3.5-turbo-16k\",\n      \"object\":
+        \"model\",\n      \"created\": 1683758102,\n      \"owned_by\": \"openai-internal\"\n
+        \   },\n    {\n      \"id\": \"tts-1\",\n      \"object\": \"model\",\n      \"created\":
+        1681940951,\n      \"owned_by\": \"openai-internal\"\n    },\n    {\n      \"id\":
+        \"whisper-1\",\n      \"object\": \"model\",\n      \"created\": 1677532384,\n
+        \     \"owned_by\": \"openai-internal\"\n    },\n    {\n      \"id\": \"text-embedding-ada-002\",\n
         \     \"object\": \"model\",\n      \"created\": 1671217299,\n      \"owned_by\":
         \"openai-internal\"\n    }\n  ]\n}"
     headers:
       CF-RAY:
-      - 9b6c99c26e0bf851-ORD
+      - 9ed58e156c3575e4-ORD
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Date:
-      - Wed, 31 Dec 2025 20:41:57 GMT
+      - Thu, 16 Apr 2026 19:21:47 GMT
       Server:
       - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
       - chunked
       X-Content-Type-Options:
@@ -263,15 +279,11 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       content-length:
-      - '15424'
+      - '16417'
       openai-processing-ms:
-      - '298'
+      - '154'
       openai-version:
       - '2020-10-01'
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains; preload
-      x-envoy-upstream-service-time:
-      - '300'
       x-openai-proxy-wasm:
       - v0.1
     status:

--- a/tests/_vcr/test_provider_openai_completions/test_openai_logprobs.yaml
+++ b/tests/_vcr/test_provider_openai_completions/test_openai_logprobs.yaml
@@ -7,7 +7,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -24,56 +24,56 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: "data: {\"id\":\"chatcmpl-CsxIvHy9zaFaJz2Gf8MhW2PG0Zy3X\",\"object\":\"chat.completion.chunk\",\"created\":1767213713,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\",\"refusal\":null},\"logprobs\":{\"content\":[],\"refusal\":null},\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"9GS6\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIvHy9zaFaJz2Gf8MhW2PG0Zy3X\",\"object\":\"chat.completion.chunk\",\"created\":1767213713,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"},\"logprobs\":{\"content\":[{\"token\":\"Hello\",\"logprob\":-0.004078401252627373,\"bytes\":[72,101,108,108,111],\"top_logprobs\":[]}],\"refusal\":null},\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"h\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIvHy9zaFaJz2Gf8MhW2PG0Zy3X\",\"object\":\"chat.completion.chunk\",\"created\":1767213713,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"!\"},\"logprobs\":{\"content\":[{\"token\":\"!\",\"logprob\":-7.941850526549388e-6,\"bytes\":[33],\"top_logprobs\":[]}],\"refusal\":null},\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"DRkJRkrQs\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIvHy9zaFaJz2Gf8MhW2PG0Zy3X\",\"object\":\"chat.completion.chunk\",\"created\":1767213713,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        How\"},\"logprobs\":{\"content\":[{\"token\":\" How\",\"logprob\":-0.0020377261098474264,\"bytes\":[32,72,111,119],\"top_logprobs\":[]}],\"refusal\":null},\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"xnfmp1B\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIvHy9zaFaJz2Gf8MhW2PG0Zy3X\",\"object\":\"chat.completion.chunk\",\"created\":1767213713,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        can\"},\"logprobs\":{\"content\":[{\"token\":\" can\",\"logprob\":0.0,\"bytes\":[32,99,97,110],\"top_logprobs\":[]}],\"refusal\":null},\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"ReAgNQQvEdJ\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIvHy9zaFaJz2Gf8MhW2PG0Zy3X\",\"object\":\"chat.completion.chunk\",\"created\":1767213713,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        I\"},\"logprobs\":{\"content\":[{\"token\":\" I\",\"logprob\":0.0,\"bytes\":[32,73],\"top_logprobs\":[]}],\"refusal\":null},\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"5zevjh\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIvHy9zaFaJz2Gf8MhW2PG0Zy3X\",\"object\":\"chat.completion.chunk\",\"created\":1767213713,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        help\"},\"logprobs\":{\"content\":[{\"token\":\" help\",\"logprob\":-0.02324547804892063,\"bytes\":[32,104,101,108,112],\"top_logprobs\":[]}],\"refusal\":null},\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"gf\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIvHy9zaFaJz2Gf8MhW2PG0Zy3X\",\"object\":\"chat.completion.chunk\",\"created\":1767213713,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        you\"},\"logprobs\":{\"content\":[{\"token\":\" you\",\"logprob\":0.0,\"bytes\":[32,121,111,117],\"top_logprobs\":[]}],\"refusal\":null},\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"8VeVqiMm8\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIvHy9zaFaJz2Gf8MhW2PG0Zy3X\",\"object\":\"chat.completion.chunk\",\"created\":1767213713,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        today\"},\"logprobs\":{\"content\":[{\"token\":\" today\",\"logprob\":0.0,\"bytes\":[32,116,111,100,97,121],\"top_logprobs\":[]}],\"refusal\":null},\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"yhFrqizX7Huf5G\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIvHy9zaFaJz2Gf8MhW2PG0Zy3X\",\"object\":\"chat.completion.chunk\",\"created\":1767213713,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"?\"},\"logprobs\":{\"content\":[{\"token\":\"?\",\"logprob\":-7.896309739408025e-7,\"bytes\":[63],\"top_logprobs\":[]}],\"refusal\":null},\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"e61LfXKit\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIvHy9zaFaJz2Gf8MhW2PG0Zy3X\",\"object\":\"chat.completion.chunk\",\"created\":1767213713,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
-        \U0001F60A\"},\"logprobs\":{\"content\":[{\"token\":\" \U0001F60A\",\"logprob\":-0.16023895144462585,\"bytes\":[32,240,159,152,138],\"top_logprobs\":[]}],\"refusal\":null},\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"QkrUKkic\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIvHy9zaFaJz2Gf8MhW2PG0Zy3X\",\"object\":\"chat.completion.chunk\",\"created\":1767213713,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[{\"index\":0,\"delta\":{},\"logprobs\":null,\"finish_reason\":\"stop\"}],\"usage\":null,\"obfuscation\":\"ryxeOd59o\"}\n\ndata:
-        {\"id\":\"chatcmpl-CsxIvHy9zaFaJz2Gf8MhW2PG0Zy3X\",\"object\":\"chat.completion.chunk\",\"created\":1767213713,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_1a2c4a5ede\",\"choices\":[],\"usage\":{\"prompt_tokens\":8,\"completion_tokens\":10,\"total_tokens\":18,\"prompt_tokens_details\":{\"cached_tokens\":0,\"audio_tokens\":0},\"completion_tokens_details\":{\"reasoning_tokens\":0,\"audio_tokens\":0,\"accepted_prediction_tokens\":0,\"rejected_prediction_tokens\":0}},\"obfuscation\":\"89gdiDUGT7cz670\"}\n\ndata:
+      string: "data: {\"id\":\"chatcmpl-DVMZS11X6BpV8kCV50OkWFeY5eNv8\",\"object\":\"chat.completion.chunk\",\"created\":1776367302,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_000894f84e\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\",\"refusal\":null},\"logprobs\":{\"content\":[],\"refusal\":null},\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"NXWZ\"}\n\ndata:
+        {\"id\":\"chatcmpl-DVMZS11X6BpV8kCV50OkWFeY5eNv8\",\"object\":\"chat.completion.chunk\",\"created\":1776367302,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_000894f84e\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"},\"logprobs\":{\"content\":[{\"token\":\"Hello\",\"logprob\":-0.0019286326132714748,\"bytes\":[72,101,108,108,111],\"top_logprobs\":[]}],\"refusal\":null},\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"\"}\n\ndata:
+        {\"id\":\"chatcmpl-DVMZS11X6BpV8kCV50OkWFeY5eNv8\",\"object\":\"chat.completion.chunk\",\"created\":1776367302,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_000894f84e\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"!\"},\"logprobs\":{\"content\":[{\"token\":\"!\",\"logprob\":-3.8889261304575484e-6,\"bytes\":[33],\"top_logprobs\":[]}],\"refusal\":null},\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"WcBCdxgm\"}\n\ndata:
+        {\"id\":\"chatcmpl-DVMZS11X6BpV8kCV50OkWFeY5eNv8\",\"object\":\"chat.completion.chunk\",\"created\":1776367302,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_000894f84e\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
+        How\"},\"logprobs\":{\"content\":[{\"token\":\" How\",\"logprob\":-0.0018035804387181997,\"bytes\":[32,72,111,119],\"top_logprobs\":[]}],\"refusal\":null},\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"ZsKjg0G\"}\n\ndata:
+        {\"id\":\"chatcmpl-DVMZS11X6BpV8kCV50OkWFeY5eNv8\",\"object\":\"chat.completion.chunk\",\"created\":1776367302,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_000894f84e\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
+        can\"},\"logprobs\":{\"content\":[{\"token\":\" can\",\"logprob\":0.0,\"bytes\":[32,99,97,110],\"top_logprobs\":[]}],\"refusal\":null},\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"Uo4XceMHXWU\"}\n\ndata:
+        {\"id\":\"chatcmpl-DVMZS11X6BpV8kCV50OkWFeY5eNv8\",\"object\":\"chat.completion.chunk\",\"created\":1776367302,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_000894f84e\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
+        I\"},\"logprobs\":{\"content\":[{\"token\":\" I\",\"logprob\":0.0,\"bytes\":[32,73],\"top_logprobs\":[]}],\"refusal\":null},\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"JQYIQv\"}\n\ndata:
+        {\"id\":\"chatcmpl-DVMZS11X6BpV8kCV50OkWFeY5eNv8\",\"object\":\"chat.completion.chunk\",\"created\":1776367302,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_000894f84e\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
+        help\"},\"logprobs\":{\"content\":[{\"token\":\" help\",\"logprob\":-0.026300301775336266,\"bytes\":[32,104,101,108,112],\"top_logprobs\":[]}],\"refusal\":null},\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"4\"}\n\ndata:
+        {\"id\":\"chatcmpl-DVMZS11X6BpV8kCV50OkWFeY5eNv8\",\"object\":\"chat.completion.chunk\",\"created\":1776367302,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_000894f84e\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
+        you\"},\"logprobs\":{\"content\":[{\"token\":\" you\",\"logprob\":0.0,\"bytes\":[32,121,111,117],\"top_logprobs\":[]}],\"refusal\":null},\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"5zdgHBqMl\"}\n\ndata:
+        {\"id\":\"chatcmpl-DVMZS11X6BpV8kCV50OkWFeY5eNv8\",\"object\":\"chat.completion.chunk\",\"created\":1776367302,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_000894f84e\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
+        today\"},\"logprobs\":{\"content\":[{\"token\":\" today\",\"logprob\":-3.128163257315464e-7,\"bytes\":[32,116,111,100,97,121],\"top_logprobs\":[]}],\"refusal\":null},\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"8bQpX6S5ottO\"}\n\ndata:
+        {\"id\":\"chatcmpl-DVMZS11X6BpV8kCV50OkWFeY5eNv8\",\"object\":\"chat.completion.chunk\",\"created\":1776367302,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_000894f84e\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"?\"},\"logprobs\":{\"content\":[{\"token\":\"?\",\"logprob\":-6.704273118884885e-7,\"bytes\":[63],\"top_logprobs\":[]}],\"refusal\":null},\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"Dsp2qjzV2\"}\n\ndata:
+        {\"id\":\"chatcmpl-DVMZS11X6BpV8kCV50OkWFeY5eNv8\",\"object\":\"chat.completion.chunk\",\"created\":1776367302,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_000894f84e\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
+        \U0001F60A\"},\"logprobs\":{\"content\":[{\"token\":\" \U0001F60A\",\"logprob\":-0.3217834234237671,\"bytes\":[32,240,159,152,138],\"top_logprobs\":[]}],\"refusal\":null},\"finish_reason\":null}],\"usage\":null,\"obfuscation\":\"FgJjPDPmC\"}\n\ndata:
+        {\"id\":\"chatcmpl-DVMZS11X6BpV8kCV50OkWFeY5eNv8\",\"object\":\"chat.completion.chunk\",\"created\":1776367302,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_000894f84e\",\"choices\":[{\"index\":0,\"delta\":{},\"logprobs\":null,\"finish_reason\":\"stop\"}],\"usage\":null,\"obfuscation\":\"4be12sdNN\"}\n\ndata:
+        {\"id\":\"chatcmpl-DVMZS11X6BpV8kCV50OkWFeY5eNv8\",\"object\":\"chat.completion.chunk\",\"created\":1776367302,\"model\":\"gpt-4.1-2025-04-14\",\"service_tier\":\"default\",\"system_fingerprint\":\"fp_000894f84e\",\"choices\":[],\"usage\":{\"prompt_tokens\":8,\"completion_tokens\":10,\"total_tokens\":18,\"prompt_tokens_details\":{\"cached_tokens\":0,\"audio_tokens\":0},\"completion_tokens_details\":{\"reasoning_tokens\":0,\"audio_tokens\":0,\"accepted_prediction_tokens\":0,\"rejected_prediction_tokens\":0}},\"obfuscation\":\"XJBKvRo7Jey19OG\"}\n\ndata:
         [DONE]\n\n"
     headers:
-      CF-RAY:
-      - 9b6c99aa2b69e266-ORD
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9ed58df5eacdf606-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:53 GMT
+      - Thu, 16 Apr 2026 19:21:42 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
       - chunked
+      Vary:
+      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       access-control-expose-headers:
       - X-Request-ID
       alt-svc:
       - h3=":443"; ma=86400
-      cf-cache-status:
-      - DYNAMIC
       openai-processing-ms:
-      - '180'
+      - '702'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '195'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:

--- a/tests/_vcr/test_provider_openai_completions/test_openai_pdf.yaml
+++ b/tests/_vcr/test_provider_openai_completions/test_openai_pdf.yaml
@@ -9,7 +9,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -26,95 +26,113 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CsxIwHceMuify8a3R94b0GhUkKGwR","object":"chat.completion.chunk","created":1767213714,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"A4iQ1DTCdA1q3"}
+      string: 'data: {"id":"chatcmpl-DVMZUAU9x0ycw7bWZhfv0fSwE2rV8","object":"chat.completion.chunk","created":1776367304,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"qq2gC4SmzZtCY"}
 
 
-        data: {"id":"chatcmpl-CsxIwHceMuify8a3R94b0GhUkKGwR","object":"chat.completion.chunk","created":1767213714,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"The"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"n3p2hbcNHDjh"}
+        data: {"id":"chatcmpl-DVMZUAU9x0ycw7bWZhfv0fSwE2rV8","object":"chat.completion.chunk","created":1776367304,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"The"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"AkeTh64F3jeB"}
 
 
-        data: {"id":"chatcmpl-CsxIwHceMuify8a3R94b0GhUkKGwR","object":"chat.completion.chunk","created":1767213714,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        title"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"E57uI2CYv"}
+        data: {"id":"chatcmpl-DVMZUAU9x0ycw7bWZhfv0fSwE2rV8","object":"chat.completion.chunk","created":1776367304,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        title"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"eeJKpCR3F"}
 
 
-        data: {"id":"chatcmpl-CsxIwHceMuify8a3R94b0GhUkKGwR","object":"chat.completion.chunk","created":1767213714,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        of"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"dB7SEjU585Rg"}
+        data: {"id":"chatcmpl-DVMZUAU9x0ycw7bWZhfv0fSwE2rV8","object":"chat.completion.chunk","created":1776367304,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        of"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"m6HQb3qw9qW4"}
 
 
-        data: {"id":"chatcmpl-CsxIwHceMuify8a3R94b0GhUkKGwR","object":"chat.completion.chunk","created":1767213714,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        the"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Cp1qJNPx6lj"}
+        data: {"id":"chatcmpl-DVMZUAU9x0ycw7bWZhfv0fSwE2rV8","object":"chat.completion.chunk","created":1776367304,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        the"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Jq8JDQ7Zwz7"}
 
 
-        data: {"id":"chatcmpl-CsxIwHceMuify8a3R94b0GhUkKGwR","object":"chat.completion.chunk","created":1767213714,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        document"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"DqJOZf"}
+        data: {"id":"chatcmpl-DVMZUAU9x0ycw7bWZhfv0fSwE2rV8","object":"chat.completion.chunk","created":1776367304,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        document"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"QJvZOi"}
 
 
-        data: {"id":"chatcmpl-CsxIwHceMuify8a3R94b0GhUkKGwR","object":"chat.completion.chunk","created":1767213714,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        is"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"3c5Rt7ZSQNt8"}
+        data: {"id":"chatcmpl-DVMZUAU9x0ycw7bWZhfv0fSwE2rV8","object":"chat.completion.chunk","created":1776367304,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        is"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"GAK3G1Q5QQAC"}
 
 
-        data: {"id":"chatcmpl-CsxIwHceMuify8a3R94b0GhUkKGwR","object":"chat.completion.chunk","created":1767213714,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        \""},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"KsZ45EQOWEVx"}
+        data: {"id":"chatcmpl-DVMZUAU9x0ycw7bWZhfv0fSwE2rV8","object":"chat.completion.chunk","created":1776367304,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        **"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"rj9aFFkUaNap"}
 
 
-        data: {"id":"chatcmpl-CsxIwHceMuify8a3R94b0GhUkKGwR","object":"chat.completion.chunk","created":1767213714,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"Ap"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"2GwM0wzDffoiA"}
+        data: {"id":"chatcmpl-DVMZUAU9x0ycw7bWZhfv0fSwE2rV8","object":"chat.completion.chunk","created":1776367304,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"\""},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"2MkU0PhWVUu92"}
 
 
-        data: {"id":"chatcmpl-CsxIwHceMuify8a3R94b0GhUkKGwR","object":"chat.completion.chunk","created":1767213714,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"ples"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"XSwgIr08enC"}
+        data: {"id":"chatcmpl-DVMZUAU9x0ycw7bWZhfv0fSwE2rV8","object":"chat.completion.chunk","created":1776367304,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"Ap"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"2JAdhCRzZfAvs"}
 
 
-        data: {"id":"chatcmpl-CsxIwHceMuify8a3R94b0GhUkKGwR","object":"chat.completion.chunk","created":1767213714,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        are"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"CCBKICZfacg"}
+        data: {"id":"chatcmpl-DVMZUAU9x0ycw7bWZhfv0fSwE2rV8","object":"chat.completion.chunk","created":1776367304,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"ples"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"3MRvEQ3xSn9"}
 
 
-        data: {"id":"chatcmpl-CsxIwHceMuify8a3R94b0GhUkKGwR","object":"chat.completion.chunk","created":1767213714,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        tasty"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"AyQaMeVtt"}
+        data: {"id":"chatcmpl-DVMZUAU9x0ycw7bWZhfv0fSwE2rV8","object":"chat.completion.chunk","created":1776367304,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        are"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"m7gy4urewPa"}
 
 
-        data: {"id":"chatcmpl-CsxIwHceMuify8a3R94b0GhUkKGwR","object":"chat.completion.chunk","created":1767213714,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"\""},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"rCI2gw1CoFeE2"}
+        data: {"id":"chatcmpl-DVMZUAU9x0ycw7bWZhfv0fSwE2rV8","object":"chat.completion.chunk","created":1776367304,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        tasty"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"yt7J8Hn9o"}
 
 
-        data: {"id":"chatcmpl-CsxIwHceMuify8a3R94b0GhUkKGwR","object":"chat.completion.chunk","created":1767213714,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        ("},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"gox9g0RSf0RDh"}
+        data: {"id":"chatcmpl-DVMZUAU9x0ycw7bWZhfv0fSwE2rV8","object":"chat.completion.chunk","created":1776367304,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"\""},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"FDEKWVMqqDZsm"}
 
 
-        data: {"id":"chatcmpl-CsxIwHceMuify8a3R94b0GhUkKGwR","object":"chat.completion.chunk","created":1767213714,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"found"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"YC7sddD2Zm"}
+        data: {"id":"chatcmpl-DVMZUAU9x0ycw7bWZhfv0fSwE2rV8","object":"chat.completion.chunk","created":1776367304,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"**"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"P9itKXZr5FVIe"}
 
 
-        data: {"id":"chatcmpl-CsxIwHceMuify8a3R94b0GhUkKGwR","object":"chat.completion.chunk","created":1767213714,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        at"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"qgWlrPDBYCUd"}
+        data: {"id":"chatcmpl-DVMZUAU9x0ycw7bWZhfv0fSwE2rV8","object":"chat.completion.chunk","created":1776367304,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"LBQdp0vNDI0kF3"}
 
 
-        data: {"id":"chatcmpl-CsxIwHceMuify8a3R94b0GhUkKGwR","object":"chat.completion.chunk","created":1767213714,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        the"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"hkKiCqe5g3K"}
+        data: {"id":"chatcmpl-DVMZUAU9x0ycw7bWZhfv0fSwE2rV8","object":"chat.completion.chunk","created":1776367304,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        This"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"u7lRCpOloq"}
 
 
-        data: {"id":"chatcmpl-CsxIwHceMuify8a3R94b0GhUkKGwR","object":"chat.completion.chunk","created":1767213714,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        top"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"OPga2vOnDwQ"}
+        data: {"id":"chatcmpl-DVMZUAU9x0ycw7bWZhfv0fSwE2rV8","object":"chat.completion.chunk","created":1776367304,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        can"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"VUiDzWzJnq8"}
 
 
-        data: {"id":"chatcmpl-CsxIwHceMuify8a3R94b0GhUkKGwR","object":"chat.completion.chunk","created":1767213714,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        of"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"kvtXjyXt3rUp"}
+        data: {"id":"chatcmpl-DVMZUAU9x0ycw7bWZhfv0fSwE2rV8","object":"chat.completion.chunk","created":1776367304,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        be"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"foTocMrYyohN"}
 
 
-        data: {"id":"chatcmpl-CsxIwHceMuify8a3R94b0GhUkKGwR","object":"chat.completion.chunk","created":1767213714,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        the"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"RypwwEs3QyP"}
+        data: {"id":"chatcmpl-DVMZUAU9x0ycw7bWZhfv0fSwE2rV8","object":"chat.completion.chunk","created":1776367304,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        seen"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"UoUV2Eyh0n"}
 
 
-        data: {"id":"chatcmpl-CsxIwHceMuify8a3R94b0GhUkKGwR","object":"chat.completion.chunk","created":1767213714,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        first"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"ZLQf2i1l8"}
+        data: {"id":"chatcmpl-DVMZUAU9x0ycw7bWZhfv0fSwE2rV8","object":"chat.completion.chunk","created":1776367304,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        at"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"T5G1Q8nSO6Ch"}
 
 
-        data: {"id":"chatcmpl-CsxIwHceMuify8a3R94b0GhUkKGwR","object":"chat.completion.chunk","created":1767213714,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        page"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"M78WAZVTv5"}
+        data: {"id":"chatcmpl-DVMZUAU9x0ycw7bWZhfv0fSwE2rV8","object":"chat.completion.chunk","created":1776367304,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        the"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"2DHgvk1Bgb7"}
 
 
-        data: {"id":"chatcmpl-CsxIwHceMuify8a3R94b0GhUkKGwR","object":"chat.completion.chunk","created":1767213714,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":")."},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"m0Cpd2RjKVAhg"}
+        data: {"id":"chatcmpl-DVMZUAU9x0ycw7bWZhfv0fSwE2rV8","object":"chat.completion.chunk","created":1776367304,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        top"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"79ltCCm7SsG"}
 
 
-        data: {"id":"chatcmpl-CsxIwHceMuify8a3R94b0GhUkKGwR","object":"chat.completion.chunk","created":1767213714,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"pHgn8J8lH"}
+        data: {"id":"chatcmpl-DVMZUAU9x0ycw7bWZhfv0fSwE2rV8","object":"chat.completion.chunk","created":1776367304,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        of"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"GOSrYQOSPCYy"}
 
 
-        data: {"id":"chatcmpl-CsxIwHceMuify8a3R94b0GhUkKGwR","object":"chat.completion.chunk","created":1767213714,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[],"usage":{"prompt_tokens":268,"completion_tokens":22,"total_tokens":290,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"K22iayxaOpnS"}
+        data: {"id":"chatcmpl-DVMZUAU9x0ycw7bWZhfv0fSwE2rV8","object":"chat.completion.chunk","created":1776367304,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        the"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"0KNDQow97lo"}
+
+
+        data: {"id":"chatcmpl-DVMZUAU9x0ycw7bWZhfv0fSwE2rV8","object":"chat.completion.chunk","created":1776367304,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        first"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Qzla1jRYp"}
+
+
+        data: {"id":"chatcmpl-DVMZUAU9x0ycw7bWZhfv0fSwE2rV8","object":"chat.completion.chunk","created":1776367304,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        page"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"71WVCOhebx"}
+
+
+        data: {"id":"chatcmpl-DVMZUAU9x0ycw7bWZhfv0fSwE2rV8","object":"chat.completion.chunk","created":1776367304,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"HS9kvc4RWx4ryN"}
+
+
+        data: {"id":"chatcmpl-DVMZUAU9x0ycw7bWZhfv0fSwE2rV8","object":"chat.completion.chunk","created":1776367304,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"OYbGxaLQL"}
+
+
+        data: {"id":"chatcmpl-DVMZUAU9x0ycw7bWZhfv0fSwE2rV8","object":"chat.completion.chunk","created":1776367304,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[],"usage":{"prompt_tokens":268,"completion_tokens":27,"total_tokens":295,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"FtxRPs82utpN"}
 
 
         data: [DONE]
@@ -122,14 +140,16 @@ interactions:
 
         '
     headers:
-      CF-RAY:
-      - 9b6c99adaac061f0-ORD
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9ed58dfe0f6922db-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:55 GMT
+      - Thu, 16 Apr 2026 19:21:44 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -142,14 +162,10 @@ interactions:
       - X-Request-ID
       alt-svc:
       - h3=":443"; ma=86400
-      cf-cache-status:
-      - DYNAMIC
       openai-processing-ms:
-      - '1009'
+      - '1128'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '1228'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -172,25 +188,24 @@ interactions:
       of this document?"}, {"type": "file", "file": {"filename": "apples.pdf", "file_data":
       "data:application/pdf;base64,JVBERi0xLjMKJcTl8uXrp/Og0MTGCjMgMCBvYmoKPDwgL0ZpbHRlciAvRmxhdGVEZWNvZGUgL0xlbmd0aCA0MTggPj4Kc3RyZWFtCngBnZLdS8MwFMXf81cc31aQNGnXrIEhuDlQwY9hwAfxoXYZq2v31Qruv/e26zb3oUzJQwK5ueeXc+4cfcwhaCnpoaU9LCyeMYHbzSXiHLJaeUwV5W22qUurk0BavU7ZCEO4j2i34d51b67o2cUFOlfdSkD5XARaa7Q8NMOAhyFUoLhu7ssRCRMguTk1KLFk+URpwf1QEFCGjoFfXoj1ZjK4xpScZojG5WyW2tyBeUfPsD7cp1k0qagu4+IjSo39LNCAs6Y7TUeH3AsJbVeLulQy9MXeXfdEZCkUV95+rxc0ooUDGaJhHbzC3BI+9f0XPtu3SQYel5os+zv/YS8leOAf9CqivFjuGfJ9HDwynJXjsGt4y+cqWOcq68hX24rVq3N9W+I6GqR2ieckHo+izGHkPQXv1wVnu2F81/aPh93UtTajmfpFm7JZTRU2EWFg0yROph85oskAq8+XpxukydiimMJGBYqRzTgcVuV5GmvzOKvfOpm19xnbWYHhdIH1RA22vOcERWRJzmFG5CZ9iVVTh/sHsy3j9RD+DN3/ArZS/GcKZW5kc3RyZWFtCmVuZG9iagoxIDAgb2JqCjw8IC9UeXBlIC9QYWdlIC9QYXJlbnQgMiAwIFIgL1Jlc291cmNlcyA0IDAgUiAvQ29udGVudHMgMyAwIFIgL01lZGlhQm94IFswIDAgNjEyIDc5Ml0KPj4KZW5kb2JqCjQgMCBvYmoKPDwgL1Byb2NTZXQgWyAvUERGIC9UZXh0IF0gL0NvbG9yU3BhY2UgPDwgL0NzMSA1IDAgUiA+PiAvRm9udCA8PCAvVFQxIDYgMCBSCi9UVDIgNyAwIFIgL1RUMyA4IDAgUiA+PiA+PgplbmRvYmoKMTAgMCBvYmoKPDwgL04gMyAvQWx0ZXJuYXRlIC9EZXZpY2VSR0IgL0xlbmd0aCAyNjEyIC9GaWx0ZXIgL0ZsYXRlRGVjb2RlID4+CnN0cmVhbQp4AZ2Wd1RT2RaHz703vdASIiAl9Bp6CSDSO0gVBFGJSYBQAoaEJnZEBUYUESlWZFTAAUeHImNFFAuDgmLXCfIQUMbBUURF5d2MawnvrTXz3pr9x1nf2ee319ln733XugBQ/IIEwnRYAYA0oVgU7uvBXBITy8T3AhgQAQ5YAcDhZmYER/hEAtT8vT2ZmahIxrP27i6AZLvbLL9QJnPW/3+RIjdDJAYACkXVNjx+JhflApRTs8UZMv8EyvSVKTKGMTIWoQmirCLjxK9s9qfmK7vJmJcm5KEaWc4ZvDSejLtQ3pol4aOMBKFcmCXgZ6N8B2W9VEmaAOX3KNPT+JxMADAUmV/M5yahbIkyRRQZ7onyAgAIlMQ5vHIOi/k5aJ4AeKZn5IoEiUliphHXmGnl6Mhm+vGzU/liMSuUw03hiHhMz/S0DI4wF4Cvb5ZFASVZbZloke2tHO3tWdbmaPm/2d8eflP9Pch6+1XxJuzPnkGMnlnfbOysL70WAPYkWpsds76VVQC0bQZA5eGsT+8gAPIFALTenPMehmxeksTiDCcLi+zsbHMBn2suK+g3+5+Cb8q/hjn3mcvu+1Y7phc/gSNJFTNlReWmp6ZLRMzMDA6Xz2T99xD/48A5ac3Jwyycn8AX8YXoVVHolAmEiWi7hTyBWJAuZAqEf9Xhfxg2JwcZfp1rFGh1XwB9hTlQuEkHyG89AEMjAyRuP3oCfetbEDEKyL68aK2Rr3OPMnr+5/ofC1yKbuFMQSJT5vYMj2RyJaIsGaPfhGzBAhKQB3SgCjSBLjACLGANHIAzcAPeIACEgEgQA5YDLkgCaUAEskE+2AAKQTHYAXaDanAA1IF60AROgjZwBlwEV8ANcAsMgEdACobBSzAB3oFpCILwEBWiQaqQFqQPmULWEBtaCHlDQVA4FAPFQ4mQEJJA+dAmqBgqg6qhQ1A99CN0GroIXYP6oAfQIDQG/QF9hBGYAtNhDdgAtoDZsDscCEfCy+BEeBWcBxfA2+FKuBY+DrfCF+Eb8AAshV/CkwhAyAgD0UZYCBvxREKQWCQBESFrkSKkAqlFmpAOpBu5jUiRceQDBoehYZgYFsYZ44dZjOFiVmHWYkow1ZhjmFZMF+Y2ZhAzgfmCpWLVsaZYJ6w/dgk2EZuNLcRWYI9gW7CXsQPYYew7HA7HwBniHHB+uBhcMm41rgS3D9eMu4Drww3hJvF4vCreFO+CD8Fz8GJ8Ib4Kfxx/Ht+PH8a/J5AJWgRrgg8hliAkbCRUEBoI5wj9hBHCNFGBqE90IoYQecRcYimxjthBvEkcJk6TFEmGJBdSJCmZtIFUSWoiXSY9Jr0hk8k6ZEdyGFlAXk+uJJ8gXyUPkj9QlCgmFE9KHEVC2U45SrlAeUB5Q6VSDahu1FiqmLqdWk+9RH1KfS9HkzOX85fjya2Tq5FrleuXeyVPlNeXd5dfLp8nXyF/Sv6m/LgCUcFAwVOBo7BWoUbhtMI9hUlFmqKVYohimmKJYoPiNcVRJbySgZK3Ek+pQOmw0iWlIRpC06V50ri0TbQ62mXaMB1HN6T705PpxfQf6L30CWUlZVvlKOUc5Rrls8pSBsIwYPgzUhmljJOMu4yP8zTmuc/jz9s2r2le/7wplfkqbip8lSKVZpUBlY+qTFVv1RTVnaptqk/UMGomamFq2Wr71S6rjc+nz3eez51fNP/k/IfqsLqJerj6avXD6j3qkxqaGr4aGRpVGpc0xjUZmm6ayZrlmuc0x7RoWgu1BFrlWue1XjCVme7MVGYls4s5oa2u7act0T6k3as9rWOos1hno06zzhNdki5bN0G3XLdTd0JPSy9YL1+vUe+hPlGfrZ+kv0e/W3/KwNAg2mCLQZvBqKGKob9hnmGj4WMjqpGr0SqjWqM7xjhjtnGK8T7jWyawiZ1JkkmNyU1T2NTeVGC6z7TPDGvmaCY0qzW7x6Kw3FlZrEbWoDnDPMh8o3mb+SsLPYtYi50W3RZfLO0sUy3rLB9ZKVkFWG206rD6w9rEmmtdY33HhmrjY7POpt3mta2pLd92v+19O5pdsN0Wu067z/YO9iL7JvsxBz2HeIe9DvfYdHYou4R91RHr6OG4zvGM4wcneyex00mn351ZzinODc6jCwwX8BfULRhy0XHhuBxykS5kLoxfeHCh1FXbleNa6/rMTdeN53bEbcTd2D3Z/bj7Kw9LD5FHi8eUp5PnGs8LXoiXr1eRV6+3kvdi72rvpz46Pok+jT4Tvna+q30v+GH9Av12+t3z1/Dn+tf7TwQ4BKwJ6AqkBEYEVgc+CzIJEgV1BMPBAcG7gh8v0l8kXNQWAkL8Q3aFPAk1DF0V+nMYLiw0rCbsebhVeH54dwQtYkVEQ8S7SI/I0shHi40WSxZ3RslHxUXVR01Fe0WXRUuXWCxZs+RGjFqMIKY9Fh8bFXskdnKp99LdS4fj7OIK4+4uM1yWs+zacrXlqcvPrpBfwVlxKh4bHx3fEP+JE8Kp5Uyu9F+5d+UE15O7h/uS58Yr543xXfhl/JEEl4SyhNFEl8RdiWNJrkkVSeMCT0G14HWyX/KB5KmUkJSjKTOp0anNaYS0+LTTQiVhirArXTM9J70vwzSjMEO6ymnV7lUTokDRkUwoc1lmu5iO/kz1SIwkmyWDWQuzarLeZ0dln8pRzBHm9OSa5G7LHcnzyft+NWY1d3Vnvnb+hvzBNe5rDq2F1q5c27lOd13BuuH1vuuPbSBtSNnwy0bLjWUb326K3tRRoFGwvmBos+/mxkK5QlHhvS3OWw5sxWwVbO3dZrOtatuXIl7R9WLL4oriTyXckuvfWX1X+d3M9oTtvaX2pft34HYId9zd6brzWJliWV7Z0K7gXa3lzPKi8re7V+y+VmFbcWAPaY9kj7QyqLK9Sq9qR9Wn6qTqgRqPmua96nu37Z3ax9vXv99tf9MBjQPFBz4eFBy8f8j3UGutQW3FYdzhrMPP66Lqur9nf19/RO1I8ZHPR4VHpcfCj3XVO9TXN6g3lDbCjZLGseNxx2/94PVDexOr6VAzo7n4BDghOfHix/gf754MPNl5in2q6Sf9n/a20FqKWqHW3NaJtqQ2aXtMe9/pgNOdHc4dLT+b/3z0jPaZmrPKZ0vPkc4VnJs5n3d+8kLGhfGLiReHOld0Prq05NKdrrCu3suBl69e8blyqdu9+/xVl6tnrjldO32dfb3thv2N1h67npZf7H5p6bXvbb3pcLP9luOtjr4Ffef6Xfsv3va6feWO/50bA4sG+u4uvnv/Xtw96X3e/dEHqQ9eP8x6OP1o/WPs46InCk8qnqo/rf3V+Ndmqb307KDXYM+ziGePhrhDL/+V+a9PwwXPqc8rRrRG6ketR8+M+YzderH0xfDLjJfT44W/Kf6295XRq59+d/u9Z2LJxPBr0euZP0reqL45+tb2bedk6OTTd2nvpqeK3qu+P/aB/aH7Y/THkensT/hPlZ+NP3d8CfzyeCZtZubf94Tz+wplbmRzdHJlYW0KZW5kb2JqCjUgMCBvYmoKWyAvSUNDQmFzZWQgMTAgMCBSIF0KZW5kb2JqCjEyIDAgb2JqCjw8IC9UeXBlIC9TdHJ1Y3RUcmVlUm9vdCAvSyAxMSAwIFIgL1BhcmVudFRyZWUgMTMgMCBSIC9JRFRyZWUgMTQgMCBSPj4KZW5kb2JqCjExIDAgb2JqCjw8IC9UeXBlIC9TdHJ1Y3RFbGVtIC9TIC9Eb2N1bWVudCAvUCAxMiAwIFIgL0sgWyAxNSAwIFIgMTYgMCBSIDE3IDAgUiAxOCAwIFIKXSAgPj4KZW5kb2JqCjE1IDAgb2JqCjw8IC9UeXBlIC9TdHJ1Y3RFbGVtIC9TIC9IIC9QIDExIDAgUiAvUGcgMSAwIFIgL0sgMSAgPj4KZW5kb2JqCjE2IDAgb2JqCjw8IC9UeXBlIC9TdHJ1Y3RFbGVtIC9TIC9QIC9QIDExIDAgUiAvUGcgMSAwIFIgL0sgMiAgPj4KZW5kb2JqCjE3IDAgb2JqCjw8IC9UeXBlIC9TdHJ1Y3RFbGVtIC9TIC9QIC9QIDExIDAgUiAvUGcgMSAwIFIgL0sgMyAgPj4KZW5kb2JqCjE4IDAgb2JqCjw8IC9UeXBlIC9TdHJ1Y3RFbGVtIC9TIC9QIC9QIDExIDAgUiAvUGcgMSAwIFIgL0sgNCAgPj4KZW5kb2JqCjIgMCBvYmoKPDwgL1R5cGUgL1BhZ2VzIC9NZWRpYUJveCBbMCAwIDYxMiA3OTJdIC9Db3VudCAxIC9LaWRzIFsgMSAwIFIgXSA+PgplbmRvYmoKMTkgMCBvYmoKPDwgL1R5cGUgL0NhdGFsb2cgL1BhZ2VzIDIgMCBSIC9NYXJrSW5mbyA8PCAvTWFya2VkIHRydWUgPj4gL1N0cnVjdFRyZWVSb290CjEyIDAgUiA+PgplbmRvYmoKOSAwIG9iagpbIDEgMCBSICAvWFlaIDAgNzkyIDAgXQplbmRvYmoKNiAwIG9iago8PCAvVHlwZSAvRm9udCAvU3VidHlwZSAvVHJ1ZVR5cGUgL0Jhc2VGb250IC9BQUFBQUIrSGVsdmV0aWNhTmV1ZS1Cb2xkIC9Gb250RGVzY3JpcHRvcgoyMCAwIFIgL0VuY29kaW5nIC9NYWNSb21hbkVuY29kaW5nIC9GaXJzdENoYXIgMzIgL0xhc3RDaGFyIDEyMSAvV2lkdGhzIFsgMjc4CjAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCA2ODUgMCAwIDAKMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCA1NzQgMCAwIDAgNTc0IDAgMAowIDAgMCAwIDI1OCAwIDAgMCA2MTEgMCAzODkgNTM3IDM1MiAwIDAgMCAwIDUxOSBdID4+CmVuZG9iagoyMCAwIG9iago8PCAvVHlwZSAvRm9udERlc2NyaXB0b3IgL0ZvbnROYW1lIC9BQUFBQUIrSGVsdmV0aWNhTmV1ZS1Cb2xkIC9GbGFncyAzMiAvRm9udEJCb3gKWy0xMDE4IC00ODEgMTQzNyAxMTQxXSAvSXRhbGljQW5nbGUgMCAvQXNjZW50IDk3NSAvRGVzY2VudCAtMjE3IC9DYXBIZWlnaHQKNzE0IC9TdGVtViAxNTcgL0xlYWRpbmcgMjkgL1hIZWlnaHQgNTE3IC9TdGVtSCAxMzIgL0F2Z1dpZHRoIDQ3OCAvTWF4V2lkdGgKMTUwMCAvRm9udEZpbGUyIDIxIDAgUiA+PgplbmRvYmoKMjEgMCBvYmoKPDwgL0xlbmd0aDEgMzY1MiAvTGVuZ3RoIDIxMjQgL0ZpbHRlciAvRmxhdGVEZWNvZGUgPj4Kc3RyZWFtCngBrVdtbJtXFT73vv5IHMf2G38m/sj7+o3txHZiJ46d5mOpkzlRu1Ysa9dibwtt2rhroGnLSMYmMVGJVR0RRBP7MaGtGxL82BBIRirFy4+2PxCCCmkVvyoUUMUfxn4yKkHb2Dz3tRs1o0xVtdc6955z7r3nnvPccz+88tJqmax0jiTKH19eOEv6Z7qF6o/HX15RdJH4s6h3nTj74nJT/gGRoffFU6+eaMjm3xKZAifLC4sNme6hzp2EoiGzYdQ9J5dXXmnIpkuok6fOHG+2m38B2be88EpzftqErJxeWC43+tt8ov/ZM99aacjtt1DvOvtSudmfFSHfbbQ9UDLwbTRFXNc1yhBBNPTqGtEO+pPr0odH7BO3Waf0idBffvLf+0X911v98j1Trdt40bCKfq1NO/oY6eN6jILGTbR/23hRWNnxtVXJlWAbZCAHeRLsKskUo27qog6ATRRIXAWXpMgOjZN6dvShq2SjNDop5N0eZqdhSuzQOCi+wxBtkAsT+xNValdmXlvyFapkSUDLEIBVeCU1mCtgemGqE760UUfiCkb1UBCTyWSBTFcwJAPrKlQ2vQOHFCY/OeEPOmyQEWNkzET3Z4JzLlqm8/RDeheROmhf3UZGbqPrXCY0rdA36HVap+/SRTTL9aeonRvJxq+TDCvJfVVqnSv+irH1UpXVz1cLFPwIyEtHvtZfJZZUlJmlQoUdhcCTUMRVcFJSma1IkdkDRa2krClrexfXlFnl5MJixRDRazSU10oppUIHi0sony2qlXzJv82WS6Ux2DEIOxiC7mslWPh60wJqXZXaQidjcp9SkaJzxWeKlXMFfyVfKPlVVZmpXJsrVq4V/GqphF6mbU/hsViChs9m+GyKo72lYeUgbMBEaW1N2ITEo2rl2tqafw2R6BpNrTJqKhCp6CNFZqosP1cUTXlN9QuFpmoq/CgVYLs1ue9gcQaeqMITy/9ASoUHIG3bdhR9rXCvTYe0/UuC1PYokNofCVLHtqc7IJXhs0NA2vFwSLUvAHQb4fxDED7XQPjcQxB27kDY9cUIu7f9hpMeeOvWEfZ+SQj7HgXhzkdCuGvb0x0I++Fzl0A4sI1w3l+h7aQFwuc+l7L0f3P4cSEPPgA5+xfJzINz/Jf1O3ySFFCQcRrjxynHzlOOd0I+SiZuros7geEnPiuZcKLhpKLnmhpd/ZhF4zZ5zMEYJjWHGnaYMDYlE2ozteDku/9ZdMZDHpqly8zKetnvOOdv8JuSDae5TBL7GxcnuxkBq7LqlFWZXah9wnzP11L8SI3481t7+W8AWv0Oiks4byUc+hHCsZfCqQZqTW3os0riOHdswCoOd7ljND3oZxmnxDIjqjfD/jPPn/t57Z/v7WJtuZ/WbjMXM9XusMtbufffh01xuSr1z7iPO3ER5AmmXIn04JSEe6yF2DyYEdLuM3kwBFWOxsE5J6XMUIi7ZZfHqw2wmI1p4QGeHZ40xYYHuBY2mb02yWyT3K4QzwxN8mxaShYOJWJz0/EWy5sGIwu/kI7k0/7uwd35yXSA2TtVZzxt2Gj1d4dlR7fXZvMpcnzAY2QnhqZ75TZlNFX7TMs7rJ3tWqAjOtabHA3LFpPV6/H67cae+FJLq8kgSRa5y+XsspsCsV5xdXMKIr4exNeCm3D3BpbIRQKyVgfuoxu4EsWFKhQKMLQj5wRvBy9eEIJn6NgJCm6mB5kmgvaY1ZyI0MYbseVGNBF8lP3o76zN3x8ezvyFrRoCu49Njy/MRiOFY08UvxN6zTyZmMizMXs07N315sTpw5n43sWxicU9sbl5X2JSpAujMZS/19faL5IDaQcHJExu3MTKM6w6pdKDTjkjj63z61s5fQkRY66+jxcQoxP3/dUqJZEaXnLro71i9I1GyiTBK5sIb3PKSH9GtJ+C+PyUH6HaAYOd+kCjoL2gEmgJ9Cro+6Afgz4EfQT6A6h9vkrCei+s92LGPszoRQI2tHFo4yl47UZTBA8UEUoEuBLeI4IXOesDTxgiBlsoomdvpJFFyBkkl8vGmZzJZkJMT6FmYmlZNh5OB9utwZQWToVEXbu5zrueSY8eGg0ExopPpOe6+Hygf6JbmRgIBlMT3d0T/QH2wdbs7Wgs+dTR4ZHy/oFofFpgnkPxPWDnpsENFA3M3YiLIwIuImCIwIb8EV7b4LULvE33FSuBhIerHm82KhLCrGVz6zY1F2sPWGSbfygZtnBu3Lr7D22iv0virxsdwT7fUUzCRF6ye5h3lJYFKAzmNyiE95yYJoT5g6C2zQ28+XAg6rj2IgHcWD/RkoZ3acii5/gm8jjbzN0sPNTwUBVmNDSaQIRBghc5PKKFkMPYjwAzNiDd9z8zIN3PaG+ICeDFdv7ZBZ548nB/8tB0X2BgvDs01h9weAPW6C7pgqFv8ul4fC4fEw37D3X4Vbs7FnJ+MDwT75DjM5meQdVlNlvtPqfDaZGCfendUYc9kh8Kp7qdZoeiODvtZotb1UM31e+yA/wnSMGDYuNx3Xmx8bgI4EZjE3puNNdCvGZFdE5EasCpJ3gDOhI6WlHbUdsBjRG89wb2S1Zza+6MrB9EuZGsvlmzWLpP1w8f7uofV93JDovH2uM7yY3vvHOk9nEs3dXKpdOc+3oYHSFWv4v9Jd69biwP3i+w7QSJ/WhEbhiw75ieD0anJuHn9LhdJrMpGnOLvM2x7M23vslX3/61yR9wx12ehGfvgTyfqb3HjtX8dtkblZiBr3IJmYjQ9a/+Lg01uM+VbZAlPPsLtIeepoN0iA7TV+kFaBn+FiBR8JmAI02Jbzqxp3zq5fLK0vGFr5RXy/3TZ04t0n8BcHfSQQplbmRzdHJlYW0KZW5kb2JqCjcgMCBvYmoKPDwgL1R5cGUgL0ZvbnQgL1N1YnR5cGUgL1RydWVUeXBlIC9CYXNlRm9udCAvQUFBQUFDK0hlbHZldGljYU5ldWUgL0ZvbnREZXNjcmlwdG9yCjIyIDAgUiAvRW5jb2RpbmcgL01hY1JvbWFuRW5jb2RpbmcgL0ZpcnN0Q2hhciAzMiAvTGFzdENoYXIgMTIxIC9XaWR0aHMgWyAyNzgKMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDI3OCAwIDI3OCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCA2NDggMAowIDAgNjExIDAgMCA3MjIgMjU5IDAgMCAwIDAgNzIyIDc2MCAwIDAgMCAwIDU3NCAwIDAgOTI2IDAgMCAwIDAgMCAwIDAgMCAwCjUzNyA1OTMgNTM3IDU5MyA1MzcgMjk2IDAgNTU2IDIyMiAwIDUxOSAyMjIgODUzIDU1NiA1NzQgNTkzIDAgMzMzIDUwMCAzMTUKNTU2IDAgMCA1MTggNTAwIF0gPj4KZW5kb2JqCjIyIDAgb2JqCjw8IC9UeXBlIC9Gb250RGVzY3JpcHRvciAvRm9udE5hbWUgL0FBQUFBQytIZWx2ZXRpY2FOZXVlIC9GbGFncyAzMiAvRm9udEJCb3gKWy05NTEgLTQ4MSAxOTg3IDEwNzddIC9JdGFsaWNBbmdsZSAwIC9Bc2NlbnQgOTUyIC9EZXNjZW50IC0yMTMgL0NhcEhlaWdodAo3MTQgL1N0ZW1WIDk1IC9MZWFkaW5nIDI4IC9YSGVpZ2h0IDUxNyAvU3RlbUggODAgL0F2Z1dpZHRoIDQ0NyAvTWF4V2lkdGggMjIyNQovRm9udEZpbGUyIDIzIDAgUiA+PgplbmRvYmoKMjMgMCBvYmoKPDwgL0xlbmd0aDEgNzYwOCAvTGVuZ3RoIDQxNjYgL0ZpbHRlciAvRmxhdGVEZWNvZGUgPj4Kc3RyZWFtCngB5Vl9bFvXdb/38vtDlCh+i5RE6omkRFKkKJof+qYsUZasSlFsM6bsyIotK5aLuDYSN026LfDQxUmFrXULtFvSoCsSbO3QtVC2NZHZbTGabW3TBjA6LAEyoRg2bNiKIAiCtBvSitrvvPdIS1oWBEX+GLBHnXfPve/ec889X/fcq6sPfnKNWdk1pmHF1UtnrzD50a+j+PHqw1eDSp1/A6X3/isXLqn1W4xpey488Oj9St3wCGOuv1hfO3teqbNfocyto0Gp80Mou9cvXUU/enT/jte1By6vqt8N9P3wpbOPqPOzbdSDnzh7aQ0lnvYbePVcufzQVbnK2hMoz195cE3tzyuozyvf9rw58CCbZEJuU94dDFVtj9xC3wHvPObVrjSP/JzbNcQXe2HyPirYT/+pz/6r2Vqn4WVtFlWTSkceo9najbOA8Xl8v2Z4majse4JbzBnnVYwQzB3nL0G8YyzP4qyTOdAxEGcv4cvR/U1VpsXPH99iPFj6rYveqS1mRgWjGHPS3xw7BdS+O8QsQses4hVmx+fE3BYzLVae5/xzS1t89/GtKdZ+E9xqVs70gVQiGCxdnNrk96EiEmiIhYBpEsHpTU14+lhFWgpuBDdmz28Ep4PrZ89vasNyiQ9rG0up4CY7XrmI94lKaLO45G+ga0tLQ6CjJToYgu4bS6DwcZUCSrkptYNOusRccFMTWazcXdm8NuXfLE4t+UOhYGnz1mJl89aUP7S0hF76BqfgmJav8GwAz/oYvhsVKsdBAySWNjaIJmoiEtq8tbHh38BK5BYptMWZ2oCVUh9NuLTFi4sV+lSUQn5qkEJSCHwsTYG2KTF3vFICJyHixPw/RMqm9ojU0mAUfa1gzyKLtOkjEqntw4i0+UOJtKXB6T6R2sFzC4m09f1FKn2AQBsSLr6PhK8pEr72PhJ27JOw84Ml7GrwDSbd4NYlS9jzEUnY+2Ek7PtQEm5rcLpPwn7w3EYSDjQkXPRvsobRQsLXDpgs+19t+NcVefsekfN3WYa7Ebrc7DiBeHL3PbHKFsRP2ALXsGMo58V/sYgYY0LzVcQWH+sWd7NJteymkvegPcGK7KesJAysRKWmzIrUhnFyfz7PRjFXJx9mJrldz0yoGxG3uBolrUzP/hr1IKLZwbiJZvmhWK1R8Q8utOpnnVzqmaHR3YgYWH/MMmKpV/eUVtbEbKyZtTA7Wlvl8OxkLuZmHuZlPrS1MT8LsHZ5TAcCOD0z+D3MbrBb7B2e5DP8SdEjFsSTmi9qY9pndEO6Z3Vv6Yv6j+uf0b9gWDT8gbFgvG2smZ41vWueMl8xvwEKgmUY5z8WP8A6DWyN9guEuBTiOcDYgph3G5C6iY6ad9HachN7A2GmbYYgXqog9qb81GgeW1IbdNSgY1pq0GIAZsEAHTDsQ+/2p3nIHnLYQ3b+VO1VnsnULoind74kntoZFN+HJo7vfoJ9j11GNtBXxQsKAEdWcMIABnBjSFVlRVrtrYPgQWG2P513Zdw2YXCN8VF+fJjrbB770KHLl60Bv0c/YD82uEa0QY5oa5i/KiuWaGtaWBXtXJ6ItciUsscv4yHOd9/D6wb2OA2zsDDm00IwOoAJbDDIjEiwFtpjsWSw1J/284xDwzP5kCfDf/io+NQ3az87u8iTCxdr/8GjfL725/y5ndzrr4MmzboA+mPALSxTlU2FCJqwVu1t8KWV+aKZsJOqMxkxE+FG8Ao5Zuu/Bf527TJ/qPZ7/HPilZ3c4n8u/ssiBqpz/I48x5EqJlJkagHTepWUHvNZAALy1aE03sZKyQQMAC6vuMrMkAHNa5bnzUCDGbuE98IKf2RlpfYkTcqP1G6KV0ivNO8xTPW8LDvPPnkrNFmK+M/Yj63QSFkcGIP8SVyXeZ3bO6YKURvl6Q3EH8AMXs0pskKZvzq/iswYNEEcw7NlndA8GU78Snz+lOCfXD8lFI7F6M7LmP+vxCTJSrDI7tviJ+If4YFR9qMt1gPivYAezOjEjE7gbHvCD9ExeCdjEUAOMA24B3A/4GHAdcCXAX8MeAHwd4Cm5Qkd+wcg/woQy6AMqh3bWMc2PrwBfn8GEMsgbwLiA/QCBgGzgCXARcCjgM8CngL8CeAm4IeApmVYTDOGkZaaoV5JVa9EGjs0JjIDHcLltAmpKymizg7Ux0T2UBJ1m3g8MHJmYuLMSKBersTvuVYuX7snXi/5Wu7iiUzmxMVcvZx9Yn10dP2JWZRjY+tPYFEcEmRiFPozsOhe/cl6IoNTPIYMjhSpua3YQCYbcr298tbO34pP71wXn14kw+Xk/povglYzy+7Rs4lUALDAAynuclnXcmyXMZva1p8OOSSN+nNk8BN//9LKF8RXL3xN/O7ZF1f/SDwHxX9bHJMhJyo73wD33bs/F2ZhZ/3sML+X4uF3WQGG38S8wGLAEJAhXg+Y192mUDBhx6oKsIUCbKEAWyjAFgqwhQJsoQBbKDAj6f1xIF8CkN4LCIZBxNGbCOQUTT2o96vYFkuDbhoLjGGOqUacDVNYDTNjI84KasApotFgpAYjNVSheMHCEMcWC4N2AIEXLHwWyFNUWQbTRiBeQA+gAJgBVADrgEcARvAZBgedsE8BGkmiYYf+khBBEt6RxLkhyY4ATgIuAD4FkNd6HciXAWK5inUpnFRZusHTKNQe1ktdkayNkzFmYZz5MY1ii3qDNKaRTdXudGcG8lGbzlU3VmF2R0NRaTknjSf9HenxkDTeH3CFep25GU1ZdI/MJ6RSocvgtDRvtBwaHEq22/3dzthIpFU0hWOxcEtXPpooSK16g6HJ5w10tep7B/sP97aaOwt9tV90BHTft1oMJmc46GpvNXqk3laYEpiehE30wQ69LMG+tcWSMDwvPpCbeSEhippUalHS9pAEboPUqM2NNjfabMB9ipf74OW+upf7gPrg5T54uQ9e7oOX++DlPni5DwrzQWE+eLkPXu6Dl/vg5QplCZQlin8M7HSo+0MHvN4BlRJrDiVOZzMdkGbd0SFcO1dDAEmd5DxZFrbeZMoxvDTc3jG8NJI75RJ8uKV7OJEYi7baIyPx3tGog4J0ydPZaozNnsvnz80lonFuqY1GZgpdodyRSPd0viuYK5HvkQ/x9+BDEnu0CkuyyOwEWuSoGYCnBOApAXhKAJ4SgKcE4CkBeEoAUTMAwwkgagYQNQOImoF61AwgapLpIsZ5kCfRCj3yFhaScYooDEJvQencRpaRSWoorimmk8tLdywtM+Dmf1jRRYbnE6P3jnZ0jp4eXn3IdtJ4ZLxnqNveEh5L5op8JTmZcMXn1oaGzk5H1u8bORzMTnVHZwtdOcUmKE7YYBMO2MR3t1gflEDpGrHlAgt9gK7bAOj+o9sv3KCq7HuwKuBezODFDITHgMfARZx1MZfs+dSaoJ3cheZmeCwxR/tCu7ovtMNC8gf2BR3tkftFl3E91tI9Et9rDPyGbDNJ516bqR2whTeQCfzC0+kwxmWLOZqIxKdlfyLZaWAfZtjB6SquFBAFwZoTrLlUvyIZOgEcq6LMz4rSmpL3t+7GOtoQeWlgGwZykCGco3M3DSAbCCmBxKMqPx/KKZudi1wix79ee124I9lQMBv1nDhhKeViYz2tnH9GuPKnS9mliW7ROXZ6rHKVH+rI9ng80dy3MwOB1GhXar0y2DNzbnj4/ExPRdmneC/OLh521949T8meifsmGCaVTtIGhzZo7cSt/cCSqZPmtmJCusbeKGUP5WC0nmwS0VLfziXXavn8+a5OS5vF2mmdnj3Jq7VpXp2b6fJqtEe12onx+TnywyJeb8JG29jdVbyUiEXCsqk+SVGpDUARjErFnuSYQnySyCmeKImXAwN9oHono5JNx+1CbqUmEQguxbIjMhhNF8r22FTGk+7rNguKHLxbGk54C/21Z/mJWGkgYHaFvNyO2EoR42nwSOcPTEYJRF2NAhxRTCWV6klyOrmDsgxO0S0rtXPM/nS5LM6try/v/BIXUiABmsIAmnJOfSffpXXK8idKUAioGdX1HMgVs3lHRpOXDPZSefH5B7ZffRBS3Mn9zdHaO3z2L/+Zf12ZQ+X7g3LbUpkGghU8sj40Lth9jL24306atic0bAVJBl8G8vk6EqwjmzKC4Ea7CvX9PDYgue9KHQnWkU0Z2WL+bUoAm1iLHAs0kGEPZNmDRfeSJcitfrQm5AwD8rABfPgcUfUdwUdKtB0YRnhQtcd6wCC1wyyRUtYNQG8gAzVI2WK5OZQNt4fdpvLMeGfUbSz7+sajmXJby0L/pSEhdDu/5Ieb+2Id9s6Yr/YtfnhkprUz5gX2Gz2D3fZkrL+n8rGGzGDDdvhWaa/M9tswrc4FNinQudXVqZreb8FKtnnAbmWG91jtQ1mFwwMmewbHGSU/bAM//9/OB4/5EsOh0HDCVy9PBYtnRseWi8FgcXls9EwxyEVqdqCtbWA2lZpNt7WlZ1OD52Z7e2fPDQ6uzsZis6tQDOVSw8il7DDS/4u5FMXmO/nT3rxKPaccyKWyul8vl9IhIpr3J1PTB7dPxf5HETjmhQMhWz5PKdcUZO9NsPcm5fxLFwdKjDZRVLRn5MwuG0Gylx0tOxMzmdKpTtmm/21gPhc4JUbG8S8UzjqRp70GXQyxb9IVA9Gu4lyi7MZBhPs08KAcKdIp+YSaRu6KNF45oaaxHaQRTdLIXdPIXdPIXdPIXdPIXdPIXdPIXdPIXdPIXdPIXdNy7mpR98IYSheA7h1GtrGz59TdPIeJw9iuaBugA0g9s1MOI8hYpDtKiCZxaFCyWM+dhE9bP+RepTPBQjx613i0PTUa7Bjp73QGow5Xb5dblDVdg0cTXaW8NDBXmRvwhhPOtnTU+1z/ZG9rc2QsFR4IOXFMcLS7nb5mvckZ8qXGw812qRAdKHTaXV0hb2eL3uyJQmy44ePt4muIUchmDu5geuiJ9EV3V7SjebBm0h3tao18oBlnXVovZWdaNTvTogNDRx1KF8XerOSSXBk7zkLDPCsfm6DpF8qViq09FZqIOn023QWh+8pX5movdie8pjmNubWZTyATINUWoes3sT16KReg60aazorpDvKrnFgoyRby0VrhupEZ1LMCI/yESNAtVAg5o+wHkSxhdLGQy2dc/M29ucDgCT9MsLat5AH8TO1PkQf4+/rpkkiV4Q74syBPVe6dzNiPaDYtfFKDHgYYIlm6gkEemkzeI2/TUelH37tw48alH/zZ/b/9m5d4S+3t117jnre+8x30Ne6m5XW72XXIO067At1a2umsjENw4/DsogbXngb1GlNPp2kTVGLH9DchOfUUbIWArODVilOwFadgK07BVpyCrTgFW+unYCsOMxiBU7BTpdCf1tlwLolEsx0cUhrnGrqYyHBLc7sUDzR32Czt5jbJJL163++LL5wqRQ6FmrW6BZ3B5zkpRG0JqQfUIj+7z7ABBTvwDqKuQb5vZ904CcYRZ9PomYeXTyEzmgavM3DWOfYx3D3exRbZ3binO87KOIedxAXAaXavTI/jFhq5Hh49mGcT9EzGZ9YeeHjt6sXVswtr+I8t+29Q7uggCmVuZHN0cmVhbQplbmRvYmoKOCAwIG9iago8PCAvVHlwZSAvRm9udCAvU3VidHlwZSAvVHJ1ZVR5cGUgL0Jhc2VGb250IC9BQUFBQUQrSGVsdmV0aWNhTmV1ZSAvRm9udERlc2NyaXB0b3IKMjQgMCBSIC9Ub1VuaWNvZGUgMjUgMCBSIC9GaXJzdENoYXIgMzMgL0xhc3RDaGFyIDMzIC9XaWR0aHMgWyAyNzggXSA+PgplbmRvYmoKMjUgMCBvYmoKPDwgL0xlbmd0aCAyMjIgL0ZpbHRlciAvRmxhdGVEZWNvZGUgPj4Kc3RyZWFtCngBXZC9bsQgEIR7nmLLS3ECX42QootOcpEfxckDYFhbSPGC1rjw2weIc5FSbMHMfDCsvPZPPYUM8o2jGzDDFMgzrnFjhzDiHEh0F/DB5ePUNLfYJGSBh33NuPQ0RdBaAMj3gqyZdzg9+jjiQ9Ve2SMHmuH0eR2aMmwpfeGClEEJY8DjVK57tunFLgiyoefeFz/k/Vyov8THnhBKo0J0P5Vc9Lgm65AtzSi0UkbfbkYg+X/WAYzTkbx0RtdRStmW/3UqWr94r+Q25tKm7aEVrQUC4X1VKab6YJtvfCZwQQplbmRzdHJlYW0KZW5kb2JqCjI0IDAgb2JqCjw8IC9UeXBlIC9Gb250RGVzY3JpcHRvciAvRm9udE5hbWUgL0FBQUFBRCtIZWx2ZXRpY2FOZXVlIC9GbGFncyA0IC9Gb250QkJveApbLTk1MSAtNDgxIDE5ODcgMTA3N10gL0l0YWxpY0FuZ2xlIDAgL0FzY2VudCA5NTIgL0Rlc2NlbnQgLTIxMyAvQ2FwSGVpZ2h0CjcxNCAvU3RlbVYgOTUgL0xlYWRpbmcgMjggL1hIZWlnaHQgNTE3IC9TdGVtSCA4MCAvQXZnV2lkdGggNDQ3IC9NYXhXaWR0aCAyMjI1Ci9Gb250RmlsZTIgMjYgMCBSID4+CmVuZG9iagoyNiAwIG9iago8PCAvTGVuZ3RoMSAxNzg4IC9MZW5ndGggODQ1IC9GaWx0ZXIgL0ZsYXRlRGVjb2RlID4+CnN0cmVhbQp4Aa1VTUzTUBz/v7b7AKYyvkSK2mZCiBvZFD+iMWbEjqBEM8VD60FYoMIMA4LD6EGzi5cejBcPGo8ePNaLKVxY4kFjNPHg0RiPHo3BmzB/r20apkiI4XXv/T/fv7/3y+t/5YVFk2JUIZGyE6XCPLkj9B2ia+J2WfFs9gKy88b8VMm3q0RS39TM3RueHW6DfDRtFiY9m35BnpiGw7PZMchD06XyHc8OfYOMzsxN+PFwDHa4VLjjv58+w1ZmCyXTyw9/guybn7tV9u3nkJn5BdPPZzrsi15sw8qgCxTF5MNbD3BF6nM9PI75436nNLbnzE8WFzkuenVunAv68rU//uv8+sHIa+k4zAa/grtHdGpJ6o6+RLwSec2r1A3BobYkW8YOgTqSbAX0nqWTlKSD1IrE7iStIHKh3rVMEh456RBTcveKnZpDjTCwi6iN/0boGtR47TQ1CSGKCe8ojnBqxKGGvP6SsYeGw2oPHI32LwGtOHa9H6VSipIrajYbhyGk4DisQhNTypAt9gxd0ROGYinW+UlLGVKmC5O21ONKBEzLSCs2jepFrFd11c4acqCahnEadSReB1uQbhmocNOvAOm60mtICqVGFFvszeuXdbuiyXZWM2RVVXJ2Na/bVU1WDQNZ4QApEPPje5gjwBw+jHjUqzKKGihhWBavCUvoVe2qZckWTuJ6EqrDyHfgpDxH7Mk5LJvXeSibUGXuSKgJFTgMDbUbUiOjeg5IVI6k8S9KSdtAaVMAFLkxwGtyKd21Q5Tu3g6le7ZFaXOAtI7SODA3c0pbNqc0sQWhAcPZTRiueAxXNmG4tY7htq0Zbg9wA2QH0La7DO/dIYY7t8Pwvm0x3BUgrWNYBuYuznB3wHBWtim4tGC48seVpX/e4f+lfP8GytkqDbAOdA/evbxuFaMwOj+RGniIhvHwBjlAjL0X3qJtRcjkvQyfXxq9BjPajO/xI2Z6CYniKrzNS+hbXGv4TGgwOR19IS1zZ+NZw3eEuCNEEndI2IC3YEMIGnrkauYIU+Nqa1yNsyfrH9jAwPqU8HTtsfBk7ZTwBhnuqD2jo572x4o4EyKLs8VMJjPoxhi1+KcM89Y5yIeWHDZnbpvl4kThkol/PfoN6L+nmgplbmRzdHJlYW0KZW5kb2JqCjI3IDAgb2JqCjw8IC9UaXRsZSAoYXBwbGVzKSAvUHJvZHVjZXIgKG1hY09TIFZlcnNpb24gMTUuMiBcKEJ1aWxkIDI0QzEwMVwpIFF1YXJ0eiBQREZDb250ZXh0KQovQ3JlYXRvciAoUGFnZXMpIC9DcmVhdGlvbkRhdGUgKEQ6MjAyNTAyMDYxNjAzNDFaMDAnMDAnKSAvTW9kRGF0ZSAoRDoyMDI1MDIwNjE2MDM0MVowMCcwMCcpCj4+CmVuZG9iagp4cmVmCjAgMjgKMDAwMDAwMDAwMCA2NTUzNSBmIAowMDAwMDAwNTEyIDAwMDAwIG4gCjAwMDAwMDM5NTggMDAwMDAgbiAKMDAwMDAwMDAyMiAwMDAwMCBuIAowMDAwMDAwNjE2IDAwMDAwIG4gCjAwMDAwMDM0NDggMDAwMDAgbiAKMDAwMDAwNDE4MiAwMDAwMCBuIAowMDAwMDA3MDQ4IDAwMDAwIG4gCjAwMDAwMTE5ODUgMDAwMDAgbiAKMDAwMDAwNDE0MyAwMDAwMCBuIAowMDAwMDAwNzM1IDAwMDAwIG4gCjAwMDAwMDM1NzEgMDAwMDAgbiAKMDAwMDAwMzQ4NCAwMDAwMCBuIAowMDAwMDAwMDAwIDAwMDAwIG4gCjAwMDAwMDAwMDAgMDAwMDAgbiAKMDAwMDAwMzY3MCAwMDAwMCBuIAowMDAwMDAzNzQyIDAwMDAwIG4gCjAwMDAwMDM4MTQgMDAwMDAgbiAKMDAwMDAwMzg4NiAwMDAwMCBuIAowMDAwMDA0MDQxIDAwMDAwIG4gCjAwMDAwMDQ1NjIgMDAwMDAgbiAKMDAwMDAwNDgzNiAwMDAwMCBuIAowMDAwMDA3NDY1IDAwMDAwIG4gCjAwMDAwMDc3MzEgMDAwMDAgbiAKMDAwMDAxMjQ0OCAwMDAwMCBuIAowMDAwMDEyMTUzIDAwMDAwIG4gCjAwMDAwMTI3MTMgMDAwMDAgbiAKMDAwMDAxMzY0NSAwMDAwMCBuIAp0cmFpbGVyCjw8IC9TaXplIDI4IC9Sb290IDE5IDAgUiAvSW5mbyAyNyAwIFIgL0lEIFsgPGI2ZTBhMjA4YmMwOWEwNDQ0NjU3MmU0NGQ1ODViNDQwPgo8YjZlMGEyMDhiYzA5YTA0NDQ2NTcyZTQ0ZDU4NWI0NDA+IF0gPj4Kc3RhcnR4cmVmCjEzODQxCiUlRU9GCg=="}}],
       "role": "user"}, {"role": "assistant", "content": [{"type": "text", "text":
-      "The title of the document is \"Apples are tasty\" (found at the top of the
-      first page)."}]}, {"content": [{"type": "text", "text": "What apple is not tasty
-      according to the document?"}, {"type": "text", "text": "Two word answer only."}],
-      "role": "user"}], "model": "gpt-4.1", "seed": 1014, "stream": true, "stream_options":
-      {"include_usage": true}}'
+      "The title of the document is **\"Apples are tasty\"**. This can be seen at
+      the top of the first page."}]}, {"content": [{"type": "text", "text": "What
+      apple is not tasty according to the document?"}, {"type": "text", "text": "Two
+      word answer only."}], "role": "user"}], "model": "gpt-4.1", "seed": 1014, "stream":
+      true, "stream_options": {"include_usage": true}}'
     headers:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
-      - '19991'
+      - '20005'
       Content-Type:
       - application/json
       Cookie:
-      - __cf_bm=ORGvOfF6xDUFsPJq6VHRLmwtt0T2H9bdBrQAu0Xm2nk-1767213715-1.0.1.1-Tz13E.N3zHWTmPy7SyFVAxA5XwtG5u03jpJuW4Pv1GQDKzkwaMdliTwK2XRkFJv1v4aLXCC9ezW6JOaeVhXTgB9yRy_7zMH8Nh3LDRjdN2Q;
-        _cfuvid=Gjnj8ZtQaQS6hLT9AiWLGZvyWetopV2eaZCphXjMt1g-1767213715314-0.0.1.1-604800000
+      - __cf_bm=0F0SWwMLQmnsUvFavWarN6OCQlVXoVZixu_IrjGF1gs-1776367303.370414-1.0.1.1-WugpGFAI0Irm5lw1OLIwKZrI0MuaOIr10CmMPYStZJgOQQ2mheEHi0pYUHR8KpMRqIHoRhk2U51bZjZvSCOYNc4p7tV0S2IZLLHA1862XD3UMVAi7bXNXGMi6E30stE8
       Host:
       - api.openai.com
       X-Stainless-Async:
@@ -201,20 +216,20 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CsxIyyFpPSmuUcif9wykJRrNhJ3jP","object":"chat.completion.chunk","created":1767213716,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"fjG6XaROtlhFK"}
+      string: 'data: {"id":"chatcmpl-DVMZWy0mXr53pWcoXztZ6VcvEunsN","object":"chat.completion.chunk","created":1776367306,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"JgdHnQ78OpB0i"}
 
 
-        data: {"id":"chatcmpl-CsxIyyFpPSmuUcif9wykJRrNhJ3jP","object":"chat.completion.chunk","created":1767213716,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"Red"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"bOx2dQUeookq"}
+        data: {"id":"chatcmpl-DVMZWy0mXr53pWcoXztZ6VcvEunsN","object":"chat.completion.chunk","created":1776367306,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"Red"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"N1CRpqG7sr7T"}
 
 
-        data: {"id":"chatcmpl-CsxIyyFpPSmuUcif9wykJRrNhJ3jP","object":"chat.completion.chunk","created":1767213716,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        delicious"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"oYEPF"}
+        data: {"id":"chatcmpl-DVMZWy0mXr53pWcoXztZ6VcvEunsN","object":"chat.completion.chunk","created":1776367306,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{"content":"
+        delicious"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"zf8i2"}
 
 
-        data: {"id":"chatcmpl-CsxIyyFpPSmuUcif9wykJRrNhJ3jP","object":"chat.completion.chunk","created":1767213716,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"jgE1OBRpr"}
+        data: {"id":"chatcmpl-DVMZWy0mXr53pWcoXztZ6VcvEunsN","object":"chat.completion.chunk","created":1776367306,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"oxhSg1mPf"}
 
 
-        data: {"id":"chatcmpl-CsxIyyFpPSmuUcif9wykJRrNhJ3jP","object":"chat.completion.chunk","created":1767213716,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[],"usage":{"prompt_tokens":313,"completion_tokens":2,"total_tokens":315,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"aGGfcYVOTkuFV"}
+        data: {"id":"chatcmpl-DVMZWy0mXr53pWcoXztZ6VcvEunsN","object":"chat.completion.chunk","created":1776367306,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_3c41ab60ec","choices":[],"usage":{"prompt_tokens":395,"completion_tokens":2,"total_tokens":397,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"1DkBtEAaIMEOf"}
 
 
         data: [DONE]
@@ -222,14 +237,16 @@ interactions:
 
         '
     headers:
-      CF-RAY:
-      - 9b6c99bbc822fa11-ORD
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9ed58e096979fc3a-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:56 GMT
+      - Thu, 16 Apr 2026 19:21:46 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -242,14 +259,10 @@ interactions:
       - X-Request-ID
       alt-svc:
       - h3=":443"; ma=86400
-      cf-cache-status:
-      - DYNAMIC
       openai-processing-ms:
-      - '686'
+      - '1392'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '705'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -259,7 +272,7 @@ interactions:
       x-ratelimit-remaining-requests:
       - '9999'
       x-ratelimit-remaining-tokens:
-      - '29999183'
+      - '29999180'
       x-ratelimit-reset-requests:
       - 6ms
       x-ratelimit-reset-tokens:

--- a/tests/_vcr/test_provider_openai_completions/test_openai_respects_turns_interface.yaml
+++ b/tests/_vcr/test_provider_openai_completions/test_openai_respects_turns_interface.yaml
@@ -8,7 +8,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -25,32 +25,32 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CsxIYvRVonKkHOwYgTxmZPLhUl5BE","object":"chat.completion.chunk","created":1767213690,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"lQMbIsFfmwGxq"}
+      string: 'data: {"id":"chatcmpl-DVMZ6Kzsi2PiHDy8Y6g1guO9nBDuJ","object":"chat.completion.chunk","created":1776367280,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"KzGHu06ctK8GZ"}
 
 
-        data: {"id":"chatcmpl-CsxIYvRVonKkHOwYgTxmZPLhUl5BE","object":"chat.completion.chunk","created":1767213690,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"CH"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"X7Xn57w7U8r5l"}
+        data: {"id":"chatcmpl-DVMZ6Kzsi2PiHDy8Y6g1guO9nBDuJ","object":"chat.completion.chunk","created":1776367280,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[{"index":0,"delta":{"content":"CH"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Wj0YAUOcrFZIa"}
 
 
-        data: {"id":"chatcmpl-CsxIYvRVonKkHOwYgTxmZPLhUl5BE","object":"chat.completion.chunk","created":1767213690,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"RIST"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"JAW0X9Oe9xQ"}
+        data: {"id":"chatcmpl-DVMZ6Kzsi2PiHDy8Y6g1guO9nBDuJ","object":"chat.completion.chunk","created":1776367280,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[{"index":0,"delta":{"content":"RIST"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"8mgkFBhLfUw"}
 
 
-        data: {"id":"chatcmpl-CsxIYvRVonKkHOwYgTxmZPLhUl5BE","object":"chat.completion.chunk","created":1767213690,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"OP"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"0pFDbEHx9y1Hq"}
+        data: {"id":"chatcmpl-DVMZ6Kzsi2PiHDy8Y6g1guO9nBDuJ","object":"chat.completion.chunk","created":1776367280,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[{"index":0,"delta":{"content":"OP"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"8CfnFombUd9sL"}
 
 
-        data: {"id":"chatcmpl-CsxIYvRVonKkHOwYgTxmZPLhUl5BE","object":"chat.completion.chunk","created":1767213690,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"HER"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"ogVqdDn04tz1"}
+        data: {"id":"chatcmpl-DVMZ6Kzsi2PiHDy8Y6g1guO9nBDuJ","object":"chat.completion.chunk","created":1776367280,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[{"index":0,"delta":{"content":"HER"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"FgsfgYIGWzLA"}
 
 
-        data: {"id":"chatcmpl-CsxIYvRVonKkHOwYgTxmZPLhUl5BE","object":"chat.completion.chunk","created":1767213690,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        ROB"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"kFVdraTlzjL"}
+        data: {"id":"chatcmpl-DVMZ6Kzsi2PiHDy8Y6g1guO9nBDuJ","object":"chat.completion.chunk","created":1776367280,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[{"index":0,"delta":{"content":"
+        ROB"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"uYr3KQpWjwY"}
 
 
-        data: {"id":"chatcmpl-CsxIYvRVonKkHOwYgTxmZPLhUl5BE","object":"chat.completion.chunk","created":1767213690,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"IN"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"9wBCa4NHOMHI3"}
+        data: {"id":"chatcmpl-DVMZ6Kzsi2PiHDy8Y6g1guO9nBDuJ","object":"chat.completion.chunk","created":1776367280,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[{"index":0,"delta":{"content":"IN"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"bkkMew5xzTgDr"}
 
 
-        data: {"id":"chatcmpl-CsxIYvRVonKkHOwYgTxmZPLhUl5BE","object":"chat.completion.chunk","created":1767213690,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"5gNlLlbwy"}
+        data: {"id":"chatcmpl-DVMZ6Kzsi2PiHDy8Y6g1guO9nBDuJ","object":"chat.completion.chunk","created":1776367280,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"P4U7SCHmR"}
 
 
-        data: {"id":"chatcmpl-CsxIYvRVonKkHOwYgTxmZPLhUl5BE","object":"chat.completion.chunk","created":1767213690,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[],"usage":{"prompt_tokens":35,"completion_tokens":6,"total_tokens":41,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"oMj6ZNQEGEtA21U"}
+        data: {"id":"chatcmpl-DVMZ6Kzsi2PiHDy8Y6g1guO9nBDuJ","object":"chat.completion.chunk","created":1776367280,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[],"usage":{"prompt_tokens":35,"completion_tokens":6,"total_tokens":41,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"xSmMKKfI4sq2Yvh"}
 
 
         data: [DONE]
@@ -58,14 +58,16 @@ interactions:
 
         '
     headers:
-      CF-RAY:
-      - 9b6c99199aad19b0-ORD
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9ed58d6c7ca8eb08-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:30 GMT
+      - Thu, 16 Apr 2026 19:21:20 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -78,14 +80,10 @@ interactions:
       - X-Request-ID
       alt-svc:
       - h3=":443"; ma=86400
-      cf-cache-status:
-      - DYNAMIC
       openai-processing-ms:
-      - '152'
+      - '319'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '406'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -112,7 +110,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -129,32 +127,32 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CsxIZTqeAHEWRbWr5exOEFot6cNYc","object":"chat.completion.chunk","created":1767213691,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"ji5g2vrgYDxNM"}
+      string: 'data: {"id":"chatcmpl-DVMZ78LdmNRHL5SSJozZSZpm7iZL4","object":"chat.completion.chunk","created":1776367281,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"T6RIL7xx6V8Af"}
 
 
-        data: {"id":"chatcmpl-CsxIZTqeAHEWRbWr5exOEFot6cNYc","object":"chat.completion.chunk","created":1767213691,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"CH"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"wc9KYE7nrQwiG"}
+        data: {"id":"chatcmpl-DVMZ78LdmNRHL5SSJozZSZpm7iZL4","object":"chat.completion.chunk","created":1776367281,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[{"index":0,"delta":{"content":"CH"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"uynqr7ou4kok9"}
 
 
-        data: {"id":"chatcmpl-CsxIZTqeAHEWRbWr5exOEFot6cNYc","object":"chat.completion.chunk","created":1767213691,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"RIST"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"elSP6vm3f53"}
+        data: {"id":"chatcmpl-DVMZ78LdmNRHL5SSJozZSZpm7iZL4","object":"chat.completion.chunk","created":1776367281,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[{"index":0,"delta":{"content":"RIST"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"9C2Ne1hmM8C"}
 
 
-        data: {"id":"chatcmpl-CsxIZTqeAHEWRbWr5exOEFot6cNYc","object":"chat.completion.chunk","created":1767213691,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"OP"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"xydLpDwwO1LCa"}
+        data: {"id":"chatcmpl-DVMZ78LdmNRHL5SSJozZSZpm7iZL4","object":"chat.completion.chunk","created":1776367281,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[{"index":0,"delta":{"content":"OP"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"PzCknkNq8phlp"}
 
 
-        data: {"id":"chatcmpl-CsxIZTqeAHEWRbWr5exOEFot6cNYc","object":"chat.completion.chunk","created":1767213691,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"HER"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"nBcSbGiWIcq1"}
+        data: {"id":"chatcmpl-DVMZ78LdmNRHL5SSJozZSZpm7iZL4","object":"chat.completion.chunk","created":1776367281,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[{"index":0,"delta":{"content":"HER"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"4j8xXLyS0ENP"}
 
 
-        data: {"id":"chatcmpl-CsxIZTqeAHEWRbWr5exOEFot6cNYc","object":"chat.completion.chunk","created":1767213691,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        ROB"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"ZioATSn2cof"}
+        data: {"id":"chatcmpl-DVMZ78LdmNRHL5SSJozZSZpm7iZL4","object":"chat.completion.chunk","created":1776367281,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[{"index":0,"delta":{"content":"
+        ROB"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"oLRvN5z37t5"}
 
 
-        data: {"id":"chatcmpl-CsxIZTqeAHEWRbWr5exOEFot6cNYc","object":"chat.completion.chunk","created":1767213691,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"IN"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"BVaA6wZyC0Bch"}
+        data: {"id":"chatcmpl-DVMZ78LdmNRHL5SSJozZSZpm7iZL4","object":"chat.completion.chunk","created":1776367281,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[{"index":0,"delta":{"content":"IN"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"fjZOhjGa3AsMB"}
 
 
-        data: {"id":"chatcmpl-CsxIZTqeAHEWRbWr5exOEFot6cNYc","object":"chat.completion.chunk","created":1767213691,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"sAgUnO3i5"}
+        data: {"id":"chatcmpl-DVMZ78LdmNRHL5SSJozZSZpm7iZL4","object":"chat.completion.chunk","created":1776367281,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"foVLj6gAq"}
 
 
-        data: {"id":"chatcmpl-CsxIZTqeAHEWRbWr5exOEFot6cNYc","object":"chat.completion.chunk","created":1767213691,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[],"usage":{"prompt_tokens":35,"completion_tokens":6,"total_tokens":41,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"w7o5OspLVEoxaHf"}
+        data: {"id":"chatcmpl-DVMZ78LdmNRHL5SSJozZSZpm7iZL4","object":"chat.completion.chunk","created":1776367281,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[],"usage":{"prompt_tokens":35,"completion_tokens":6,"total_tokens":41,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"wtAEBevcLwNbj17"}
 
 
         data: [DONE]
@@ -162,14 +160,16 @@ interactions:
 
         '
     headers:
-      CF-RAY:
-      - 9b6c99216a23011d-ORD
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9ed58d7218b9e254-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:31 GMT
+      - Thu, 16 Apr 2026 19:21:21 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -182,14 +182,10 @@ interactions:
       - X-Request-ID
       alt-svc:
       - h3=":443"; ma=86400
-      cf-cache-status:
-      - DYNAMIC
       openai-processing-ms:
-      - '190'
+      - '311'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '320'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -217,7 +213,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -234,65 +230,65 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CsxIbb72DW4eoaJ5x5qZELtI1drSv","object":"chat.completion.chunk","created":1767213693,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"bXLIERkCnsWyN"}
+      string: 'data: {"id":"chatcmpl-DVMZ8lLnMlozvcR14WehpbFDckauS","object":"chat.completion.chunk","created":1776367282,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"iuRIwoerYHRs0"}
 
 
-        data: {"id":"chatcmpl-CsxIbb72DW4eoaJ5x5qZELtI1drSv","object":"chat.completion.chunk","created":1767213693,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"Your"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"uRncgNaR44i"}
+        data: {"id":"chatcmpl-DVMZ8lLnMlozvcR14WehpbFDckauS","object":"chat.completion.chunk","created":1776367282,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[{"index":0,"delta":{"content":"Your"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"BkVg1ttnE0P"}
 
 
-        data: {"id":"chatcmpl-CsxIbb72DW4eoaJ5x5qZELtI1drSv","object":"chat.completion.chunk","created":1767213693,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        name"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"f3R4F5NuSB"}
+        data: {"id":"chatcmpl-DVMZ8lLnMlozvcR14WehpbFDckauS","object":"chat.completion.chunk","created":1776367282,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[{"index":0,"delta":{"content":"
+        name"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"vPUEaaDOUG"}
 
 
-        data: {"id":"chatcmpl-CsxIbb72DW4eoaJ5x5qZELtI1drSv","object":"chat.completion.chunk","created":1767213693,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        is"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"lXzfq5KQwXtb"}
+        data: {"id":"chatcmpl-DVMZ8lLnMlozvcR14WehpbFDckauS","object":"chat.completion.chunk","created":1776367282,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[{"index":0,"delta":{"content":"
+        is"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"XW2wtOtF17pj"}
 
 
-        data: {"id":"chatcmpl-CsxIbb72DW4eoaJ5x5qZELtI1drSv","object":"chat.completion.chunk","created":1767213693,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        Steve"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Wl6chby3s"}
+        data: {"id":"chatcmpl-DVMZ8lLnMlozvcR14WehpbFDckauS","object":"chat.completion.chunk","created":1776367282,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[{"index":0,"delta":{"content":"
+        Steve"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"J75U448hm"}
 
 
-        data: {"id":"chatcmpl-CsxIbb72DW4eoaJ5x5qZELtI1drSv","object":"chat.completion.chunk","created":1767213693,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"!"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"nDhq0TCjjCfYiL"}
+        data: {"id":"chatcmpl-DVMZ8lLnMlozvcR14WehpbFDckauS","object":"chat.completion.chunk","created":1776367282,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[{"index":0,"delta":{"content":"!"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"feYkxy5EBxIUBF"}
 
 
-        data: {"id":"chatcmpl-CsxIbb72DW4eoaJ5x5qZELtI1drSv","object":"chat.completion.chunk","created":1767213693,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        How"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"ML5QQthD3im"}
+        data: {"id":"chatcmpl-DVMZ8lLnMlozvcR14WehpbFDckauS","object":"chat.completion.chunk","created":1776367282,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[{"index":0,"delta":{"content":"
+        How"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"7ZwyWPq9WHL"}
 
 
-        data: {"id":"chatcmpl-CsxIbb72DW4eoaJ5x5qZELtI1drSv","object":"chat.completion.chunk","created":1767213693,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        can"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"QfN3OiiSDqV"}
+        data: {"id":"chatcmpl-DVMZ8lLnMlozvcR14WehpbFDckauS","object":"chat.completion.chunk","created":1776367282,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[{"index":0,"delta":{"content":"
+        can"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"EjFbQWyPbVd"}
 
 
-        data: {"id":"chatcmpl-CsxIbb72DW4eoaJ5x5qZELtI1drSv","object":"chat.completion.chunk","created":1767213693,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        I"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"GpnjaVhK1aVZS"}
+        data: {"id":"chatcmpl-DVMZ8lLnMlozvcR14WehpbFDckauS","object":"chat.completion.chunk","created":1776367282,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[{"index":0,"delta":{"content":"
+        I"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"PEuVrx8yGLsRP"}
 
 
-        data: {"id":"chatcmpl-CsxIbb72DW4eoaJ5x5qZELtI1drSv","object":"chat.completion.chunk","created":1767213693,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        assist"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"q3GiH3fo"}
+        data: {"id":"chatcmpl-DVMZ8lLnMlozvcR14WehpbFDckauS","object":"chat.completion.chunk","created":1776367282,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[{"index":0,"delta":{"content":"
+        assist"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"ZGmCBBY0"}
 
 
-        data: {"id":"chatcmpl-CsxIbb72DW4eoaJ5x5qZELtI1drSv","object":"chat.completion.chunk","created":1767213693,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        you"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"dvfGdRSPOh3"}
+        data: {"id":"chatcmpl-DVMZ8lLnMlozvcR14WehpbFDckauS","object":"chat.completion.chunk","created":1776367282,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[{"index":0,"delta":{"content":"
+        you"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"lGmTxgyrApa"}
 
 
-        data: {"id":"chatcmpl-CsxIbb72DW4eoaJ5x5qZELtI1drSv","object":"chat.completion.chunk","created":1767213693,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        today"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"9aRUT95Y5"}
+        data: {"id":"chatcmpl-DVMZ8lLnMlozvcR14WehpbFDckauS","object":"chat.completion.chunk","created":1776367282,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[{"index":0,"delta":{"content":"
+        today"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"W0wZdoTuH"}
 
 
-        data: {"id":"chatcmpl-CsxIbb72DW4eoaJ5x5qZELtI1drSv","object":"chat.completion.chunk","created":1767213693,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"wnDjy8quVgvGDX"}
+        data: {"id":"chatcmpl-DVMZ8lLnMlozvcR14WehpbFDckauS","object":"chat.completion.chunk","created":1776367282,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Sw6OLe6FeFaXzh"}
 
 
-        data: {"id":"chatcmpl-CsxIbb72DW4eoaJ5x5qZELtI1drSv","object":"chat.completion.chunk","created":1767213693,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        Steve"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"dGvFjOEkj"}
+        data: {"id":"chatcmpl-DVMZ8lLnMlozvcR14WehpbFDckauS","object":"chat.completion.chunk","created":1776367282,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[{"index":0,"delta":{"content":"
+        Steve"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"ntHu4sHDE"}
 
 
-        data: {"id":"chatcmpl-CsxIbb72DW4eoaJ5x5qZELtI1drSv","object":"chat.completion.chunk","created":1767213693,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"?"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Cl3SaQdpAOGuwp"}
+        data: {"id":"chatcmpl-DVMZ8lLnMlozvcR14WehpbFDckauS","object":"chat.completion.chunk","created":1776367282,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[{"index":0,"delta":{"content":"?"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"PWdmOMYdnP0MaW"}
 
 
-        data: {"id":"chatcmpl-CsxIbb72DW4eoaJ5x5qZELtI1drSv","object":"chat.completion.chunk","created":1767213693,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"XiimZEsvZ"}
+        data: {"id":"chatcmpl-DVMZ8lLnMlozvcR14WehpbFDckauS","object":"chat.completion.chunk","created":1776367282,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"RNoB06sNo"}
 
 
-        data: {"id":"chatcmpl-CsxIbb72DW4eoaJ5x5qZELtI1drSv","object":"chat.completion.chunk","created":1767213693,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[],"usage":{"prompt_tokens":34,"completion_tokens":14,"total_tokens":48,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"UwDVOtaS1g8tAu"}
+        data: {"id":"chatcmpl-DVMZ8lLnMlozvcR14WehpbFDckauS","object":"chat.completion.chunk","created":1776367282,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[],"usage":{"prompt_tokens":34,"completion_tokens":14,"total_tokens":48,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"cpveRmfVrxv9EB"}
 
 
         data: [DONE]
@@ -300,14 +296,16 @@ interactions:
 
         '
     headers:
-      CF-RAY:
-      - 9b6c9928ac6b0bf0-ORD
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9ed58d768b9998b9-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:33 GMT
+      - Thu, 16 Apr 2026 19:21:22 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -320,14 +318,10 @@ interactions:
       - X-Request-ID
       alt-svc:
       - h3=":443"; ma=86400
-      cf-cache-status:
-      - DYNAMIC
       openai-processing-ms:
-      - '281'
+      - '316'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '516'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:

--- a/tests/_vcr/test_provider_openai_completions/test_openai_simple_request.yaml
+++ b/tests/_vcr/test_provider_openai_completions/test_openai_simple_request.yaml
@@ -8,7 +8,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -25,16 +25,16 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CsxIWvSTKBsZ6ssoNC9DQXdtKlwxw","object":"chat.completion.chunk","created":1767213688,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"35DOGHngxPXoX"}
+      string: 'data: {"id":"chatcmpl-DVMZ47XFpzjwsXOS53xv9DRdw6r22","object":"chat.completion.chunk","created":1776367278,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"6va8AF4jCP7Ai"}
 
 
-        data: {"id":"chatcmpl-CsxIWvSTKBsZ6ssoNC9DQXdtKlwxw","object":"chat.completion.chunk","created":1767213688,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"2"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"MgX0WVfFnKRCQP"}
+        data: {"id":"chatcmpl-DVMZ47XFpzjwsXOS53xv9DRdw6r22","object":"chat.completion.chunk","created":1776367278,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[{"index":0,"delta":{"content":"2"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"TXb3GQeqjur5w7"}
 
 
-        data: {"id":"chatcmpl-CsxIWvSTKBsZ6ssoNC9DQXdtKlwxw","object":"chat.completion.chunk","created":1767213688,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"nvcztzWX1"}
+        data: {"id":"chatcmpl-DVMZ47XFpzjwsXOS53xv9DRdw6r22","object":"chat.completion.chunk","created":1776367278,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"9hTLtfU6S"}
 
 
-        data: {"id":"chatcmpl-CsxIWvSTKBsZ6ssoNC9DQXdtKlwxw","object":"chat.completion.chunk","created":1767213688,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[],"usage":{"prompt_tokens":27,"completion_tokens":1,"total_tokens":28,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"HbCEQwXDEJgq41T"}
+        data: {"id":"chatcmpl-DVMZ47XFpzjwsXOS53xv9DRdw6r22","object":"chat.completion.chunk","created":1776367278,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[],"usage":{"prompt_tokens":27,"completion_tokens":1,"total_tokens":28,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"iZ4nSD7WuolHPKK"}
 
 
         data: [DONE]
@@ -42,14 +42,16 @@ interactions:
 
         '
     headers:
-      CF-RAY:
-      - 9b6c990b2fc32ced-ORD
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9ed58d5de9bc3bdc-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:28 GMT
+      - Thu, 16 Apr 2026 19:21:18 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -62,14 +64,10 @@ interactions:
       - X-Request-ID
       alt-svc:
       - h3=":443"; ma=86400
-      cf-cache-status:
-      - DYNAMIC
       openai-processing-ms:
-      - '185'
+      - '359'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '338'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:

--- a/tests/_vcr/test_provider_openai_completions/test_openai_simple_streaming_request.yaml
+++ b/tests/_vcr/test_provider_openai_completions/test_openai_simple_streaming_request.yaml
@@ -8,7 +8,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -25,16 +25,16 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CsxIXTyLAnWkbHcAwNnPPrmpWvcQn","object":"chat.completion.chunk","created":1767213689,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Rg8dV18wLe7qy"}
+      string: 'data: {"id":"chatcmpl-DVMZ5yIuY32QKvzuNiPkXWrp61ple","object":"chat.completion.chunk","created":1776367279,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"kkm0KDXu80SZ8"}
 
 
-        data: {"id":"chatcmpl-CsxIXTyLAnWkbHcAwNnPPrmpWvcQn","object":"chat.completion.chunk","created":1767213689,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"2"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"XS37Ja6mv4yeL6"}
+        data: {"id":"chatcmpl-DVMZ5yIuY32QKvzuNiPkXWrp61ple","object":"chat.completion.chunk","created":1776367279,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[{"index":0,"delta":{"content":"2"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"tParcgMSde9g71"}
 
 
-        data: {"id":"chatcmpl-CsxIXTyLAnWkbHcAwNnPPrmpWvcQn","object":"chat.completion.chunk","created":1767213689,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"Gwx8fAwwW"}
+        data: {"id":"chatcmpl-DVMZ5yIuY32QKvzuNiPkXWrp61ple","object":"chat.completion.chunk","created":1776367279,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"IOobXNysJ"}
 
 
-        data: {"id":"chatcmpl-CsxIXTyLAnWkbHcAwNnPPrmpWvcQn","object":"chat.completion.chunk","created":1767213689,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[],"usage":{"prompt_tokens":27,"completion_tokens":1,"total_tokens":28,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"uDttX21sxoXYggU"}
+        data: {"id":"chatcmpl-DVMZ5yIuY32QKvzuNiPkXWrp61ple","object":"chat.completion.chunk","created":1776367279,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_0551618383","choices":[],"usage":{"prompt_tokens":27,"completion_tokens":1,"total_tokens":28,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"UH9ZkuSPeIpJSTa"}
 
 
         data: [DONE]
@@ -42,14 +42,16 @@ interactions:
 
         '
     headers:
-      CF-RAY:
-      - 9b6c99110c57f851-ORD
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9ed58d670be4eadc-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:29 GMT
+      - Thu, 16 Apr 2026 19:21:19 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -62,14 +64,10 @@ interactions:
       - X-Request-ID
       alt-svc:
       - h3=":443"; ma=86400
-      cf-cache-status:
-      - DYNAMIC
       openai-processing-ms:
-      - '274'
+      - '311'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '533'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:

--- a/tests/_vcr/test_provider_openai_completions/test_openai_tool_variations.yaml
+++ b/tests/_vcr/test_provider_openai_completions/test_openai_tool_variations.yaml
@@ -11,7 +11,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -28,16 +28,16 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CsxIbPcbXRItVubSB6vSVxaHSC7Ik","object":"chat.completion.chunk","created":1767213693,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_7le0pHsyW59jcigp72v0YiII","type":"function","function":{"name":"get_date","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"S0yjmOlmH3F"}
+      string: 'data: {"id":"chatcmpl-DVMZ9nIIblPQNY6wcdwMphHzURITN","object":"chat.completion.chunk","created":1776367283,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_ea8b6bc153","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_skV9zDpk9TiZa36XnJxfUtKA","type":"function","function":{"name":"get_date","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"h8j8qepP3xp"}
 
 
-        data: {"id":"chatcmpl-CsxIbPcbXRItVubSB6vSVxaHSC7Ik","object":"chat.completion.chunk","created":1767213693,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{}"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"VaW"}
+        data: {"id":"chatcmpl-DVMZ9nIIblPQNY6wcdwMphHzURITN","object":"chat.completion.chunk","created":1776367283,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_ea8b6bc153","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{}"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"zlr"}
 
 
-        data: {"id":"chatcmpl-CsxIbPcbXRItVubSB6vSVxaHSC7Ik","object":"chat.completion.chunk","created":1767213693,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"usage":null,"obfuscation":"Nbt"}
+        data: {"id":"chatcmpl-DVMZ9nIIblPQNY6wcdwMphHzURITN","object":"chat.completion.chunk","created":1776367283,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_ea8b6bc153","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"usage":null,"obfuscation":"M6H"}
 
 
-        data: {"id":"chatcmpl-CsxIbPcbXRItVubSB6vSVxaHSC7Ik","object":"chat.completion.chunk","created":1767213693,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[],"usage":{"prompt_tokens":63,"completion_tokens":10,"total_tokens":73,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"YzFqv0920yAjaK"}
+        data: {"id":"chatcmpl-DVMZ9nIIblPQNY6wcdwMphHzURITN","object":"chat.completion.chunk","created":1776367283,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_ea8b6bc153","choices":[],"usage":{"prompt_tokens":63,"completion_tokens":10,"total_tokens":73,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"baxIAAXm71ncgP"}
 
 
         data: [DONE]
@@ -45,14 +45,16 @@ interactions:
 
         '
     headers:
-      CF-RAY:
-      - 9b6c99311e9bef30-ORD
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9ed58d7e3c6de819-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:33 GMT
+      - Thu, 16 Apr 2026 19:21:23 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -65,14 +67,10 @@ interactions:
       - X-Request-ID
       alt-svc:
       - h3=":443"; ma=86400
-      cf-cache-status:
-      - DYNAMIC
       openai-processing-ms:
-      - '183'
+      - '387'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '196'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -94,9 +92,9 @@ interactions:
     body: '{"messages": [{"content": "Always use a tool to help you answer. Reply
       with ''It is ____.''.", "role": "system"}, {"content": [{"type": "text", "text":
       "What''s the current date in YYYY-MM-DD format?"}], "role": "user"}, {"role":
-      "assistant", "tool_calls": [{"id": "call_7le0pHsyW59jcigp72v0YiII", "function":
+      "assistant", "tool_calls": [{"id": "call_skV9zDpk9TiZa36XnJxfUtKA", "function":
       {"name": "get_date", "arguments": "{}"}, "type": "function"}]}, {"content":
-      "2024-01-01", "tool_call_id": "call_7le0pHsyW59jcigp72v0YiII", "role": "tool"}],
+      "2024-01-01", "tool_call_id": "call_skV9zDpk9TiZa36XnJxfUtKA", "role": "tool"}],
       "model": "gpt-4.1", "seed": 1014, "stream": true, "stream_options": {"include_usage":
       true}, "tools": [{"type": "function", "function": {"name": "get_date", "description":
       "Gets the current date", "parameters": {"properties": {}, "type": "object",
@@ -105,7 +103,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -113,8 +111,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - __cf_bm=Sq.4DwUNSGLUSi.YloK3A6tg6SoTWG_cBqN3cyyDTI0-1767213693-1.0.1.1-GiwOtpPNMf2r4kNoolkMaidivsctNR5fGznbPhMP8NFKShRqB6tO7aAPsXCOY6WmgdtAqbVcrs6EB3owT3CJKLaPMCFEWiBW.YQx7yV07wI;
-        _cfuvid=KzzW3bB3xdHH7GQ32tZ3Eb54M.4QSCeE_goJgpG55R4-1767213693898-0.0.1.1-604800000
+      - __cf_bm=0X952pPYMzipvaGvQ8_fSAIp8ySmHIZoScBw72QeiIE-1776367282.9204953-1.0.1.1-v24QDfgrni15oJGbMPNXY.xSZyl7NihNsne.nD1O6m.05TgoNGJdawK5h7TwFhMVFG36QDFnW866PQ4VjtYYPveGxAtBi6YSt__T06TytzTK8.7bBJRDclDhBZIhZDPU
       Host:
       - api.openai.com
       X-Stainless-Async:
@@ -125,45 +122,45 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CsxIcjwewcoqVzQRX29nHlXtqX3op","object":"chat.completion.chunk","created":1767213694,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"94AfK8yLWO86w"}
+      string: 'data: {"id":"chatcmpl-DVMZ9uj6aMY7thmv4hkPLvjgJfeFc","object":"chat.completion.chunk","created":1776367283,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_ea8b6bc153","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"0kmj2KlpM5wFW"}
 
 
-        data: {"id":"chatcmpl-CsxIcjwewcoqVzQRX29nHlXtqX3op","object":"chat.completion.chunk","created":1767213694,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"It"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"NIKrcNb81naOL"}
+        data: {"id":"chatcmpl-DVMZ9uj6aMY7thmv4hkPLvjgJfeFc","object":"chat.completion.chunk","created":1776367283,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_ea8b6bc153","choices":[{"index":0,"delta":{"content":"It"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"A5FdZylLzmDSE"}
 
 
-        data: {"id":"chatcmpl-CsxIcjwewcoqVzQRX29nHlXtqX3op","object":"chat.completion.chunk","created":1767213694,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        is"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"m6mYcDsJTEyY"}
+        data: {"id":"chatcmpl-DVMZ9uj6aMY7thmv4hkPLvjgJfeFc","object":"chat.completion.chunk","created":1776367283,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_ea8b6bc153","choices":[{"index":0,"delta":{"content":"
+        is"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"cdvUrUbGC1E9"}
 
 
-        data: {"id":"chatcmpl-CsxIcjwewcoqVzQRX29nHlXtqX3op","object":"chat.completion.chunk","created":1767213694,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        "},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"pN6CYSQUvr9OdD"}
+        data: {"id":"chatcmpl-DVMZ9uj6aMY7thmv4hkPLvjgJfeFc","object":"chat.completion.chunk","created":1776367283,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_ea8b6bc153","choices":[{"index":0,"delta":{"content":"
+        "},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"hx7y0Fh5l0Ami1"}
 
 
-        data: {"id":"chatcmpl-CsxIcjwewcoqVzQRX29nHlXtqX3op","object":"chat.completion.chunk","created":1767213694,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"202"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"YRyUduxoir3L"}
+        data: {"id":"chatcmpl-DVMZ9uj6aMY7thmv4hkPLvjgJfeFc","object":"chat.completion.chunk","created":1776367283,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_ea8b6bc153","choices":[{"index":0,"delta":{"content":"202"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"6D7oSvNWy5I5"}
 
 
-        data: {"id":"chatcmpl-CsxIcjwewcoqVzQRX29nHlXtqX3op","object":"chat.completion.chunk","created":1767213694,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"4"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"xmAAuh5vVOVS4Y"}
+        data: {"id":"chatcmpl-DVMZ9uj6aMY7thmv4hkPLvjgJfeFc","object":"chat.completion.chunk","created":1776367283,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_ea8b6bc153","choices":[{"index":0,"delta":{"content":"4"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"BY57GqY4lUgG9y"}
 
 
-        data: {"id":"chatcmpl-CsxIcjwewcoqVzQRX29nHlXtqX3op","object":"chat.completion.chunk","created":1767213694,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"-"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"dYrntDeD6md2lq"}
+        data: {"id":"chatcmpl-DVMZ9uj6aMY7thmv4hkPLvjgJfeFc","object":"chat.completion.chunk","created":1776367283,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_ea8b6bc153","choices":[{"index":0,"delta":{"content":"-"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"ngpnGfoNjSyD1A"}
 
 
-        data: {"id":"chatcmpl-CsxIcjwewcoqVzQRX29nHlXtqX3op","object":"chat.completion.chunk","created":1767213694,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"01"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"7AJ2U2Zrg7A3J"}
+        data: {"id":"chatcmpl-DVMZ9uj6aMY7thmv4hkPLvjgJfeFc","object":"chat.completion.chunk","created":1776367283,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_ea8b6bc153","choices":[{"index":0,"delta":{"content":"01"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Ne42Qd5j53aq6"}
 
 
-        data: {"id":"chatcmpl-CsxIcjwewcoqVzQRX29nHlXtqX3op","object":"chat.completion.chunk","created":1767213694,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"-"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"a8tOqVXWkliJ8P"}
+        data: {"id":"chatcmpl-DVMZ9uj6aMY7thmv4hkPLvjgJfeFc","object":"chat.completion.chunk","created":1776367283,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_ea8b6bc153","choices":[{"index":0,"delta":{"content":"-"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"TrdsQlGwBLuqEQ"}
 
 
-        data: {"id":"chatcmpl-CsxIcjwewcoqVzQRX29nHlXtqX3op","object":"chat.completion.chunk","created":1767213694,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"01"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"pCdxTnhsz0d2a"}
+        data: {"id":"chatcmpl-DVMZ9uj6aMY7thmv4hkPLvjgJfeFc","object":"chat.completion.chunk","created":1776367283,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_ea8b6bc153","choices":[{"index":0,"delta":{"content":"01"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"u2AxXwnpNM4lC"}
 
 
-        data: {"id":"chatcmpl-CsxIcjwewcoqVzQRX29nHlXtqX3op","object":"chat.completion.chunk","created":1767213694,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"1DpPC4RLMuhgvz"}
+        data: {"id":"chatcmpl-DVMZ9uj6aMY7thmv4hkPLvjgJfeFc","object":"chat.completion.chunk","created":1776367283,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_ea8b6bc153","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"aTJBbeHAuYmqqC"}
 
 
-        data: {"id":"chatcmpl-CsxIcjwewcoqVzQRX29nHlXtqX3op","object":"chat.completion.chunk","created":1767213694,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"eP0U8dUKC"}
+        data: {"id":"chatcmpl-DVMZ9uj6aMY7thmv4hkPLvjgJfeFc","object":"chat.completion.chunk","created":1776367283,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_ea8b6bc153","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"3uMG6ADi0"}
 
 
-        data: {"id":"chatcmpl-CsxIcjwewcoqVzQRX29nHlXtqX3op","object":"chat.completion.chunk","created":1767213694,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[],"usage":{"prompt_tokens":87,"completion_tokens":11,"total_tokens":98,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"jT9u8MzDgR0Q0M"}
+        data: {"id":"chatcmpl-DVMZ9uj6aMY7thmv4hkPLvjgJfeFc","object":"chat.completion.chunk","created":1776367283,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_ea8b6bc153","choices":[],"usage":{"prompt_tokens":87,"completion_tokens":11,"total_tokens":98,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"qnrGnbOmxncaaW"}
 
 
         data: [DONE]
@@ -171,14 +168,16 @@ interactions:
 
         '
     headers:
-      CF-RAY:
-      - 9b6c99343e6c50d9-ORD
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9ed58d82ae8c7a44-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:35 GMT
+      - Thu, 16 Apr 2026 19:21:24 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -191,14 +190,10 @@ interactions:
       - X-Request-ID
       alt-svc:
       - h3=":443"; ma=86400
-      cf-cache-status:
-      - DYNAMIC
       openai-processing-ms:
-      - '186'
+      - '691'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '406'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -220,9 +215,9 @@ interactions:
     body: '{"messages": [{"content": "Always use a tool to help you answer. Reply
       with ''It is ____.''.", "role": "system"}, {"content": [{"type": "text", "text":
       "What''s the current date in YYYY-MM-DD format?"}], "role": "user"}, {"role":
-      "assistant", "tool_calls": [{"id": "call_7le0pHsyW59jcigp72v0YiII", "function":
+      "assistant", "tool_calls": [{"id": "call_skV9zDpk9TiZa36XnJxfUtKA", "function":
       {"name": "get_date", "arguments": "{}"}, "type": "function"}]}, {"content":
-      "2024-01-01", "tool_call_id": "call_7le0pHsyW59jcigp72v0YiII", "role": "tool"},
+      "2024-01-01", "tool_call_id": "call_skV9zDpk9TiZa36XnJxfUtKA", "role": "tool"},
       {"role": "assistant", "content": [{"type": "text", "text": "It is 2024-01-01."}]},
       {"content": [{"type": "text", "text": "What month is it? Provide the full name."}],
       "role": "user"}], "model": "gpt-4.1", "seed": 1014, "stream": true, "stream_options":
@@ -233,7 +228,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -241,8 +236,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - __cf_bm=Sq.4DwUNSGLUSi.YloK3A6tg6SoTWG_cBqN3cyyDTI0-1767213693-1.0.1.1-GiwOtpPNMf2r4kNoolkMaidivsctNR5fGznbPhMP8NFKShRqB6tO7aAPsXCOY6WmgdtAqbVcrs6EB3owT3CJKLaPMCFEWiBW.YQx7yV07wI;
-        _cfuvid=KzzW3bB3xdHH7GQ32tZ3Eb54M.4QSCeE_goJgpG55R4-1767213693898-0.0.1.1-604800000
+      - __cf_bm=0X952pPYMzipvaGvQ8_fSAIp8ySmHIZoScBw72QeiIE-1776367282.9204953-1.0.1.1-v24QDfgrni15oJGbMPNXY.xSZyl7NihNsne.nD1O6m.05TgoNGJdawK5h7TwFhMVFG36QDFnW866PQ4VjtYYPveGxAtBi6YSt__T06TytzTK8.7bBJRDclDhBZIhZDPU
       Host:
       - api.openai.com
       X-Stainless-Async:
@@ -253,27 +247,27 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CsxIdluDB9POPj9IveSkT4dTowMpv","object":"chat.completion.chunk","created":1767213695,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"RIJAlzRAABqr9"}
+      string: 'data: {"id":"chatcmpl-DVMZByNX424Edbh453T1VI4DkEPyC","object":"chat.completion.chunk","created":1776367285,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_ea8b6bc153","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"pFU0gZdursoeb"}
 
 
-        data: {"id":"chatcmpl-CsxIdluDB9POPj9IveSkT4dTowMpv","object":"chat.completion.chunk","created":1767213695,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"It"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"cSZVpXW88yCvS"}
+        data: {"id":"chatcmpl-DVMZByNX424Edbh453T1VI4DkEPyC","object":"chat.completion.chunk","created":1776367285,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_ea8b6bc153","choices":[{"index":0,"delta":{"content":"It"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"VbOg3SXswPVMe"}
 
 
-        data: {"id":"chatcmpl-CsxIdluDB9POPj9IveSkT4dTowMpv","object":"chat.completion.chunk","created":1767213695,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        is"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"1lq5cmVu9Trj"}
+        data: {"id":"chatcmpl-DVMZByNX424Edbh453T1VI4DkEPyC","object":"chat.completion.chunk","created":1776367285,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_ea8b6bc153","choices":[{"index":0,"delta":{"content":"
+        is"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"V65csvFnPEEV"}
 
 
-        data: {"id":"chatcmpl-CsxIdluDB9POPj9IveSkT4dTowMpv","object":"chat.completion.chunk","created":1767213695,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        January"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"8lzkGH7"}
+        data: {"id":"chatcmpl-DVMZByNX424Edbh453T1VI4DkEPyC","object":"chat.completion.chunk","created":1776367285,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_ea8b6bc153","choices":[{"index":0,"delta":{"content":"
+        January"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"A9bQCMM"}
 
 
-        data: {"id":"chatcmpl-CsxIdluDB9POPj9IveSkT4dTowMpv","object":"chat.completion.chunk","created":1767213695,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"ZBtbezMgve1K3r"}
+        data: {"id":"chatcmpl-DVMZByNX424Edbh453T1VI4DkEPyC","object":"chat.completion.chunk","created":1776367285,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_ea8b6bc153","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"5M8vQT3q2EsQIR"}
 
 
-        data: {"id":"chatcmpl-CsxIdluDB9POPj9IveSkT4dTowMpv","object":"chat.completion.chunk","created":1767213695,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"tQjftgPr8"}
+        data: {"id":"chatcmpl-DVMZByNX424Edbh453T1VI4DkEPyC","object":"chat.completion.chunk","created":1776367285,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_ea8b6bc153","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"zoniNmkjy"}
 
 
-        data: {"id":"chatcmpl-CsxIdluDB9POPj9IveSkT4dTowMpv","object":"chat.completion.chunk","created":1767213695,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[],"usage":{"prompt_tokens":115,"completion_tokens":5,"total_tokens":120,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"eHl6HNBKdbVwA"}
+        data: {"id":"chatcmpl-DVMZByNX424Edbh453T1VI4DkEPyC","object":"chat.completion.chunk","created":1776367285,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_ea8b6bc153","choices":[],"usage":{"prompt_tokens":115,"completion_tokens":5,"total_tokens":120,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"h5fL5jpLSXh2G"}
 
 
         data: [DONE]
@@ -281,14 +275,16 @@ interactions:
 
         '
     headers:
-      CF-RAY:
-      - 9b6c993c5dba1419-ORD
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9ed58d8dd9dbf153-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:35 GMT
+      - Thu, 16 Apr 2026 19:21:26 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -301,14 +297,10 @@ interactions:
       - X-Request-ID
       alt-svc:
       - h3=":443"; ma=86400
-      cf-cache-status:
-      - DYNAMIC
       openai-processing-ms:
-      - '156'
+      - '319'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '175'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -338,7 +330,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -355,16 +347,16 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CsxIe59OVlPK4Ce6VGjK3Wanby8au","object":"chat.completion.chunk","created":1767213696,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_mGixp2kOstMDZzD5uVr2XYGG","type":"function","function":{"name":"get_date","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"6ZIl3Kn32q7"}
+      string: 'data: {"id":"chatcmpl-DVMZC8QNn1O5VeB1jNbqjPZcXZnao","object":"chat.completion.chunk","created":1776367286,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1d414b603b","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_vzqpjCXJGAWbrORztTYHKpi8","type":"function","function":{"name":"get_date","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"CHezw7vtren"}
 
 
-        data: {"id":"chatcmpl-CsxIe59OVlPK4Ce6VGjK3Wanby8au","object":"chat.completion.chunk","created":1767213696,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{}"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"yFr"}
+        data: {"id":"chatcmpl-DVMZC8QNn1O5VeB1jNbqjPZcXZnao","object":"chat.completion.chunk","created":1776367286,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1d414b603b","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{}"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"sEZ"}
 
 
-        data: {"id":"chatcmpl-CsxIe59OVlPK4Ce6VGjK3Wanby8au","object":"chat.completion.chunk","created":1767213696,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"usage":null,"obfuscation":"3tF"}
+        data: {"id":"chatcmpl-DVMZC8QNn1O5VeB1jNbqjPZcXZnao","object":"chat.completion.chunk","created":1776367286,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1d414b603b","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"usage":null,"obfuscation":"XOQ"}
 
 
-        data: {"id":"chatcmpl-CsxIe59OVlPK4Ce6VGjK3Wanby8au","object":"chat.completion.chunk","created":1767213696,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[],"usage":{"prompt_tokens":54,"completion_tokens":10,"total_tokens":64,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"mkG8GIvavBvFLH"}
+        data: {"id":"chatcmpl-DVMZC8QNn1O5VeB1jNbqjPZcXZnao","object":"chat.completion.chunk","created":1776367286,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1d414b603b","choices":[],"usage":{"prompt_tokens":54,"completion_tokens":10,"total_tokens":64,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"S5vi3D2JVBpe5D"}
 
 
         data: [DONE]
@@ -372,14 +364,16 @@ interactions:
 
         '
     headers:
-      CF-RAY:
-      - 9b6c993f8a7b10d5-ORD
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9ed58d934b0b72e5-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:36 GMT
+      - Thu, 16 Apr 2026 19:21:26 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -392,14 +386,10 @@ interactions:
       - X-Request-ID
       alt-svc:
       - h3=":443"; ma=86400
-      cf-cache-status:
-      - DYNAMIC
       openai-processing-ms:
-      - '333'
+      - '329'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '346'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -409,7 +399,7 @@ interactions:
       x-ratelimit-remaining-requests:
       - '9999'
       x-ratelimit-remaining-tokens:
-      - '29999975'
+      - '29999976'
       x-ratelimit-reset-requests:
       - 6ms
       x-ratelimit-reset-tokens:
@@ -421,8 +411,8 @@ interactions:
     body: '{"messages": [{"content": "Be very terse, not even punctuation.", "role":
       "system"}, {"content": [{"type": "text", "text": "What''s the current date in
       YYYY-MM-DD format?"}], "role": "user"}, {"role": "assistant", "tool_calls":
-      [{"id": "call_mGixp2kOstMDZzD5uVr2XYGG", "function": {"name": "get_date", "arguments":
-      "{}"}, "type": "function"}]}, {"content": "2024-01-01", "tool_call_id": "call_mGixp2kOstMDZzD5uVr2XYGG",
+      [{"id": "call_vzqpjCXJGAWbrORztTYHKpi8", "function": {"name": "get_date", "arguments":
+      "{}"}, "type": "function"}]}, {"content": "2024-01-01", "tool_call_id": "call_vzqpjCXJGAWbrORztTYHKpi8",
       "role": "tool"}], "model": "gpt-4.1", "seed": 1014, "stream": true, "stream_options":
       {"include_usage": true}, "tools": [{"type": "function", "function": {"name":
       "get_date", "description": "Gets the current date", "parameters": {"properties":
@@ -431,7 +421,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -439,8 +429,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - __cf_bm=hqWye8xBOiVS_TcKKgZtsO9_gRGuKS23fivV_WVHIgk-1767213696-1.0.1.1-2geQ66WvIW5pIV.Ft6czGgciC7cu6tbnqPCCSMOrnm4gWL7TIs6ARhCIZnjrsNdAv924tXBGxOUbEReWedlDcgrVJY_u1ljW96oIa8ooe6s;
-        _cfuvid=jI_fGEZsl3QX5KXPThQADJyDzoI5PwVLyJ7Z7bIN8JY-1767213696346-0.0.1.1-604800000
+      - __cf_bm=jtWQh99JJeYc2G__2kSYr9Xu72ZWcXzchX6ZpX2ULYM-1776367286.2838712-1.0.1.1-V8_FzQwaHarR.EL8i_VE0E3fVio1ZebEHucM7NJLhXE0N.jrWFkhC30TF7632JZ3PaAt1We3zMneyeOaNSWQvRDrhIelbymMsChEi2gv4prP6h65d4_rKT5MoqUZMuuB
       Host:
       - api.openai.com
       X-Stainless-Async:
@@ -451,31 +440,31 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CsxIfIiF0EbPSAeNaDm8JRklsKxF6","object":"chat.completion.chunk","created":1767213697,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"7bUN3Gqa5DzdY"}
+      string: 'data: {"id":"chatcmpl-DVMZDCAHRFehBN0WBVOwfC3T14d6K","object":"chat.completion.chunk","created":1776367287,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_6a260480be","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"BPOnYx9zVLLOY"}
 
 
-        data: {"id":"chatcmpl-CsxIfIiF0EbPSAeNaDm8JRklsKxF6","object":"chat.completion.chunk","created":1767213697,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"202"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"HXaZNrNkgIax"}
+        data: {"id":"chatcmpl-DVMZDCAHRFehBN0WBVOwfC3T14d6K","object":"chat.completion.chunk","created":1776367287,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_6a260480be","choices":[{"index":0,"delta":{"content":"202"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"4L3WpUOjhBLw"}
 
 
-        data: {"id":"chatcmpl-CsxIfIiF0EbPSAeNaDm8JRklsKxF6","object":"chat.completion.chunk","created":1767213697,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"4"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"rmb4oRQo74OAoQ"}
+        data: {"id":"chatcmpl-DVMZDCAHRFehBN0WBVOwfC3T14d6K","object":"chat.completion.chunk","created":1776367287,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_6a260480be","choices":[{"index":0,"delta":{"content":"4"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"O2JcbQS8ucrJdc"}
 
 
-        data: {"id":"chatcmpl-CsxIfIiF0EbPSAeNaDm8JRklsKxF6","object":"chat.completion.chunk","created":1767213697,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"-"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"ywwVupvpgo9wsN"}
+        data: {"id":"chatcmpl-DVMZDCAHRFehBN0WBVOwfC3T14d6K","object":"chat.completion.chunk","created":1776367287,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_6a260480be","choices":[{"index":0,"delta":{"content":"-"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"vrxudjiLiY35Dp"}
 
 
-        data: {"id":"chatcmpl-CsxIfIiF0EbPSAeNaDm8JRklsKxF6","object":"chat.completion.chunk","created":1767213697,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"01"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"IbHiS9kjO2soU"}
+        data: {"id":"chatcmpl-DVMZDCAHRFehBN0WBVOwfC3T14d6K","object":"chat.completion.chunk","created":1776367287,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_6a260480be","choices":[{"index":0,"delta":{"content":"01"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"A05gnwndjgiMk"}
 
 
-        data: {"id":"chatcmpl-CsxIfIiF0EbPSAeNaDm8JRklsKxF6","object":"chat.completion.chunk","created":1767213697,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"-"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"loIFGC33zMWhmt"}
+        data: {"id":"chatcmpl-DVMZDCAHRFehBN0WBVOwfC3T14d6K","object":"chat.completion.chunk","created":1776367287,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_6a260480be","choices":[{"index":0,"delta":{"content":"-"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"c6F0lmUa0I0LX2"}
 
 
-        data: {"id":"chatcmpl-CsxIfIiF0EbPSAeNaDm8JRklsKxF6","object":"chat.completion.chunk","created":1767213697,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"01"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"mGbugWbKsIvw3"}
+        data: {"id":"chatcmpl-DVMZDCAHRFehBN0WBVOwfC3T14d6K","object":"chat.completion.chunk","created":1776367287,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_6a260480be","choices":[{"index":0,"delta":{"content":"01"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"vT12um5k1GcQ2"}
 
 
-        data: {"id":"chatcmpl-CsxIfIiF0EbPSAeNaDm8JRklsKxF6","object":"chat.completion.chunk","created":1767213697,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"4PJM7O41r"}
+        data: {"id":"chatcmpl-DVMZDCAHRFehBN0WBVOwfC3T14d6K","object":"chat.completion.chunk","created":1776367287,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_6a260480be","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"uwdUegSbx"}
 
 
-        data: {"id":"chatcmpl-CsxIfIiF0EbPSAeNaDm8JRklsKxF6","object":"chat.completion.chunk","created":1767213697,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[],"usage":{"prompt_tokens":78,"completion_tokens":7,"total_tokens":85,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"nH9s0FuhBevbUMy"}
+        data: {"id":"chatcmpl-DVMZDCAHRFehBN0WBVOwfC3T14d6K","object":"chat.completion.chunk","created":1776367287,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_6a260480be","choices":[],"usage":{"prompt_tokens":78,"completion_tokens":7,"total_tokens":85,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"YMxqn7RcBThUksO"}
 
 
         data: [DONE]
@@ -483,14 +472,16 @@ interactions:
 
         '
     headers:
-      CF-RAY:
-      - 9b6c99434d6760ae-ORD
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9ed58d98ce6c2340-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:37 GMT
+      - Thu, 16 Apr 2026 19:21:27 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -503,14 +494,10 @@ interactions:
       - X-Request-ID
       alt-svc:
       - h3=":443"; ma=86400
-      cf-cache-status:
-      - DYNAMIC
       openai-processing-ms:
-      - '354'
+      - '283'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '619'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -541,7 +528,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -558,48 +545,48 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CsxIgmWtAjIxkhtnCTmHHzm21UGe6","object":"chat.completion.chunk","created":1767213698,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","usage":null,"choices":[{"index":0,"delta":{"role":"assistant","content":null},"logprobs":null,"finish_reason":null}],"obfuscation":"shNFZtYWmg"}
+      string: 'data: {"id":"chatcmpl-DVMZEaqyETYcaK43iJieXh3IKfw2V","object":"chat.completion.chunk","created":1776367288,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_000894f84e","usage":null,"choices":[{"index":0,"delta":{"role":"assistant","content":null},"logprobs":null,"finish_reason":null}],"obfuscation":"0rs681Nqa5"}
 
 
-        data: {"id":"chatcmpl-CsxIgmWtAjIxkhtnCTmHHzm21UGe6","object":"chat.completion.chunk","created":1767213698,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","usage":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_OOuqvZUfs6BgsQBdzCTg4z4S","type":"function","function":{"name":"favorite_color","arguments":""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"NuV3RZ"}
+        data: {"id":"chatcmpl-DVMZEaqyETYcaK43iJieXh3IKfw2V","object":"chat.completion.chunk","created":1776367288,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_000894f84e","usage":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_ZEidIjMr8MNeQZrhLbrbz3a3","type":"function","function":{"name":"favorite_color","arguments":""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"Q5XNdx"}
 
 
-        data: {"id":"chatcmpl-CsxIgmWtAjIxkhtnCTmHHzm21UGe6","object":"chat.completion.chunk","created":1767213698,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","usage":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"_p"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-DVMZEaqyETYcaK43iJieXh3IKfw2V","object":"chat.completion.chunk","created":1776367288,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_000894f84e","usage":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"_p"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CsxIgmWtAjIxkhtnCTmHHzm21UGe6","object":"chat.completion.chunk","created":1767213698,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","usage":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"erson"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-DVMZEaqyETYcaK43iJieXh3IKfw2V","object":"chat.completion.chunk","created":1776367288,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_000894f84e","usage":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"erson"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CsxIgmWtAjIxkhtnCTmHHzm21UGe6","object":"chat.completion.chunk","created":1767213698,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","usage":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":
-        \"Jo"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"ThMP1sneV3hTA"}
+        data: {"id":"chatcmpl-DVMZEaqyETYcaK43iJieXh3IKfw2V","object":"chat.completion.chunk","created":1776367288,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_000894f84e","usage":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":
+        \"Jo"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"dvEpRYdzK9vBd"}
 
 
-        data: {"id":"chatcmpl-CsxIgmWtAjIxkhtnCTmHHzm21UGe6","object":"chat.completion.chunk","created":1767213698,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","usage":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"e\"}"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"r"}
+        data: {"id":"chatcmpl-DVMZEaqyETYcaK43iJieXh3IKfw2V","object":"chat.completion.chunk","created":1776367288,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_000894f84e","usage":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"e\"}"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"O"}
 
 
-        data: {"id":"chatcmpl-CsxIgmWtAjIxkhtnCTmHHzm21UGe6","object":"chat.completion.chunk","created":1767213698,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","usage":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"id":"call_6uPjX8LVWdJmRcyfW1cHvQfc","type":"function","function":{"name":"favorite_color","arguments":""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"YIBorg"}
+        data: {"id":"chatcmpl-DVMZEaqyETYcaK43iJieXh3IKfw2V","object":"chat.completion.chunk","created":1776367288,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_000894f84e","usage":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"id":"call_5eQrVI9il3glDPLTXcYZXHvQ","type":"function","function":{"name":"favorite_color","arguments":""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"ByNINX"}
 
 
-        data: {"id":"chatcmpl-CsxIgmWtAjIxkhtnCTmHHzm21UGe6","object":"chat.completion.chunk","created":1767213698,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","usage":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"function":{"arguments":"{\"_p"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-DVMZEaqyETYcaK43iJieXh3IKfw2V","object":"chat.completion.chunk","created":1776367288,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_000894f84e","usage":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"function":{"arguments":"{\"_p"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CsxIgmWtAjIxkhtnCTmHHzm21UGe6","object":"chat.completion.chunk","created":1767213698,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","usage":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"function":{"arguments":"erson"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-DVMZEaqyETYcaK43iJieXh3IKfw2V","object":"chat.completion.chunk","created":1776367288,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_000894f84e","usage":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"function":{"arguments":"erson"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CsxIgmWtAjIxkhtnCTmHHzm21UGe6","object":"chat.completion.chunk","created":1767213698,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","usage":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"function":{"arguments":"\":
-        \"Ha"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"6PXWEK7E7zDIJ"}
+        data: {"id":"chatcmpl-DVMZEaqyETYcaK43iJieXh3IKfw2V","object":"chat.completion.chunk","created":1776367288,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_000894f84e","usage":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"function":{"arguments":"\":
+        \"Ha"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"byQTREAbyleQ2"}
 
 
-        data: {"id":"chatcmpl-CsxIgmWtAjIxkhtnCTmHHzm21UGe6","object":"chat.completion.chunk","created":1767213698,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","usage":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"function":{"arguments":"dley"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"M"}
+        data: {"id":"chatcmpl-DVMZEaqyETYcaK43iJieXh3IKfw2V","object":"chat.completion.chunk","created":1776367288,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_000894f84e","usage":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"function":{"arguments":"dley"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"G"}
 
 
-        data: {"id":"chatcmpl-CsxIgmWtAjIxkhtnCTmHHzm21UGe6","object":"chat.completion.chunk","created":1767213698,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","usage":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"function":{"arguments":"\"}"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"M7"}
+        data: {"id":"chatcmpl-DVMZEaqyETYcaK43iJieXh3IKfw2V","object":"chat.completion.chunk","created":1776367288,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_000894f84e","usage":null,"choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"function":{"arguments":"\"}"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"ce"}
 
 
-        data: {"id":"chatcmpl-CsxIgmWtAjIxkhtnCTmHHzm21UGe6","object":"chat.completion.chunk","created":1767213698,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"usage":null,"obfuscation":"Kq8"}
+        data: {"id":"chatcmpl-DVMZEaqyETYcaK43iJieXh3IKfw2V","object":"chat.completion.chunk","created":1776367288,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_000894f84e","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"usage":null,"obfuscation":"OSb"}
 
 
-        data: {"id":"chatcmpl-CsxIgmWtAjIxkhtnCTmHHzm21UGe6","object":"chat.completion.chunk","created":1767213698,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[],"usage":{"prompt_tokens":79,"completion_tokens":47,"total_tokens":126,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"RwXn1sLaovHGX"}
+        data: {"id":"chatcmpl-DVMZEaqyETYcaK43iJieXh3IKfw2V","object":"chat.completion.chunk","created":1776367288,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_000894f84e","choices":[],"usage":{"prompt_tokens":79,"completion_tokens":47,"total_tokens":126,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"8ZbwgVIROSu80"}
 
 
         data: [DONE]
@@ -607,34 +594,34 @@ interactions:
 
         '
     headers:
-      CF-RAY:
-      - 9b6c994cbc76a162-ORD
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9ed58d9caeb855fa-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:38 GMT
+      - Thu, 16 Apr 2026 19:21:28 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
       - chunked
+      Vary:
+      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
       access-control-expose-headers:
       - X-Request-ID
       alt-svc:
       - h3=":443"; ma=86400
-      cf-cache-status:
-      - DYNAMIC
       openai-processing-ms:
-      - '614'
+      - '755'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '628'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -656,12 +643,12 @@ interactions:
     body: '{"messages": [{"content": "Be very terse, not even punctuation.", "role":
       "system"}, {"content": [{"type": "text", "text": "\n        What are Joe and
       Hadley''s favourite colours?\n        Answer like name1: colour1, name2: colour2\n    "}],
-      "role": "user"}, {"role": "assistant", "tool_calls": [{"id": "call_OOuqvZUfs6BgsQBdzCTg4z4S",
+      "role": "user"}, {"role": "assistant", "tool_calls": [{"id": "call_ZEidIjMr8MNeQZrhLbrbz3a3",
       "function": {"name": "favorite_color", "arguments": "{\"_person\":\"Joe\"}"},
-      "type": "function"}, {"id": "call_6uPjX8LVWdJmRcyfW1cHvQfc", "function": {"name":
+      "type": "function"}, {"id": "call_5eQrVI9il3glDPLTXcYZXHvQ", "function": {"name":
       "favorite_color", "arguments": "{\"_person\":\"Hadley\"}"}, "type": "function"}]},
-      {"content": "sage green", "tool_call_id": "call_OOuqvZUfs6BgsQBdzCTg4z4S", "role":
-      "tool"}, {"content": "red", "tool_call_id": "call_6uPjX8LVWdJmRcyfW1cHvQfc",
+      {"content": "sage green", "tool_call_id": "call_ZEidIjMr8MNeQZrhLbrbz3a3", "role":
+      "tool"}, {"content": "red", "tool_call_id": "call_5eQrVI9il3glDPLTXcYZXHvQ",
       "role": "tool"}], "model": "gpt-4.1", "seed": 1014, "stream": true, "stream_options":
       {"include_usage": true}, "tools": [{"type": "function", "function": {"name":
       "favorite_color", "description": "Returns a person''s favourite colour", "parameters":
@@ -671,7 +658,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -679,8 +666,8 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - __cf_bm=5uT4svv0X27AXdtINdbmqPr09RbH5MWpJTCCZOv1v9M-1767213698-1.0.1.1-OOpA9WdTfee2xjZpse5tjOi2yuF86fl1bQiyhvO8ZEIDPI.5nQO6jKQ89kFpaGde315369qoDjEvKgc.xmOHNncaYQ37RyZvyeDrFeOJz8s;
-        _cfuvid=MLCmqoH4yeBrGv9st.2F5c7R7WjEDsjmFsGHm5jhA7s-1767213698688-0.0.1.1-604800000
+      - __cf_bm=sYxHQVeVz6yNNgYf85ZAWIXlKwR8BhLdsh8gvhXAGoE-1776367288-1.0.1.1-aE3o4d3lAr6rlNxvED3dtRfmDgOgjbIN03Ombev5g9Bhs4Sq.cUBaREg7sA_B05VCBe1gHhjy3WLwMkJJ0Q011oDEs90DOr3mdAYneH3UVg;
+        _cfuvid=1r68nJAwan_Xk6namXu8fmvI0ePkGc_SRXRp42sENFo-1776367288821-0.0.1.1-604800000
       Host:
       - api.openai.com
       X-Stainless-Async:
@@ -691,44 +678,44 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CsxIhyj2xXIdACDkTIl12zZ2DrEsJ","object":"chat.completion.chunk","created":1767213699,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"IeENUTPohYSN8"}
+      string: 'data: {"id":"chatcmpl-DVMZFRgv6Xr292zgQ9KPDtw1KaoPW","object":"chat.completion.chunk","created":1776367289,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_000894f84e","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"mIjHQDEAKra8z"}
 
 
-        data: {"id":"chatcmpl-CsxIhyj2xXIdACDkTIl12zZ2DrEsJ","object":"chat.completion.chunk","created":1767213699,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"Joe"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"26z5ShHafN7p"}
+        data: {"id":"chatcmpl-DVMZFRgv6Xr292zgQ9KPDtw1KaoPW","object":"chat.completion.chunk","created":1776367289,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_000894f84e","choices":[{"index":0,"delta":{"content":"Joe"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"hfvUx4PM1fNq"}
 
 
-        data: {"id":"chatcmpl-CsxIhyj2xXIdACDkTIl12zZ2DrEsJ","object":"chat.completion.chunk","created":1767213699,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":":"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"m46Cbm6CzvM4at"}
+        data: {"id":"chatcmpl-DVMZFRgv6Xr292zgQ9KPDtw1KaoPW","object":"chat.completion.chunk","created":1776367289,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_000894f84e","choices":[{"index":0,"delta":{"content":":"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"RRnLfSW6QGA6WD"}
 
 
-        data: {"id":"chatcmpl-CsxIhyj2xXIdACDkTIl12zZ2DrEsJ","object":"chat.completion.chunk","created":1767213699,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        sage"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"M0fHQx7jE5"}
+        data: {"id":"chatcmpl-DVMZFRgv6Xr292zgQ9KPDtw1KaoPW","object":"chat.completion.chunk","created":1776367289,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_000894f84e","choices":[{"index":0,"delta":{"content":"
+        sage"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Ro6ptRoB5P"}
 
 
-        data: {"id":"chatcmpl-CsxIhyj2xXIdACDkTIl12zZ2DrEsJ","object":"chat.completion.chunk","created":1767213699,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        green"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"xuxzlGhSu"}
+        data: {"id":"chatcmpl-DVMZFRgv6Xr292zgQ9KPDtw1KaoPW","object":"chat.completion.chunk","created":1776367289,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_000894f84e","choices":[{"index":0,"delta":{"content":"
+        green"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"3NBP6hTrk"}
 
 
-        data: {"id":"chatcmpl-CsxIhyj2xXIdACDkTIl12zZ2DrEsJ","object":"chat.completion.chunk","created":1767213699,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"SmXAZ335K1T5ut"}
+        data: {"id":"chatcmpl-DVMZFRgv6Xr292zgQ9KPDtw1KaoPW","object":"chat.completion.chunk","created":1776367289,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_000894f84e","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"em3sH5SgF058YC"}
 
 
-        data: {"id":"chatcmpl-CsxIhyj2xXIdACDkTIl12zZ2DrEsJ","object":"chat.completion.chunk","created":1767213699,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        Had"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"rRjRSOpaCkm"}
+        data: {"id":"chatcmpl-DVMZFRgv6Xr292zgQ9KPDtw1KaoPW","object":"chat.completion.chunk","created":1776367289,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_000894f84e","choices":[{"index":0,"delta":{"content":"
+        Had"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"sgiX3a145SB"}
 
 
-        data: {"id":"chatcmpl-CsxIhyj2xXIdACDkTIl12zZ2DrEsJ","object":"chat.completion.chunk","created":1767213699,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"ley"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"fcAzMGBTh0h5"}
+        data: {"id":"chatcmpl-DVMZFRgv6Xr292zgQ9KPDtw1KaoPW","object":"chat.completion.chunk","created":1776367289,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_000894f84e","choices":[{"index":0,"delta":{"content":"ley"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Tm45Y2fo4Nxs"}
 
 
-        data: {"id":"chatcmpl-CsxIhyj2xXIdACDkTIl12zZ2DrEsJ","object":"chat.completion.chunk","created":1767213699,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":":"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"fceC20PDZbhqdw"}
+        data: {"id":"chatcmpl-DVMZFRgv6Xr292zgQ9KPDtw1KaoPW","object":"chat.completion.chunk","created":1776367289,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_000894f84e","choices":[{"index":0,"delta":{"content":":"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"JuSVubwXHKhYRQ"}
 
 
-        data: {"id":"chatcmpl-CsxIhyj2xXIdACDkTIl12zZ2DrEsJ","object":"chat.completion.chunk","created":1767213699,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"
-        red"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"06xozIyXTWt"}
+        data: {"id":"chatcmpl-DVMZFRgv6Xr292zgQ9KPDtw1KaoPW","object":"chat.completion.chunk","created":1776367289,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_000894f84e","choices":[{"index":0,"delta":{"content":"
+        red"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"GmmjsTLd8Fp"}
 
 
-        data: {"id":"chatcmpl-CsxIhyj2xXIdACDkTIl12zZ2DrEsJ","object":"chat.completion.chunk","created":1767213699,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"8q4krYkt7"}
+        data: {"id":"chatcmpl-DVMZFRgv6Xr292zgQ9KPDtw1KaoPW","object":"chat.completion.chunk","created":1776367289,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_000894f84e","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"fRhwysCKB"}
 
 
-        data: {"id":"chatcmpl-CsxIhyj2xXIdACDkTIl12zZ2DrEsJ","object":"chat.completion.chunk","created":1767213699,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[],"usage":{"prompt_tokens":143,"completion_tokens":10,"total_tokens":153,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"6B6uR3I4VZWg"}
+        data: {"id":"chatcmpl-DVMZFRgv6Xr292zgQ9KPDtw1KaoPW","object":"chat.completion.chunk","created":1776367289,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_000894f84e","choices":[],"usage":{"prompt_tokens":143,"completion_tokens":10,"total_tokens":153,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"IP5j0vFt2hvk"}
 
 
         data: [DONE]
@@ -736,14 +723,16 @@ interactions:
 
         '
     headers:
-      CF-RAY:
-      - 9b6c99520aa86129-ORD
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9ed58da4bcadeaff-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:39 GMT
+      - Thu, 16 Apr 2026 19:21:29 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -756,14 +745,10 @@ interactions:
       - X-Request-ID
       alt-svc:
       - h3=":443"; ma=86400
-      cf-cache-status:
-      - DYNAMIC
       openai-processing-ms:
-      - '264'
+      - '348'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '278'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -799,7 +784,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -816,32 +801,32 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CsxIhyGHmxknJfpcufiNjzvL3QP7f","object":"chat.completion.chunk","created":1767213699,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_Qm8TMggXq75VLzm14OmFdEwB","type":"function","function":{"name":"weather_forecast","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"6Q0"}
+      string: 'data: {"id":"chatcmpl-DVMZGLuyiHi4ln55kgBa9bm9gN5xw","object":"chat.completion.chunk","created":1776367290,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_72e90ad10d","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_a5l3Q7T3NdRYepBKjTxoNoMy","type":"function","function":{"name":"weather_forecast","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"v4w"}
 
 
-        data: {"id":"chatcmpl-CsxIhyGHmxknJfpcufiNjzvL3QP7f","object":"chat.completion.chunk","created":1767213699,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"op"}
+        data: {"id":"chatcmpl-DVMZGLuyiHi4ln55kgBa9bm9gN5xw","object":"chat.completion.chunk","created":1776367290,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_72e90ad10d","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"35"}
 
 
-        data: {"id":"chatcmpl-CsxIhyGHmxknJfpcufiNjzvL3QP7f","object":"chat.completion.chunk","created":1767213699,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"city"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"R"}
+        data: {"id":"chatcmpl-DVMZGLuyiHi4ln55kgBa9bm9gN5xw","object":"chat.completion.chunk","created":1776367290,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_72e90ad10d","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"city"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"T"}
 
 
-        data: {"id":"chatcmpl-CsxIhyGHmxknJfpcufiNjzvL3QP7f","object":"chat.completion.chunk","created":1767213699,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":""}
+        data: {"id":"chatcmpl-DVMZGLuyiHi4ln55kgBa9bm9gN5xw","object":"chat.completion.chunk","created":1776367290,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_72e90ad10d","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CsxIhyGHmxknJfpcufiNjzvL3QP7f","object":"chat.completion.chunk","created":1767213699,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"New"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Nk"}
+        data: {"id":"chatcmpl-DVMZGLuyiHi4ln55kgBa9bm9gN5xw","object":"chat.completion.chunk","created":1776367290,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_72e90ad10d","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"New"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"PI"}
 
 
-        data: {"id":"chatcmpl-CsxIhyGHmxknJfpcufiNjzvL3QP7f","object":"chat.completion.chunk","created":1767213699,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
+        data: {"id":"chatcmpl-DVMZGLuyiHi4ln55kgBa9bm9gN5xw","object":"chat.completion.chunk","created":1776367290,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_72e90ad10d","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
         York"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CsxIhyGHmxknJfpcufiNjzvL3QP7f","object":"chat.completion.chunk","created":1767213699,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"}"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Cf"}
+        data: {"id":"chatcmpl-DVMZGLuyiHi4ln55kgBa9bm9gN5xw","object":"chat.completion.chunk","created":1776367290,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_72e90ad10d","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"}"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"W0"}
 
 
-        data: {"id":"chatcmpl-CsxIhyGHmxknJfpcufiNjzvL3QP7f","object":"chat.completion.chunk","created":1767213699,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"usage":null,"obfuscation":"g6i"}
+        data: {"id":"chatcmpl-DVMZGLuyiHi4ln55kgBa9bm9gN5xw","object":"chat.completion.chunk","created":1776367290,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_72e90ad10d","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"usage":null,"obfuscation":"TUi"}
 
 
-        data: {"id":"chatcmpl-CsxIhyGHmxknJfpcufiNjzvL3QP7f","object":"chat.completion.chunk","created":1767213699,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[],"usage":{"prompt_tokens":120,"completion_tokens":16,"total_tokens":136,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"nmklbycyXpz4"}
+        data: {"id":"chatcmpl-DVMZGLuyiHi4ln55kgBa9bm9gN5xw","object":"chat.completion.chunk","created":1776367290,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_72e90ad10d","choices":[],"usage":{"prompt_tokens":120,"completion_tokens":16,"total_tokens":136,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"JshhiK4BL9el"}
 
 
         data: [DONE]
@@ -849,14 +834,16 @@ interactions:
 
         '
     headers:
-      CF-RAY:
-      - 9b6c99565caff84a-ORD
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9ed58dab2b32e1e7-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:39 GMT
+      - Thu, 16 Apr 2026 19:21:30 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -869,14 +856,10 @@ interactions:
       - X-Request-ID
       alt-svc:
       - h3=":443"; ma=86400
-      cf-cache-status:
-      - DYNAMIC
       openai-processing-ms:
-      - '283'
+      - '426'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '314'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -900,9 +883,9 @@ interactions:
       provided to you. Then, use the\n        equipment tool provided to you.\n        ",
       "role": "system"}, {"content": [{"type": "text", "text": "What should I pack
       for New York this weekend?"}], "role": "user"}, {"role": "assistant", "tool_calls":
-      [{"id": "call_Qm8TMggXq75VLzm14OmFdEwB", "function": {"name": "weather_forecast",
+      [{"id": "call_a5l3Q7T3NdRYepBKjTxoNoMy", "function": {"name": "weather_forecast",
       "arguments": "{\"city\":\"New York\"}"}, "type": "function"}]}, {"content":
-      "rainy", "tool_call_id": "call_Qm8TMggXq75VLzm14OmFdEwB", "role": "tool"}],
+      "rainy", "tool_call_id": "call_a5l3Q7T3NdRYepBKjTxoNoMy", "role": "tool"}],
       "model": "gpt-4.1", "seed": 1014, "stream": true, "stream_options": {"include_usage":
       true}, "tools": [{"type": "function", "function": {"name": "weather_forecast",
       "description": "Gets the weather forecast for a city", "parameters": {"properties":
@@ -915,7 +898,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -923,8 +906,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - __cf_bm=NmpPbPvWR9p1lOC8p4GX_yDQxt.KENfF4.lTf7G5P7Y-1767213699-1.0.1.1-6tIlAes7OYOh9eVX9TGz3zagiQ2LH2RZoVfCrvJnoX_n.9osrmoWfReb2oRfBnTv66DBYjitNIXINfKWdL4drCU_kqFzuQzh1tDsgJ5peJI;
-        _cfuvid=ZZiiK0pkv7BFclI9NCH04uIPysWARipcnOFaRT878YE-1767213699956-0.0.1.1-604800000
+      - __cf_bm=Jtz_dTFvE3GthyaE_zv5siB4QgP1x9C.Tlya2CMkNaI-1776367290.1026926-1.0.1.1-NRBLEsabpDOP9VvSrx84LorlcGkSAWe4tkauk.xYcOn_NWeTojX0O0C7G1FWTK24FMl43V5vMkQqROoxePDM4Amv5VACRvNws9ZRxstzAQ6Jr8ch.hOGs0791pB9wOPA
       Host:
       - api.openai.com
       X-Stainless-Async:
@@ -935,31 +917,31 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CsxIiZWCxmClUmtGzinbg9m3dQlM6","object":"chat.completion.chunk","created":1767213700,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_5shSdczmt679JU0Dh8IzGO9I","type":"function","function":{"name":"equipment","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"3aVyGFmE2G"}
+      string: 'data: {"id":"chatcmpl-DVMZHrh7RP9jM3kJwOU3o3DGmuh10","object":"chat.completion.chunk","created":1776367291,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_72e90ad10d","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_ratbHWw7P9H7EYGbZQdfTvoQ","type":"function","function":{"name":"equipment","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"N7Y7X3zG3e"}
 
 
-        data: {"id":"chatcmpl-CsxIiZWCxmClUmtGzinbg9m3dQlM6","object":"chat.completion.chunk","created":1767213700,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"DQ"}
+        data: {"id":"chatcmpl-DVMZHrh7RP9jM3kJwOU3o3DGmuh10","object":"chat.completion.chunk","created":1776367291,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_72e90ad10d","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"UX"}
 
 
-        data: {"id":"chatcmpl-CsxIiZWCxmClUmtGzinbg9m3dQlM6","object":"chat.completion.chunk","created":1767213700,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"weather"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"uFH4sby2hJ2JhE"}
+        data: {"id":"chatcmpl-DVMZHrh7RP9jM3kJwOU3o3DGmuh10","object":"chat.completion.chunk","created":1776367291,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_72e90ad10d","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"weather"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"JKpc6aKmfJPHxk"}
 
 
-        data: {"id":"chatcmpl-CsxIiZWCxmClUmtGzinbg9m3dQlM6","object":"chat.completion.chunk","created":1767213700,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":""}
+        data: {"id":"chatcmpl-DVMZHrh7RP9jM3kJwOU3o3DGmuh10","object":"chat.completion.chunk","created":1776367291,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_72e90ad10d","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CsxIiZWCxmClUmtGzinbg9m3dQlM6","object":"chat.completion.chunk","created":1767213700,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"rain"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"b"}
+        data: {"id":"chatcmpl-DVMZHrh7RP9jM3kJwOU3o3DGmuh10","object":"chat.completion.chunk","created":1776367291,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_72e90ad10d","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"rain"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"S"}
 
 
-        data: {"id":"chatcmpl-CsxIiZWCxmClUmtGzinbg9m3dQlM6","object":"chat.completion.chunk","created":1767213700,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"y"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"8Yj9"}
+        data: {"id":"chatcmpl-DVMZHrh7RP9jM3kJwOU3o3DGmuh10","object":"chat.completion.chunk","created":1776367291,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_72e90ad10d","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"y"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"KnxK"}
 
 
-        data: {"id":"chatcmpl-CsxIiZWCxmClUmtGzinbg9m3dQlM6","object":"chat.completion.chunk","created":1767213700,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"}"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"3g"}
+        data: {"id":"chatcmpl-DVMZHrh7RP9jM3kJwOU3o3DGmuh10","object":"chat.completion.chunk","created":1776367291,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_72e90ad10d","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"}"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"OE"}
 
 
-        data: {"id":"chatcmpl-CsxIiZWCxmClUmtGzinbg9m3dQlM6","object":"chat.completion.chunk","created":1767213700,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"usage":null,"obfuscation":"uz8"}
+        data: {"id":"chatcmpl-DVMZHrh7RP9jM3kJwOU3o3DGmuh10","object":"chat.completion.chunk","created":1776367291,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_72e90ad10d","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"usage":null,"obfuscation":"dWR"}
 
 
-        data: {"id":"chatcmpl-CsxIiZWCxmClUmtGzinbg9m3dQlM6","object":"chat.completion.chunk","created":1767213700,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[],"usage":{"prompt_tokens":147,"completion_tokens":15,"total_tokens":162,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"KK7YSOM69fw3"}
+        data: {"id":"chatcmpl-DVMZHrh7RP9jM3kJwOU3o3DGmuh10","object":"chat.completion.chunk","created":1776367291,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_72e90ad10d","choices":[],"usage":{"prompt_tokens":147,"completion_tokens":15,"total_tokens":162,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"D3JI8U3YlQqb"}
 
 
         data: [DONE]
@@ -967,14 +949,16 @@ interactions:
 
         '
     headers:
-      CF-RAY:
-      - 9b6c995a3c78cefa-ORD
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9ed58db02a081050-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:40 GMT
+      - Thu, 16 Apr 2026 19:21:31 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -987,14 +971,10 @@ interactions:
       - X-Request-ID
       alt-svc:
       - h3=":443"; ma=86400
-      cf-cache-status:
-      - DYNAMIC
       openai-processing-ms:
-      - '283'
+      - '409'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '318'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -1018,12 +998,12 @@ interactions:
       provided to you. Then, use the\n        equipment tool provided to you.\n        ",
       "role": "system"}, {"content": [{"type": "text", "text": "What should I pack
       for New York this weekend?"}], "role": "user"}, {"role": "assistant", "tool_calls":
-      [{"id": "call_Qm8TMggXq75VLzm14OmFdEwB", "function": {"name": "weather_forecast",
+      [{"id": "call_a5l3Q7T3NdRYepBKjTxoNoMy", "function": {"name": "weather_forecast",
       "arguments": "{\"city\":\"New York\"}"}, "type": "function"}]}, {"content":
-      "rainy", "tool_call_id": "call_Qm8TMggXq75VLzm14OmFdEwB", "role": "tool"}, {"role":
-      "assistant", "tool_calls": [{"id": "call_5shSdczmt679JU0Dh8IzGO9I", "function":
+      "rainy", "tool_call_id": "call_a5l3Q7T3NdRYepBKjTxoNoMy", "role": "tool"}, {"role":
+      "assistant", "tool_calls": [{"id": "call_ratbHWw7P9H7EYGbZQdfTvoQ", "function":
       {"name": "equipment", "arguments": "{\"weather\":\"rainy\"}"}, "type": "function"}]},
-      {"content": "umbrella", "tool_call_id": "call_5shSdczmt679JU0Dh8IzGO9I", "role":
+      {"content": "umbrella", "tool_call_id": "call_ratbHWw7P9H7EYGbZQdfTvoQ", "role":
       "tool"}], "model": "gpt-4.1", "seed": 1014, "stream": true, "stream_options":
       {"include_usage": true}, "tools": [{"type": "function", "function": {"name":
       "weather_forecast", "description": "Gets the weather forecast for a city", "parameters":
@@ -1036,7 +1016,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -1044,8 +1024,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - __cf_bm=NmpPbPvWR9p1lOC8p4GX_yDQxt.KENfF4.lTf7G5P7Y-1767213699-1.0.1.1-6tIlAes7OYOh9eVX9TGz3zagiQ2LH2RZoVfCrvJnoX_n.9osrmoWfReb2oRfBnTv66DBYjitNIXINfKWdL4drCU_kqFzuQzh1tDsgJ5peJI;
-        _cfuvid=ZZiiK0pkv7BFclI9NCH04uIPysWARipcnOFaRT878YE-1767213699956-0.0.1.1-604800000
+      - __cf_bm=Jtz_dTFvE3GthyaE_zv5siB4QgP1x9C.Tlya2CMkNaI-1776367290.1026926-1.0.1.1-NRBLEsabpDOP9VvSrx84LorlcGkSAWe4tkauk.xYcOn_NWeTojX0O0C7G1FWTK24FMl43V5vMkQqROoxePDM4Amv5VACRvNws9ZRxstzAQ6Jr8ch.hOGs0791pB9wOPA
       Host:
       - api.openai.com
       X-Stainless-Async:
@@ -1056,19 +1035,19 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CsxIisyrusEGtV3CCpQS1cMRcgHVR","object":"chat.completion.chunk","created":1767213700,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"XgPJMlpiHGWNV"}
+      string: 'data: {"id":"chatcmpl-DVMZHS3Cv4yQVFyHdyoD1GQ8LtyNa","object":"chat.completion.chunk","created":1776367291,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_72e90ad10d","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"xhlMut95zCAkm"}
 
 
-        data: {"id":"chatcmpl-CsxIisyrusEGtV3CCpQS1cMRcgHVR","object":"chat.completion.chunk","created":1767213700,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"umbre"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"zeG8lG9aKO"}
+        data: {"id":"chatcmpl-DVMZHS3Cv4yQVFyHdyoD1GQ8LtyNa","object":"chat.completion.chunk","created":1776367291,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_72e90ad10d","choices":[{"index":0,"delta":{"content":"umbre"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"hoXzA5cXQ8"}
 
 
-        data: {"id":"chatcmpl-CsxIisyrusEGtV3CCpQS1cMRcgHVR","object":"chat.completion.chunk","created":1767213700,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"lla"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"mHoxzJWsSVrn"}
+        data: {"id":"chatcmpl-DVMZHS3Cv4yQVFyHdyoD1GQ8LtyNa","object":"chat.completion.chunk","created":1776367291,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_72e90ad10d","choices":[{"index":0,"delta":{"content":"lla"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"aXBFKMTREJHp"}
 
 
-        data: {"id":"chatcmpl-CsxIisyrusEGtV3CCpQS1cMRcgHVR","object":"chat.completion.chunk","created":1767213700,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"ji9dkFxxC"}
+        data: {"id":"chatcmpl-DVMZHS3Cv4yQVFyHdyoD1GQ8LtyNa","object":"chat.completion.chunk","created":1776367291,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_72e90ad10d","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"G1N2xRQG9"}
 
 
-        data: {"id":"chatcmpl-CsxIisyrusEGtV3CCpQS1cMRcgHVR","object":"chat.completion.chunk","created":1767213700,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[],"usage":{"prompt_tokens":171,"completion_tokens":3,"total_tokens":174,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"TeaxStBGzN10L"}
+        data: {"id":"chatcmpl-DVMZHS3Cv4yQVFyHdyoD1GQ8LtyNa","object":"chat.completion.chunk","created":1776367291,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_72e90ad10d","choices":[],"usage":{"prompt_tokens":171,"completion_tokens":3,"total_tokens":174,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"PYBSE4gLehKYV"}
 
 
         data: [DONE]
@@ -1076,14 +1055,16 @@ interactions:
 
         '
     headers:
-      CF-RAY:
-      - 9b6c995e6a84ee11-ORD
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9ed58db4cf2d2321-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:41 GMT
+      - Thu, 16 Apr 2026 19:21:32 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -1096,14 +1077,10 @@ interactions:
       - X-Request-ID
       alt-svc:
       - h3=":443"; ma=86400
-      cf-cache-status:
-      - DYNAMIC
       openai-processing-ms:
-      - '208'
+      - '370'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '247'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:

--- a/tests/_vcr/test_provider_openai_completions/test_openai_tool_variations_async.yaml
+++ b/tests/_vcr/test_provider_openai_completions/test_openai_tool_variations_async.yaml
@@ -11,7 +11,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -28,16 +28,16 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CsxIj1RNwAZuueV3GzvanOufnU23X","object":"chat.completion.chunk","created":1767213701,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_oXzmJeFgBE1IcLWEQQQ7RJAH","type":"function","function":{"name":"get_current_date","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"CmV"}
+      string: 'data: {"id":"chatcmpl-DVMZIYG0uPEMApgvIir4kEDhDCALl","object":"chat.completion.chunk","created":1776367292,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_2ec83bf3a4","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_908T44To73tdBB7SjloS9TGj","type":"function","function":{"name":"get_current_date","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"j9e"}
 
 
-        data: {"id":"chatcmpl-CsxIj1RNwAZuueV3GzvanOufnU23X","object":"chat.completion.chunk","created":1767213701,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{}"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"iqn"}
+        data: {"id":"chatcmpl-DVMZIYG0uPEMApgvIir4kEDhDCALl","object":"chat.completion.chunk","created":1776367292,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_2ec83bf3a4","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{}"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"oth"}
 
 
-        data: {"id":"chatcmpl-CsxIj1RNwAZuueV3GzvanOufnU23X","object":"chat.completion.chunk","created":1767213701,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"usage":null,"obfuscation":"4Ip"}
+        data: {"id":"chatcmpl-DVMZIYG0uPEMApgvIir4kEDhDCALl","object":"chat.completion.chunk","created":1776367292,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_2ec83bf3a4","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"usage":null,"obfuscation":"cla"}
 
 
-        data: {"id":"chatcmpl-CsxIj1RNwAZuueV3GzvanOufnU23X","object":"chat.completion.chunk","created":1767213701,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[],"usage":{"prompt_tokens":55,"completion_tokens":11,"total_tokens":66,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"muKVGgBnWKDhSi"}
+        data: {"id":"chatcmpl-DVMZIYG0uPEMApgvIir4kEDhDCALl","object":"chat.completion.chunk","created":1776367292,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_2ec83bf3a4","choices":[],"usage":{"prompt_tokens":55,"completion_tokens":11,"total_tokens":66,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"i464v9gB1KFxur"}
 
 
         data: [DONE]
@@ -45,14 +45,16 @@ interactions:
 
         '
     headers:
-      CF-RAY:
-      - 9b6c9961dc741137-ORD
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9ed58db93f6edadf-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:41 GMT
+      - Thu, 16 Apr 2026 19:21:32 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -65,14 +67,10 @@ interactions:
       - X-Request-ID
       alt-svc:
       - h3=":443"; ma=86400
-      cf-cache-status:
-      - DYNAMIC
       openai-processing-ms:
-      - '343'
+      - '477'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '361'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -94,9 +92,9 @@ interactions:
     body: '{"messages": [{"content": "Be very terse, not even punctuation.", "role":
       "system"}, {"content": [{"type": "text", "text": "What''s the current date in
       YYYY-MM-DD format?"}], "role": "user"}, {"role": "assistant", "tool_calls":
-      [{"id": "call_oXzmJeFgBE1IcLWEQQQ7RJAH", "function": {"name": "get_current_date",
+      [{"id": "call_908T44To73tdBB7SjloS9TGj", "function": {"name": "get_current_date",
       "arguments": "{}"}, "type": "function"}]}, {"content": "2024-01-01", "tool_call_id":
-      "call_oXzmJeFgBE1IcLWEQQQ7RJAH", "role": "tool"}], "model": "gpt-4.1", "seed":
+      "call_908T44To73tdBB7SjloS9TGj", "role": "tool"}], "model": "gpt-4.1", "seed":
       1014, "stream": true, "stream_options": {"include_usage": true}, "tools": [{"type":
       "function", "function": {"name": "get_current_date", "description": "Gets the
       current date", "parameters": {"properties": {}, "type": "object", "additionalProperties":
@@ -105,7 +103,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -113,8 +111,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - __cf_bm=OGlknkQK_xAAaxW63OXrmOFfFN22_aAonM2mphlwgzo-1767213701-1.0.1.1-ttjjlaU0NYxoFHVxvwyI9Rir_pdUT_NZqlg0nrm..tX3wnfxXbIzmVQPfusf.IIVo2Ck4kjwS4LIlvAy24Al.VEnjYNZSCtauO3_hc1Btv0;
-        _cfuvid=qyPfRsUuigi4._mrdHIe9UBBVP02LUBSRhchcMW_Rbc-1767213701813-0.0.1.1-604800000
+      - __cf_bm=ti3bZMOQ4TlC.BCH3K7svXOnnA2gGfDvEvZoadosWXY-1776367292.3558025-1.0.1.1-yT7xm8FWpnojq.EsTmfdSm8jNi0sIpkpscgRVL5QX6ZX8LFlHefppzDmeepBGDsMxySc2JLKMKvfkplmrWwJH1mMNvPoXRn5AhJTxbhYYfs_oN69olFBw9gWLLhz3SLj
       Host:
       - api.openai.com
       X-Stainless-Async:
@@ -125,31 +122,31 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CsxIkc178mr78NB8E8XtP9sduaMBT","object":"chat.completion.chunk","created":1767213702,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"2grRPaaVVkt6E"}
+      string: 'data: {"id":"chatcmpl-DVMZJLdzApbee1SY0Jvun3tLT04V6","object":"chat.completion.chunk","created":1776367293,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_2ec83bf3a4","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"oHxeEzwnR3sdL"}
 
 
-        data: {"id":"chatcmpl-CsxIkc178mr78NB8E8XtP9sduaMBT","object":"chat.completion.chunk","created":1767213702,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"202"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"vqPzOxLbAQeA"}
+        data: {"id":"chatcmpl-DVMZJLdzApbee1SY0Jvun3tLT04V6","object":"chat.completion.chunk","created":1776367293,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_2ec83bf3a4","choices":[{"index":0,"delta":{"content":"202"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"0i7aM5oiVYbo"}
 
 
-        data: {"id":"chatcmpl-CsxIkc178mr78NB8E8XtP9sduaMBT","object":"chat.completion.chunk","created":1767213702,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"4"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"facAoAKNZDnlH3"}
+        data: {"id":"chatcmpl-DVMZJLdzApbee1SY0Jvun3tLT04V6","object":"chat.completion.chunk","created":1776367293,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_2ec83bf3a4","choices":[{"index":0,"delta":{"content":"4"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"odnVU1Ux2Iubvq"}
 
 
-        data: {"id":"chatcmpl-CsxIkc178mr78NB8E8XtP9sduaMBT","object":"chat.completion.chunk","created":1767213702,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"-"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Xl1SP2T8e3cHGR"}
+        data: {"id":"chatcmpl-DVMZJLdzApbee1SY0Jvun3tLT04V6","object":"chat.completion.chunk","created":1776367293,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_2ec83bf3a4","choices":[{"index":0,"delta":{"content":"-"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"rsLtM2Et5IWV3h"}
 
 
-        data: {"id":"chatcmpl-CsxIkc178mr78NB8E8XtP9sduaMBT","object":"chat.completion.chunk","created":1767213702,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"01"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"T4IQ97LDltq7Q"}
+        data: {"id":"chatcmpl-DVMZJLdzApbee1SY0Jvun3tLT04V6","object":"chat.completion.chunk","created":1776367293,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_2ec83bf3a4","choices":[{"index":0,"delta":{"content":"01"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"yU21KvAm7bXmO"}
 
 
-        data: {"id":"chatcmpl-CsxIkc178mr78NB8E8XtP9sduaMBT","object":"chat.completion.chunk","created":1767213702,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"-"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"VV82ul8ghOapZt"}
+        data: {"id":"chatcmpl-DVMZJLdzApbee1SY0Jvun3tLT04V6","object":"chat.completion.chunk","created":1776367293,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_2ec83bf3a4","choices":[{"index":0,"delta":{"content":"-"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"pi77jtC0FOZrVJ"}
 
 
-        data: {"id":"chatcmpl-CsxIkc178mr78NB8E8XtP9sduaMBT","object":"chat.completion.chunk","created":1767213702,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"01"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"vnF8U9XJlIBLC"}
+        data: {"id":"chatcmpl-DVMZJLdzApbee1SY0Jvun3tLT04V6","object":"chat.completion.chunk","created":1776367293,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_2ec83bf3a4","choices":[{"index":0,"delta":{"content":"01"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Xsf6LKmfDHUJ2"}
 
 
-        data: {"id":"chatcmpl-CsxIkc178mr78NB8E8XtP9sduaMBT","object":"chat.completion.chunk","created":1767213702,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"VQb97NkKx"}
+        data: {"id":"chatcmpl-DVMZJLdzApbee1SY0Jvun3tLT04V6","object":"chat.completion.chunk","created":1776367293,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_2ec83bf3a4","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"SVYBJxhrc"}
 
 
-        data: {"id":"chatcmpl-CsxIkc178mr78NB8E8XtP9sduaMBT","object":"chat.completion.chunk","created":1767213702,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[],"usage":{"prompt_tokens":81,"completion_tokens":7,"total_tokens":88,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"jfrhRWsW1YbxVKM"}
+        data: {"id":"chatcmpl-DVMZJLdzApbee1SY0Jvun3tLT04V6","object":"chat.completion.chunk","created":1776367293,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_2ec83bf3a4","choices":[],"usage":{"prompt_tokens":81,"completion_tokens":7,"total_tokens":88,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"bTEUSTkFJrKH9ke"}
 
 
         data: [DONE]
@@ -157,14 +154,16 @@ interactions:
 
         '
     headers:
-      CF-RAY:
-      - 9b6c99664d7aeac2-ORD
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9ed58dbf28d1c9f2-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:42 GMT
+      - Thu, 16 Apr 2026 19:21:33 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -177,14 +176,10 @@ interactions:
       - X-Request-ID
       alt-svc:
       - h3=":443"; ma=86400
-      cf-cache-status:
-      - DYNAMIC
       openai-processing-ms:
-      - '779'
+      - '342'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '795'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -214,7 +209,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -231,16 +226,16 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CsxIlc2hfMWp7isL2Z3F9ZnIRU9B6","object":"chat.completion.chunk","created":1767213703,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_EYWiCLYtPMciqf0YbBmBCpfI","type":"function","function":{"name":"get_current_date2","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"eO"}
+      string: 'data: {"id":"chatcmpl-DVMZKcUZPIBPBy8OxyBFjopGhRooH","object":"chat.completion.chunk","created":1776367294,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_e93dba37d3","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_DitdThEfbiChMRv9ce8cpas4","type":"function","function":{"name":"get_current_date2","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"mb"}
 
 
-        data: {"id":"chatcmpl-CsxIlc2hfMWp7isL2Z3F9ZnIRU9B6","object":"chat.completion.chunk","created":1767213703,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{}"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"DI9"}
+        data: {"id":"chatcmpl-DVMZKcUZPIBPBy8OxyBFjopGhRooH","object":"chat.completion.chunk","created":1776367294,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_e93dba37d3","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{}"}}]},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"VtF"}
 
 
-        data: {"id":"chatcmpl-CsxIlc2hfMWp7isL2Z3F9ZnIRU9B6","object":"chat.completion.chunk","created":1767213703,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"usage":null,"obfuscation":"bWs"}
+        data: {"id":"chatcmpl-DVMZKcUZPIBPBy8OxyBFjopGhRooH","object":"chat.completion.chunk","created":1776367294,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_e93dba37d3","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"usage":null,"obfuscation":"6a9"}
 
 
-        data: {"id":"chatcmpl-CsxIlc2hfMWp7isL2Z3F9ZnIRU9B6","object":"chat.completion.chunk","created":1767213703,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[],"usage":{"prompt_tokens":56,"completion_tokens":12,"total_tokens":68,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"8eBlqZgJP0y3nx"}
+        data: {"id":"chatcmpl-DVMZKcUZPIBPBy8OxyBFjopGhRooH","object":"chat.completion.chunk","created":1776367294,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_e93dba37d3","choices":[],"usage":{"prompt_tokens":56,"completion_tokens":12,"total_tokens":68,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"UHfEaC4uWDCraY"}
 
 
         data: [DONE]
@@ -248,14 +243,16 @@ interactions:
 
         '
     headers:
-      CF-RAY:
-      - 9b6c996d881a2c1d-ORD
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9ed58dc35abfe819-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:43 GMT
+      - Thu, 16 Apr 2026 19:21:34 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -268,14 +265,10 @@ interactions:
       - X-Request-ID
       alt-svc:
       - h3=":443"; ma=86400
-      cf-cache-status:
-      - DYNAMIC
       openai-processing-ms:
-      - '325'
+      - '476'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '338'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -297,9 +290,9 @@ interactions:
     body: '{"messages": [{"content": "Be very terse, not even punctuation.", "role":
       "system"}, {"content": [{"type": "text", "text": "What''s the current date in
       YYYY-MM-DD format?"}], "role": "user"}, {"role": "assistant", "tool_calls":
-      [{"id": "call_EYWiCLYtPMciqf0YbBmBCpfI", "function": {"name": "get_current_date2",
+      [{"id": "call_DitdThEfbiChMRv9ce8cpas4", "function": {"name": "get_current_date2",
       "arguments": "{}"}, "type": "function"}]}, {"content": "2024-01-01", "tool_call_id":
-      "call_EYWiCLYtPMciqf0YbBmBCpfI", "role": "tool"}], "model": "gpt-4.1", "seed":
+      "call_DitdThEfbiChMRv9ce8cpas4", "role": "tool"}], "model": "gpt-4.1", "seed":
       1014, "stream": true, "stream_options": {"include_usage": true}, "tools": [{"type":
       "function", "function": {"name": "get_current_date2", "description": "Gets the
       current date", "parameters": {"properties": {}, "type": "object", "additionalProperties":
@@ -308,7 +301,7 @@ interactions:
       Accept:
       - application/json
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, zstd
       Connection:
       - keep-alive
       Content-Length:
@@ -316,8 +309,7 @@ interactions:
       Content-Type:
       - application/json
       Cookie:
-      - __cf_bm=WIHY3MoAsp7VCg4sTjUYvUtKXbHbxqtvbQAPTyTpsxc-1767213703-1.0.1.1-7AwQne8BXCq0up5djoE_76oYUQs1atFl.tZhHgl74QJ2dmXlCwO.KxazJRmJxsQnSvnCQHZwAvrSqdeSI_sSZD4GS8roH3A.rwiox.5b4M8;
-        _cfuvid=CwD4RAbJL8UzUEgDG4mXmaHKwdHAOcrmlw5xVBpfBco-1767213703693-0.0.1.1-604800000
+      - __cf_bm=VLkOVDKHmOMwhxGSeWYICvam9CBA03Jya.7ax3izgw4-1776367293.9816496-1.0.1.1-MLBWt0xIdQeUYmknlA5_NsNqOGnVrodXaNFm86ylxspbGZkqN5UfjSxNTM6sJXTXacQC8gd6e.8BbfD8gt9FjTM9WltUjLNtcZtG7oPAq8tOUqnSUtVhEdbTMIXsib6B
       Host:
       - api.openai.com
       X-Stainless-Async:
@@ -328,31 +320,31 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CsxIlaxRbeBP8oz9iQSsQkXu5sSqp","object":"chat.completion.chunk","created":1767213703,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"lFSKHKDsXdRQE"}
+      string: 'data: {"id":"chatcmpl-DVMZKrecYw04rXSLK73qCAP5x58Ud","object":"chat.completion.chunk","created":1776367294,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_2ec83bf3a4","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"hlxvNg2clnQ4G"}
 
 
-        data: {"id":"chatcmpl-CsxIlaxRbeBP8oz9iQSsQkXu5sSqp","object":"chat.completion.chunk","created":1767213703,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"202"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"13WHykpSeAEM"}
+        data: {"id":"chatcmpl-DVMZKrecYw04rXSLK73qCAP5x58Ud","object":"chat.completion.chunk","created":1776367294,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_2ec83bf3a4","choices":[{"index":0,"delta":{"content":"202"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"CMWmpmrn8Cpc"}
 
 
-        data: {"id":"chatcmpl-CsxIlaxRbeBP8oz9iQSsQkXu5sSqp","object":"chat.completion.chunk","created":1767213703,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"4"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Jp7ZMWZ3536VRF"}
+        data: {"id":"chatcmpl-DVMZKrecYw04rXSLK73qCAP5x58Ud","object":"chat.completion.chunk","created":1776367294,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_2ec83bf3a4","choices":[{"index":0,"delta":{"content":"4"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"zlJJEbj8VrwL8f"}
 
 
-        data: {"id":"chatcmpl-CsxIlaxRbeBP8oz9iQSsQkXu5sSqp","object":"chat.completion.chunk","created":1767213703,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"-"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"VWYVe07SGS9PHt"}
+        data: {"id":"chatcmpl-DVMZKrecYw04rXSLK73qCAP5x58Ud","object":"chat.completion.chunk","created":1776367294,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_2ec83bf3a4","choices":[{"index":0,"delta":{"content":"-"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"tgNuXsRUvbXqd0"}
 
 
-        data: {"id":"chatcmpl-CsxIlaxRbeBP8oz9iQSsQkXu5sSqp","object":"chat.completion.chunk","created":1767213703,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"01"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"rZ6dbX54zl03h"}
+        data: {"id":"chatcmpl-DVMZKrecYw04rXSLK73qCAP5x58Ud","object":"chat.completion.chunk","created":1776367294,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_2ec83bf3a4","choices":[{"index":0,"delta":{"content":"01"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"0DkVQ0Kw8QwnR"}
 
 
-        data: {"id":"chatcmpl-CsxIlaxRbeBP8oz9iQSsQkXu5sSqp","object":"chat.completion.chunk","created":1767213703,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"-"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"u1byY0jw7H3X9u"}
+        data: {"id":"chatcmpl-DVMZKrecYw04rXSLK73qCAP5x58Ud","object":"chat.completion.chunk","created":1776367294,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_2ec83bf3a4","choices":[{"index":0,"delta":{"content":"-"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"nPKIn4PnLcBPkN"}
 
 
-        data: {"id":"chatcmpl-CsxIlaxRbeBP8oz9iQSsQkXu5sSqp","object":"chat.completion.chunk","created":1767213703,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{"content":"01"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"M4lnfHEnEZKQB"}
+        data: {"id":"chatcmpl-DVMZKrecYw04rXSLK73qCAP5x58Ud","object":"chat.completion.chunk","created":1776367294,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_2ec83bf3a4","choices":[{"index":0,"delta":{"content":"01"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Uwan7kVovYl5g"}
 
 
-        data: {"id":"chatcmpl-CsxIlaxRbeBP8oz9iQSsQkXu5sSqp","object":"chat.completion.chunk","created":1767213703,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"jEYYoaoQP"}
+        data: {"id":"chatcmpl-DVMZKrecYw04rXSLK73qCAP5x58Ud","object":"chat.completion.chunk","created":1776367294,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_2ec83bf3a4","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"goWhRz8s3"}
 
 
-        data: {"id":"chatcmpl-CsxIlaxRbeBP8oz9iQSsQkXu5sSqp","object":"chat.completion.chunk","created":1767213703,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_1a2c4a5ede","choices":[],"usage":{"prompt_tokens":84,"completion_tokens":7,"total_tokens":91,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"PuZTY0Gd1EzbXLL"}
+        data: {"id":"chatcmpl-DVMZKrecYw04rXSLK73qCAP5x58Ud","object":"chat.completion.chunk","created":1776367294,"model":"gpt-4.1-2025-04-14","service_tier":"default","system_fingerprint":"fp_2ec83bf3a4","choices":[],"usage":{"prompt_tokens":84,"completion_tokens":7,"total_tokens":91,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"SG1H7hNLcBzvuqh"}
 
 
         data: [DONE]
@@ -360,14 +352,16 @@ interactions:
 
         '
     headers:
-      CF-RAY:
-      - 9b6c99713db688cd-ORD
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9ed58dc8399a442f-ORD
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 31 Dec 2025 20:41:44 GMT
+      - Thu, 16 Apr 2026 19:21:35 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -380,14 +374,10 @@ interactions:
       - X-Request-ID
       alt-svc:
       - h3=":443"; ma=86400
-      cf-cache-status:
-      - DYNAMIC
       openai-processing-ms:
-      - '324'
+      - '325'
       openai-version:
       - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '338'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:


### PR DESCRIPTION
## Summary

- OpenAI's Responses API now emits `response.rate_limits.updated` after `response.completed` during streaming
- The fallthrough in `stream_merge_chunks()` was returning `cast(Response, None)`, overwriting the valid `Response` object
- Changed to `return completion` so the accumulated result is preserved through any unrecognized event types

Closes #282

## Test plan

- [x] All 16 `test_provider_openai.py` tests pass with live API calls
- [x] All 11 `test_provider_openai_completions.py` tests pass with live API calls
- [x] VCR cassettes re-recorded

🤖 Generated with [Claude Code](https://claude.com/claude-code)