### PR TITLE
fix: update provider types and fix Bedrock import

### DIFF
--- a/chatlas/_provider_anthropic.py
+++ b/chatlas/_provider_anthropic.py
@@ -1158,7 +1158,7 @@ class AnthropicBedrockProvider(AnthropicProvider):
         )
 
         try:
-            from anthropic import AnthropicBedrock, AsyncAnthropicBedrock
+            from anthropic.lib.bedrock import AnthropicBedrock, AsyncAnthropicBedrock
         except ImportError:
             raise ImportError(
                 "`ChatBedrockAnthropic()` requires the `anthropic` package. "

--- a/chatlas/types/google/_client.py
+++ b/chatlas/types/google/_client.py
@@ -11,6 +11,7 @@ import google.genai.types
 
 
 class ChatClientArgs(TypedDict, total=False):
+    enterprise: Optional[bool]
     vertexai: Optional[bool]
     api_key: Optional[str]
     credentials: Optional[google.auth.credentials.Credentials]

--- a/chatlas/types/openai/_submit.py
+++ b/chatlas/types/openai/_submit.py
@@ -150,7 +150,7 @@ class SubmitInputArgs(TypedDict, total=False):
     ]
     presence_penalty: Union[float, None, openai.Omit]
     prompt_cache_key: str | openai.Omit
-    prompt_cache_retention: Union[Literal["in-memory", "24h"], None, openai.Omit]
+    prompt_cache_retention: Union[Literal["in_memory", "24h"], None, openai.Omit]
     reasoning_effort: Union[
         Literal["none", "minimal", "low", "medium", "high", "xhigh"], None, openai.Omit
     ]

--- a/chatlas/types/openai/_submit_responses.py
+++ b/chatlas/types/openai/_submit_responses.py
@@ -222,7 +222,7 @@ class SubmitInputArgs(TypedDict, total=False):
         openai.Omit,
     ]
     prompt_cache_key: str | openai.Omit
-    prompt_cache_retention: Union[Literal["in-memory", "24h"], None, openai.Omit]
+    prompt_cache_retention: Union[Literal["in_memory", "24h"], None, openai.Omit]
     reasoning: Union[openai.types.shared_params.reasoning.Reasoning, None, openai.Omit]
     safety_identifier: str | openai.Omit
     service_tier: Union[


### PR DESCRIPTION
## Summary
- Regenerated provider types for latest SDK versions (openai 2.33.0, google-genai 1.74.0)
- Fixed `AnthropicBedrock` import path — the `anthropic` package's `__all__` no longer includes Bedrock classes, so pyright reports them as private. Importing from `anthropic.lib.bedrock` resolves this.

## Changes
- `chatlas/types/google/_client.py`: Added `enterprise` field to `ChatClientArgs`
- `chatlas/types/openai/_submit.py`, `_submit_responses.py`: `prompt_cache_retention` literal changed from `"in-memory"` to `"in_memory"`
- `chatlas/_provider_anthropic.py`: Import `AnthropicBedrock`/`AsyncAnthropicBedrock` from `anthropic.lib.bedrock` instead of `anthropic`