### PR TITLE
fix: return ContentThinkingDelta from completions provider streaming

### DIFF
--- a/chatlas/_provider_openai_completions.py
+++ b/chatlas/_provider_openai_completions.py
@@ -25,6 +25,7 @@ from ._content import (
     ContentPDF,
     ContentText,
     ContentThinking,
+    ContentThinkingDelta,
     ContentToolRequest,
     ContentToolResult,
 )
@@ -212,7 +213,7 @@ class OpenAICompletionsProvider(
 
         reasoning = getattr(delta, "reasoning_content", None)
         if reasoning is not None:
-            return ContentThinking(thinking=reasoning)
+            return ContentThinkingDelta(thinking=reasoning)
 
         text = delta.content
         if text is None:

--- a/tests/test_provider_openai_completions.py
+++ b/tests/test_provider_openai_completions.py
@@ -1,7 +1,7 @@
 import httpx
 import pytest
 from chatlas import ChatOpenAICompletions
-from chatlas._content import ContentText, ContentThinking
+from chatlas._content import ContentText, ContentThinking, ContentThinkingDelta
 from chatlas._provider_openai_completions import OpenAICompletionsProvider
 from chatlas._turn import AssistantTurn
 
@@ -133,7 +133,7 @@ def test_stream_content_extracts_reasoning_content():
 
     chunk = FakeChunk([FakeChoice(FakeDelta(reasoning_content="think"))])
     result = provider.stream_content(chunk)
-    assert isinstance(result, ContentThinking)
+    assert isinstance(result, ContentThinkingDelta)
     assert result.thinking == "think"
 
     chunk = FakeChunk([FakeChoice(FakeDelta(content="hello"))])


### PR DESCRIPTION
## Summary

- `OpenAICompletionsProvider.stream_content()` was returning `ContentThinking` (the finalized type for completed turns) instead of `ContentThinkingDelta` (the streaming fragment type)
- The `TurnAccumulator` only recognizes `ContentThinkingDelta` for thinking block handling, so thinking content was silently dropped during streaming
- Affects all completions-based providers: DeepSeek, Groq, OpenRouter, HuggingFace, LMStudio, Mistral, Ollama, etc.

Closes #300

## Test plan

- [x] Existing `test_stream_content_extracts_reasoning_content` updated to assert `ContentThinkingDelta`
- [x] All 11 tests in `test_stream_thinking.py` pass (verify thinking deltas flow through `TurnAccumulator` correctly)
- [x] `test_response_as_turn_extracts_reasoning_content` still passes (non-streaming path unchanged)
- [x] Pyright passes with 0 errors