### PR TITLE
fix: yield thinking tag boundaries in content='all' mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improvements
 
-* `.stream()` and `.stream_async()` now emit `<thinking>` / `</thinking>` tag boundaries around thinking content. With `content="text"`, concatenating all chunks produces well-formed output with thinking delimited by a single tag pair. With `content="all"`, behavior is unchanged — typed `ContentThinking` objects are yielded without tag strings. (#294)
+* `.stream()` and `.stream_async()` now emit `<thinking>` / `</thinking>` tag boundaries around thinking content in all stream modes. With `content="text"`, concatenating all chunks produces well-formed output with thinking delimited by a single tag pair. With `content="all"`, tag boundary strings are yielded alongside typed `ContentThinking` objects, so downstream consumers can detect thinking boundaries without type inspection. (#294, #297)
 * Updated default models across all providers to current generation: (#292)
   * Anthropic: `claude-sonnet-4-6`
   * Bedrock: `us.anthropic.claude-sonnet-4-6`

--- a/chatlas/_chat.py
+++ b/chatlas/_chat.py
@@ -2681,13 +2681,11 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
                         is_thinking = isinstance(content, ContentThinking)
                         if is_thinking and not inside_thinking:
                             emit("<thinking>\n")
-                            if content_mode == "text":
-                                yield "<thinking>\n"
+                            yield "<thinking>\n"
                             inside_thinking = True
                         elif not is_thinking and inside_thinking:
                             emit("\n</thinking>\n\n")
-                            if content_mode == "text":
-                                yield "\n</thinking>\n\n"
+                            yield "\n</thinking>\n\n"
                             inside_thinking = False
 
                         emit(text)
@@ -2699,8 +2697,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
 
             if inside_thinking:
                 emit("\n</thinking>\n\n")
-                if content_mode == "text":
-                    yield "\n</thinking>\n\n"
+                yield "\n</thinking>\n\n"
 
             turn = self.provider.stream_turn(
                 result,
@@ -2804,13 +2801,11 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
                         is_thinking = isinstance(content, ContentThinking)
                         if is_thinking and not inside_thinking:
                             emit("<thinking>\n")
-                            if content_mode == "text":
-                                yield "<thinking>\n"
+                            yield "<thinking>\n"
                             inside_thinking = True
                         elif not is_thinking and inside_thinking:
                             emit("\n</thinking>\n\n")
-                            if content_mode == "text":
-                                yield "\n</thinking>\n\n"
+                            yield "\n</thinking>\n\n"
                             inside_thinking = False
 
                         emit(text)
@@ -2822,8 +2817,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
 
             if inside_thinking:
                 emit("\n</thinking>\n\n")
-                if content_mode == "text":
-                    yield "\n</thinking>\n\n"
+                yield "\n</thinking>\n\n"
 
             turn = self.provider.stream_turn(
                 result,

--- a/tests/test_stream_thinking.py
+++ b/tests/test_stream_thinking.py
@@ -132,10 +132,10 @@ class TestStreamThinkingText:
 
 
 class TestStreamThinkingAll:
-    """Tests for content='all' mode — ContentThinking objects yielded, no tag strings."""
+    """Tests for content='all' mode — ContentThinking objects AND tag boundary strings yielded."""
 
     def test_thinking_then_text(self):
-        """content='all' yields ContentThinking objects, not tag strings."""
+        """content='all' yields tag boundaries AND ContentThinking objects."""
         chunks = [
             ContentThinking._as_chunk("step 1 "),
             ContentThinking._as_chunk("step 2"),
@@ -145,15 +145,17 @@ class TestStreamThinkingAll:
         result = list(chat.stream("test", content="all"))
 
         thinking_chunks = [x for x in result if isinstance(x, ContentThinking)]
-        text_chunks = [x for x in result if isinstance(x, str)]
+        str_chunks = [x for x in result if isinstance(x, str)]
 
         assert len(thinking_chunks) == 2
         assert thinking_chunks[0].thinking == "step 1 "
         assert thinking_chunks[1].thinking == "step 2"
-        assert text_chunks == ["Hello"]
+        assert "<thinking>\n" in str_chunks
+        assert "\n</thinking>\n\n" in str_chunks
+        assert "Hello" in str_chunks
 
-    def test_no_tag_strings_yielded(self):
-        """content='all' mode should NOT yield tag boundary strings."""
+    def test_tag_boundaries_yielded(self):
+        """content='all' mode SHOULD yield tag boundary strings."""
         chunks = [
             ContentThinking._as_chunk("thought"),
             ContentText.model_construct(text="answer"),
@@ -162,9 +164,23 @@ class TestStreamThinkingAll:
         result = list(chat.stream("test", content="all"))
 
         str_chunks = [x for x in result if isinstance(x, str)]
-        for s in str_chunks:
-            assert "<thinking>" not in s
-            assert "</thinking>" not in s
+        assert "<thinking>\n" in str_chunks
+        assert "\n</thinking>\n\n" in str_chunks
+
+    def test_order_of_chunks(self):
+        """content='all' mode: open tag, ContentThinking objects, close tag, then text."""
+        chunks = [
+            ContentThinking._as_chunk("thought"),
+            ContentText.model_construct(text="answer"),
+        ]
+        chat = _make_chat(chunks)
+        result = list(chat.stream("test", content="all"))
+
+        assert result[0] == "<thinking>\n"
+        assert isinstance(result[1], ContentThinking)
+        assert result[1].thinking == "thought"
+        assert result[2] == "\n</thinking>\n\n"
+        assert result[3] == "answer"
 
     def test_str_on_chunk_has_no_tags(self):
         """Calling str() on yielded ContentThinking chunks should not wrap in tags."""
@@ -207,7 +223,7 @@ class TestStreamThinkingAsync:
         assert combined == "<thinking>\nreasoning\n</thinking>\n\n"
 
     async def test_content_all_async(self):
-        """Async content='all' yields ContentThinking objects, no tag strings."""
+        """Async content='all' yields tag boundaries AND ContentThinking objects."""
         chunks = [
             ContentThinking._as_chunk("thought"),
             ContentText.model_construct(text="answer"),
@@ -220,6 +236,8 @@ class TestStreamThinkingAsync:
 
         assert len(thinking_chunks) == 1
         assert thinking_chunks[0].thinking == "thought"
-        assert str_chunks == ["answer"]
-        for s in str_chunks:
-            assert "<thinking>" not in s
+        assert "<thinking>\n" in str_chunks
+        assert "\n</thinking>\n\n" in str_chunks
+        assert "answer" in str_chunks
+        assert result[0] == "<thinking>\n"
+        assert result[2] == "\n</thinking>\n\n"


### PR DESCRIPTION
## Summary

Extends the `<thinking>` tag boundary emission (from #294) to `content="all"` mode. Previously, tag boundary strings were only yielded to consumers in `content="text"` mode. Now they're yielded in all modes.

### What changed

Removed the `if content_mode == "text":` guards around the tag boundary `yield` statements in both sync and async `_submit_turns`. The `emit()` calls (internal echo) were already unconditional; this makes the consumer-facing yields match.

In `content="all"` mode, the stream now yields:
1. `"<thinking>\n"` (string)
2. N × `ContentThinking` objects (unchanged)
3. `"\n</thinking>\n\n"` (string)
4. Response text strings

### Why

This is needed for [posit-dev/shinychat#210](https://github.com/posit-dev/shinychat/pull/210), which removes server-side thinking detection and relies entirely on the client's tag parser seeing `<thinking>` tags in the stream. Without this fix, tool-use apps (which require `content="all"`) with thinking-capable models would render thinking content as regular assistant text — the client never sees tag boundaries.

### Related PRs

| PR | Relationship |
|----|-------------|
| [#294](https://github.com/posit-dev/chatlas/pull/294) | Introduced tag boundaries for `content="text"` mode. This PR extends that to `content="all"`. |
| [tidyverse/ellmer#975](https://github.com/tidyverse/ellmer/pull/975) | R companion — same fix likely needed for `stream="content"` mode. |
| [posit-dev/shinychat#210](https://github.com/posit-dev/shinychat/pull/210) | Depends on this fix for correctness in `content="all"` scenarios. |

## Test plan

- [x] All 11 streaming thinking tests pass
- [x] `TestStreamThinkingAll::test_tag_boundaries_yielded` — verifies boundaries present
- [x] `TestStreamThinkingAll::test_order_of_chunks` — verifies exact sequence
- [x] `TestStreamThinkingAsync::test_content_all_async` — async equivalent