### PR TITLE
fix: handle bytes fields in model_dump(mode="json") serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes 
 
+* Fixed `model_dump(mode="json")` failing on `Turn`s containing `bytes` fields (e.g., `ContentPDF.data`, `thought_signature` in `ContentToolRequest`/`ContentThinking` extras). Bytes values are now base64-encoded during serialization and decoded on validation, so JSON round-trips work correctly.
 * Fixed thinking content being silently dropped during streaming for completions-based providers (DeepSeek, Groq, OpenRouter, etc.). The streaming path was returning finalized `ContentThinking` objects instead of `ContentThinkingDelta` fragments, which the `TurnAccumulator` didn't recognize. (#301)
 
 ## [0.17.0] - 2026-05-11

--- a/chatlas/_content.py
+++ b/chatlas/_content.py
@@ -637,7 +637,7 @@ class ContentPDF(Content):
     @classmethod
     def validate_data(cls, v: bytes | str) -> bytes:
         if isinstance(v, str):
-            return base64.b64decode(v)
+            return base64.b64decode(v, validate=True)
         return v
 
     def __str__(self):
@@ -869,8 +869,12 @@ def serialize_dict_with_bytes(d: dict[str, Any]) -> dict[str, Any]:
 def validate_dict_with_bytes(d: dict[str, Any]) -> dict[str, Any]:
     result: dict[str, Any] = {}
     for key, value in d.items():
-        if isinstance(value, dict) and BYTES_SENTINEL in value:
-            result[key] = base64.b64decode(value[BYTES_SENTINEL])
+        if (
+            isinstance(value, dict)
+            and set(value.keys()) == {BYTES_SENTINEL}
+            and isinstance(value[BYTES_SENTINEL], str)
+        ):
+            result[key] = base64.b64decode(value[BYTES_SENTINEL], validate=True)
         else:
             result[key] = value
     return result

--- a/chatlas/_content.py
+++ b/chatlas/_content.py
@@ -285,13 +285,13 @@ class ContentToolRequest(Content):
     @field_serializer("extra")
     @classmethod
     def serialize_extra(cls, v: dict[str, object]) -> dict[str, object]:
-        return _serialize_dict_with_bytes(v)
+        return serialize_dict_with_bytes(v)
 
     @field_validator("extra", mode="before")
     @classmethod
-    def validate_extra(cls, v: dict[str, object]) -> dict[str, object]:
+    def validate_extra(cls, v: object) -> object:
         if isinstance(v, dict):
-            return _validate_dict_with_bytes(v)
+            return validate_dict_with_bytes(v)
         return v
 
     def __str__(self):
@@ -671,15 +671,13 @@ class ContentThinking(Content):
     ) -> Optional[dict[str, Any]]:
         if v is None:
             return None
-        return _serialize_dict_with_bytes(v)
+        return serialize_dict_with_bytes(v)
 
     @field_validator("extra", mode="before")
     @classmethod
-    def validate_extra(
-        cls, v: Optional[dict[str, Any]]
-    ) -> Optional[dict[str, Any]]:
+    def validate_extra(cls, v: object) -> object:
         if isinstance(v, dict):
-            return _validate_dict_with_bytes(v)
+            return validate_dict_with_bytes(v)
         return v
 
     def __add__(self, other: object) -> "ContentThinking":
@@ -855,24 +853,24 @@ ContentUnion = Union[
 ]
 
 
-_BYTES_SENTINEL = "__base64_bytes__"
+BYTES_SENTINEL = "__base64_bytes__"
 
 
-def _serialize_dict_with_bytes(d: dict[str, Any]) -> dict[str, Any]:
+def serialize_dict_with_bytes(d: dict[str, Any]) -> dict[str, Any]:
     result: dict[str, Any] = {}
     for key, value in d.items():
         if isinstance(value, bytes):
-            result[key] = {_BYTES_SENTINEL: base64.b64encode(value).decode("ascii")}
+            result[key] = {BYTES_SENTINEL: base64.b64encode(value).decode("ascii")}
         else:
             result[key] = value
     return result
 
 
-def _validate_dict_with_bytes(d: dict[str, Any]) -> dict[str, Any]:
+def validate_dict_with_bytes(d: dict[str, Any]) -> dict[str, Any]:
     result: dict[str, Any] = {}
     for key, value in d.items():
-        if isinstance(value, dict) and _BYTES_SENTINEL in value:
-            result[key] = base64.b64decode(value[_BYTES_SENTINEL])
+        if isinstance(value, dict) and BYTES_SENTINEL in value:
+            result[key] = base64.b64decode(value[BYTES_SENTINEL])
         else:
             result[key] = value
     return result

--- a/chatlas/_content.py
+++ b/chatlas/_content.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import inspect
 import warnings
 from pprint import pformat
@@ -280,6 +281,18 @@ class ContentToolRequest(Content):
     extra: dict[str, object] = Field(default_factory=dict)
 
     content_type: ContentTypeEnum = "tool_request"
+
+    @field_serializer("extra")
+    @classmethod
+    def serialize_extra(cls, v: dict[str, object]) -> dict[str, object]:
+        return _serialize_dict_with_bytes(v)
+
+    @field_validator("extra", mode="before")
+    @classmethod
+    def validate_extra(cls, v: dict[str, object]) -> dict[str, object]:
+        if isinstance(v, dict):
+            return _validate_dict_with_bytes(v)
+        return v
 
     def __str__(self):
         args_str = self._arguments_str()
@@ -615,6 +628,18 @@ class ContentPDF(Content):
 
     content_type: ContentTypeEnum = "pdf"
 
+    @field_serializer("data")
+    @classmethod
+    def serialize_data(cls, v: bytes) -> str:
+        return base64.b64encode(v).decode("ascii")
+
+    @field_validator("data", mode="before")
+    @classmethod
+    def validate_data(cls, v: bytes | str) -> bytes:
+        if isinstance(v, str):
+            return base64.b64decode(v)
+        return v
+
     def __str__(self):
         return f"<PDF document file={self.filename} size={len(self.data)} bytes>"
 
@@ -638,6 +663,24 @@ class ContentThinking(Content):
     extra: Optional[dict[str, Any]] = None
 
     content_type: ContentTypeEnum = "thinking"
+
+    @field_serializer("extra")
+    @classmethod
+    def serialize_extra(
+        cls, v: Optional[dict[str, Any]]
+    ) -> Optional[dict[str, Any]]:
+        if v is None:
+            return None
+        return _serialize_dict_with_bytes(v)
+
+    @field_validator("extra", mode="before")
+    @classmethod
+    def validate_extra(
+        cls, v: Optional[dict[str, Any]]
+    ) -> Optional[dict[str, Any]]:
+        if isinstance(v, dict):
+            return _validate_dict_with_bytes(v)
+        return v
 
     def __add__(self, other: object) -> "ContentThinking":
         if not isinstance(other, ContentThinking):
@@ -810,6 +853,29 @@ ContentUnion = Union[
     ContentToolRequestFetch,
     ContentToolResponseFetch,
 ]
+
+
+_BYTES_SENTINEL = "__base64_bytes__"
+
+
+def _serialize_dict_with_bytes(d: dict[str, Any]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in d.items():
+        if isinstance(value, bytes):
+            result[key] = {_BYTES_SENTINEL: base64.b64encode(value).decode("ascii")}
+        else:
+            result[key] = value
+    return result
+
+
+def _validate_dict_with_bytes(d: dict[str, Any]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in d.items():
+        if isinstance(value, dict) and _BYTES_SENTINEL in value:
+            result[key] = base64.b64decode(value[_BYTES_SENTINEL])
+        else:
+            result[key] = value
+    return result
 
 
 def create_content(data: dict[str, Any]) -> ContentUnion:

--- a/tests/test_content_pdf.py
+++ b/tests/test_content_pdf.py
@@ -1,7 +1,8 @@
 from pathlib import Path
 
 from chatlas import content_pdf_file
-from chatlas._content import ContentPDF
+from chatlas._content import ContentPDF, ContentThinking, ContentToolRequest
+from chatlas._turn import AssistantTurn, Turn, UserTurn
 
 
 def test_can_create_pdf_from_local_file():
@@ -10,3 +11,48 @@ def test_can_create_pdf_from_local_file():
     assert isinstance(obj, ContentPDF)
     assert obj.filename == "apples.pdf"
     assert isinstance(obj.data, bytes)
+
+
+def test_pdf_bytes_round_trip():
+    raw = b"\x00\x01\x02\xd6\x05\x06"
+    pdf = ContentPDF(data=raw, filename="test.pdf")
+    turn = UserTurn([pdf])
+    dumped = turn.model_dump(mode="json")
+    restored = Turn.model_validate(dumped)
+    assert restored.contents[0].data == raw
+
+
+def test_tool_request_extra_bytes_round_trip():
+    sig = b"\xab\xcd\xef\x00\x01\x02"
+    request = ContentToolRequest(
+        id="call_1",
+        name="query",
+        arguments={"q": "SELECT 1"},
+        extra={"thought_signature": sig},
+    )
+    turn = AssistantTurn([request])
+    dumped = turn.model_dump(mode="json")
+    restored = Turn.model_validate(dumped)
+    assert restored.contents[0].extra["thought_signature"] == sig
+
+
+def test_thinking_extra_bytes_round_trip():
+    sig = b"\xd6\x01\x02\x03\x04\x05"
+    thinking = ContentThinking(thinking="reasoning...", extra={"thought_signature": sig})
+    turn = AssistantTurn([thinking])
+    dumped = turn.model_dump(mode="json")
+    restored = Turn.model_validate(dumped)
+    assert restored.contents[0].extra["thought_signature"] == sig
+
+
+def test_tool_request_extra_without_bytes():
+    request = ContentToolRequest(
+        id="call_1",
+        name="query",
+        arguments={"q": "SELECT 1"},
+        extra={"key": "value", "num": 42},
+    )
+    turn = AssistantTurn([request])
+    dumped = turn.model_dump(mode="json")
+    restored = Turn.model_validate(dumped)
+    assert restored.contents[0].extra == {"key": "value", "num": 42}


### PR DESCRIPTION
## Summary

Fixes `UnicodeDecodeError` when serializing turns that contain `bytes` values via `model_dump(mode="json")`.

- Google Gemini's `thought_signature` (opaque `bytes`) gets stored in `ContentToolRequest.extra` and can appear in `ContentThinking.extra`. Pydantic's `model_dump(mode="json")` tries to decode these bytes as UTF-8, which fails on arbitrary binary data.
- `ContentPDF.data` (raw PDF bytes) has the same issue.
- Downstream consumers like shinychat's bookmark serialization call `model_dump(mode="json")` on all turns, triggering the error.

Adds `field_serializer`/`field_validator` pairs that base64-encode bytes on dump and decode on validate, so the data round-trips correctly through JSON.

Closes #302

## Test plan

- [x] New tests in `test_content_pdf.py` covering round-trip serialization for all three affected content types
- [x] Existing tests pass (`test_content_pdf.py`, `test_turn_expand.py`)
- [x] Pyright clean on `chatlas/_content.py`
- [x] Ruff clean