### PR TITLE
fix: warn when ChatOpenAI() is used with non-OpenAI base_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improvements
 
+* `ChatOpenAI()` now warns when `base_url` points to a non-OpenAI host, guiding users to `ChatOpenAICompletions()` for third-party backends like vLLM, Ollama, and LiteLLM. (#285)
 * When a stream is interrupted (closed early, cancelled, or errors), the accumulated content is now saved as a partial `AssistantTurn` so conversation state isn't lost. Partial turns display `[interrupted]` (or the cancellation reason) in the `Chat` repr and are excluded from token/cost accounting. (#279)
 * `ChatAnthropic()` and `ChatBedrockAnthropic()` now use Anthropic's native structured outputs API for Claude 4.5+ models, enabling streaming with `data_model`. Older models fall back to the tool-based approach. A new `structured_output_mode` parameter (`"auto"`, `"native"`, or `"tool"`) lets you override the auto-detection. (#263)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improvements
 
-* `ChatOpenAI()` now warns when `base_url` points to a non-OpenAI host, guiding users to `ChatOpenAICompletions()` for third-party backends like vLLM, Ollama, and LiteLLM. (#285)
 * When a stream is interrupted (closed early, cancelled, or errors), the accumulated content is now saved as a partial `AssistantTurn` so conversation state isn't lost. Partial turns display `[interrupted]` (or the cancellation reason) in the `Chat` repr and are excluded from token/cost accounting. (#279)
 * `ChatAnthropic()` and `ChatBedrockAnthropic()` now use Anthropic's native structured outputs API for Claude 4.5+ models, enabling streaming with `data_model`. Older models fall back to the tool-based approach. A new `structured_output_mode` parameter (`"auto"`, `"native"`, or `"tool"`) lets you override the auto-detection. (#263)
+* `ChatOpenAI()` now warns when `base_url` points to a non-OpenAI host, guiding users to `ChatOpenAICompletions()` for third-party backends like vLLM, Ollama, and LiteLLM. (#285)
 
 ### Bug fixes 
 

--- a/chatlas/_provider_cloudflare.py
+++ b/chatlas/_provider_cloudflare.py
@@ -86,7 +86,7 @@ def ChatCloudflare(
 
     Note
     ----
-    This function is a lightweight wrapper around [](`~chatlas.ChatOpenAI`) with
+    This function is a lightweight wrapper around [](`~chatlas.ChatOpenAICompletions`) with
     the defaults tweaked for Cloudflare.
 
     Note

--- a/chatlas/_provider_deepseek.py
+++ b/chatlas/_provider_deepseek.py
@@ -82,7 +82,7 @@ def ChatDeepSeek(
 
     Note
     ----
-    This function is a lightweight wrapper around [](`~chatlas.ChatOpenAI`) with
+    This function is a lightweight wrapper around [](`~chatlas.ChatOpenAICompletions`) with
     the defaults tweaked for DeepSeek.
 
     Note

--- a/chatlas/_provider_github.py
+++ b/chatlas/_provider_github.py
@@ -80,7 +80,7 @@ def ChatGithub(
 
     Note
     ----
-    This function is a lightweight wrapper around [](`~chatlas.ChatOpenAI`) with
+    This function is a lightweight wrapper around [](`~chatlas.ChatOpenAICompletions`) with
     the defaults tweaked for the GitHub model marketplace.
 
     Note

--- a/chatlas/_provider_groq.py
+++ b/chatlas/_provider_groq.py
@@ -73,7 +73,7 @@ def ChatGroq(
 
     Note
     ----
-    This function is a lightweight wrapper around [](`~chatlas.ChatOpenAI`) with
+    This function is a lightweight wrapper around [](`~chatlas.ChatOpenAICompletions`) with
     the defaults tweaked for groq.
 
     Note

--- a/chatlas/_provider_huggingface.py
+++ b/chatlas/_provider_huggingface.py
@@ -82,7 +82,7 @@ def ChatHuggingFace(
 
     Note
     ----
-    This function is a lightweight wrapper around [](`~chatlas.ChatOpenAI`), with
+    This function is a lightweight wrapper around [](`~chatlas.ChatOpenAICompletions`), with
     the defaults tweaked for Hugging Face.
 
     Note

--- a/chatlas/_provider_lmstudio.py
+++ b/chatlas/_provider_lmstudio.py
@@ -86,7 +86,7 @@ def ChatLMStudio(
 
     Note
     ----
-    This function is a lightweight wrapper around [](`~chatlas.ChatOpenAI`) with
+    This function is a lightweight wrapper around [](`~chatlas.ChatOpenAICompletions`) with
     the defaults tweaked for LM Studio.
     """
     base_url = os.getenv("LMSTUDIO_BASE_URL", base_url)

--- a/chatlas/_provider_ollama.py
+++ b/chatlas/_provider_ollama.py
@@ -76,7 +76,7 @@ def ChatOllama(
 
     Note
     ----
-    This function is a lightweight wrapper around [](`~chatlas.ChatOpenAI`) with
+    This function is a lightweight wrapper around [](`~chatlas.ChatOpenAICompletions`) with
     the defaults tweaked for ollama.
 
     Limitations

--- a/chatlas/_provider_openai.py
+++ b/chatlas/_provider_openai.py
@@ -579,10 +579,12 @@ def as_message(x: "ResponseInputContentParam", role: Role) -> "EasyInputMessageP
 def check_base_url(base_url: str) -> None:
     parsed = urlparse(base_url)
     if parsed.hostname != "api.openai.com":
-        raise ValueError(
+        warnings.warn(
             "ChatOpenAI() uses OpenAI's Responses API, which is not supported by most "
             "third-party backends. Use ChatOpenAICompletions() instead for "
-            "OpenAI-compatible backends (e.g., vLLM, Ollama, LiteLLM, etc.)."
+            "OpenAI-compatible backends (e.g., vLLM, Ollama, LiteLLM, etc.).",
+            UserWarning,
+            stacklevel=3,
         )
 
 

--- a/chatlas/_provider_openai.py
+++ b/chatlas/_provider_openai.py
@@ -165,7 +165,7 @@ def ChatOpenAI(
     The responses API does not support the `seed` parameter. If you need
     reproducible output, use [](`~chatlas.ChatOpenAICompletions`) instead.
     """
-    _check_base_url(base_url)
+    check_base_url(base_url)
 
     if model is None:
         model = log_model_default("gpt-5.4")
@@ -575,7 +575,7 @@ def as_message(x: "ResponseInputContentParam", role: Role) -> "EasyInputMessageP
     return {"role": role, "content": [x]}
 
 
-def _check_base_url(base_url: str) -> None:
+def check_base_url(base_url: str) -> None:
     from urllib.parse import urlparse
 
     parsed = urlparse(base_url)

--- a/chatlas/_provider_openai.py
+++ b/chatlas/_provider_openai.py
@@ -96,7 +96,11 @@ def ChatOpenAI(
         default, and warn you about it. We strongly recommend explicitly
         choosing a model for all but the most casual use.
     base_url
-        The base URL to the endpoint; the default uses OpenAI.
+        The base URL to the endpoint; the default uses OpenAI. This must point
+        to the OpenAI API since `ChatOpenAI()` uses the Responses API, which
+        is specific to OpenAI. For third-party OpenAI-compatible backends
+        (e.g., vLLM, Ollama, LiteLLM), use
+        [](`~chatlas.ChatOpenAICompletions`) instead.
     reasoning
         The reasoning effort to use (for reasoning-capable models like the o and
         gpt-5 series).
@@ -161,6 +165,8 @@ def ChatOpenAI(
     The responses API does not support the `seed` parameter. If you need
     reproducible output, use [](`~chatlas.ChatOpenAICompletions`) instead.
     """
+    _check_base_url(base_url)
+
     if model is None:
         model = log_model_default("gpt-5.4")
 
@@ -567,6 +573,18 @@ def as_input_param(content: Content, role: Role) -> "ResponseInputItemParam":
 
 def as_message(x: "ResponseInputContentParam", role: Role) -> "EasyInputMessageParam":
     return {"role": role, "content": [x]}
+
+
+def _check_base_url(base_url: str) -> None:
+    from urllib.parse import urlparse
+
+    parsed = urlparse(base_url)
+    if parsed.hostname != "api.openai.com":
+        raise ValueError(
+            "ChatOpenAI() uses OpenAI's Responses API, which is not supported by most "
+            "third-party backends. Use ChatOpenAICompletions() instead for "
+            "OpenAI-compatible backends (e.g., vLLM, Ollama, LiteLLM, etc.)."
+        )
 
 
 def is_reasoning_model(model: str) -> bool:

--- a/chatlas/_provider_openai.py
+++ b/chatlas/_provider_openai.py
@@ -97,11 +97,10 @@ def ChatOpenAI(
         default, and warn you about it. We strongly recommend explicitly
         choosing a model for all but the most casual use.
     base_url
-        The base URL to the endpoint; the default uses OpenAI. This must point
-        to the OpenAI API since `ChatOpenAI()` uses the Responses API, which
-        is specific to OpenAI. For third-party OpenAI-compatible backends
-        (e.g., vLLM, Ollama, LiteLLM), use
-        [](`~chatlas.ChatOpenAICompletions`) instead.
+        The base URL to the endpoint; the default uses OpenAI. Since
+        `ChatOpenAI()` uses the Responses API, most third-party backends
+        won't work here. For OpenAI-compatible backends (e.g., vLLM,
+        Ollama, LiteLLM), use [](`~chatlas.ChatOpenAICompletions`) instead.
     reasoning
         The reasoning effort to use (for reasoning-capable models like the o and
         gpt-5 series).

--- a/chatlas/_provider_openai.py
+++ b/chatlas/_provider_openai.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import base64
 import warnings
 from typing import TYPE_CHECKING, Literal, Optional, cast
+from urllib.parse import urlparse
 
 import orjson
 from openai.types.responses import Response, ResponseStreamEvent
@@ -576,8 +577,6 @@ def as_message(x: "ResponseInputContentParam", role: Role) -> "EasyInputMessageP
 
 
 def check_base_url(base_url: str) -> None:
-    from urllib.parse import urlparse
-
     parsed = urlparse(base_url)
     if parsed.hostname != "api.openai.com":
         raise ValueError(

--- a/chatlas/_provider_openai_completions.py
+++ b/chatlas/_provider_openai_completions.py
@@ -65,17 +65,32 @@ def ChatOpenAICompletions(
     kwargs: Optional["ChatClientArgs"] = None,
 ) -> Chat["SubmitInputArgs", ChatCompletion]:
     """
-    Chat with an OpenAI-compatible model (via the Completions API).
+    Chat with an OpenAI-compatible model (via the Chat Completions API).
 
-    This function exists mainly for historical reasons; new code should
-    prefer `ChatOpenAI()`, which uses the newer Responses API.
+    Use this function to connect to any OpenAI-compatible backend, including
+    third-party inference engines like vLLM, Ollama, LiteLLM, and others.
+    The Chat Completions API (`/v1/chat/completions`) is the universally
+    adopted standard across the open-source ecosystem.
 
-    This function may also be useful for using an "OpenAI-compatible model"
-    hosted by another provider (e.g., vLLM, Ollama, etc.) that supports the
-    OpenAI Completions API.
+    For the OpenAI-specific Responses API, use [](`~chatlas.ChatOpenAI`)
+    instead.
 
     Parameters
     ----------
+    base_url
+        The base URL to the endpoint; the default uses OpenAI. Set this to
+        your server's URL for third-party backends (e.g.,
+        ``"http://localhost:8000/v1"`` for a local vLLM server).
+    system_prompt
+        A system prompt to set the behavior of the assistant.
+    model
+        The model to use for the chat.
+    api_key
+        The API key to use for authentication. You generally should not supply
+        this directly, but instead set the `OPENAI_API_KEY` environment
+        variable.
+    seed
+        Optional seed for reproducible output.
     preserve_thinking
         If True, reasoning content returned by the model is included when
         sending conversation history back to the API. If False (the default),

--- a/chatlas/_provider_openrouter.py
+++ b/chatlas/_provider_openrouter.py
@@ -75,7 +75,7 @@ def ChatOpenRouter(
 
     Note
     ----
-    This function is a lightweight wrapper around [](`~chatlas.ChatOpenAI`) with
+    This function is a lightweight wrapper around [](`~chatlas.ChatOpenAICompletions`) with
     the defaults tweaked for OpenRouter.
 
     Note

--- a/chatlas/_provider_perplexity.py
+++ b/chatlas/_provider_perplexity.py
@@ -78,7 +78,7 @@ def ChatPerplexity(
 
     Note
     ----
-    This function is a lightweight wrapper around [](`chatlas.ChatOpenAI`) with
+    This function is a lightweight wrapper around [](`~chatlas.ChatOpenAICompletions`) with
     the defaults tweaked for perplexity.ai.
 
     Note

--- a/chatlas/_provider_portkey.py
+++ b/chatlas/_provider_portkey.py
@@ -80,7 +80,7 @@ def ChatPortkey(
 
     Notes
     -----
-    This function is a lightweight wrapper around [](`~chatlas.ChatOpenAI`) with
+    This function is a lightweight wrapper around [](`~chatlas.ChatOpenAICompletions`) with
     the defaults tweaked for PortkeyAI.
 
     """

--- a/docs/get-started/models.qmd
+++ b/docs/get-started/models.qmd
@@ -41,8 +41,7 @@ To see the pre-requisites for a given provider, visit the relevant usage page in
 
 To use chatlas with a provider not listed in the table above, you have two options:
 
-1. If the model provider is "OpenAI compatible" (i.e., it can be used with the [`openai` Python SDK](https://github.com/openai/openai-python#readme)), use `ChatOpenAI()` with the appropriate `base_url` and `api_key`.
-    * When providers say they are "OpenAI compatible", they usually mean compatible with the [Completions API](https://github.com/openai/openai-python?tab=readme-ov-file#usage). In this case, use [`ChatOpenAICompletions()`](../reference/ChatOpenAICompletions.qmd) instead of `ChatOpenAI()` (the latter uses the newer Responses API).
+1. If the model provider is "OpenAI compatible" (i.e., it supports the `/v1/chat/completions` endpoint), use [`ChatOpenAICompletions()`](../reference/ChatOpenAICompletions.qmd) with the appropriate `base_url` and `api_key`. This is the right choice for backends like vLLM, LiteLLM, and any other OpenAI-compatible inference engine. Note that `ChatOpenAI()` uses OpenAI's proprietary [Responses API](https://platform.openai.com/docs/api-reference/responses), which is not supported by most third-party backends.
 2. If you're motivated, implement a new provider by subclassing [`Provider`](https://github.com/posit-dev/chatlas/blob/main/chatlas/_provider.py) and implementing the required methods.
 :::
 

--- a/tests/test_provider_openai.py
+++ b/tests/test_provider_openai.py
@@ -249,8 +249,13 @@ def test_openai_web_search_call_action_types():
 
 
 def test_openai_custom_base_url_error():
+    from chatlas._provider_openai import check_base_url
+
     with pytest.raises(ValueError, match="ChatOpenAICompletions"):
         ChatOpenAI(base_url="http://localhost:8000/v1")
 
     with pytest.raises(ValueError, match="ChatOpenAICompletions"):
         ChatOpenAI(base_url="https://my-proxy.example.com/v1")
+
+    # Default URL should pass validation
+    check_base_url("https://api.openai.com/v1")

--- a/tests/test_provider_openai.py
+++ b/tests/test_provider_openai.py
@@ -246,3 +246,11 @@ def test_openai_web_search_call_action_types():
     turn = provider._response_as_turn(resp, has_data_model=False)
     assert isinstance(turn.contents[0], ContentToolRequestSearch)
     assert turn.contents[0].query == "web search"
+
+
+def test_openai_custom_base_url_error():
+    with pytest.raises(ValueError, match="ChatOpenAICompletions"):
+        ChatOpenAI(base_url="http://localhost:8000/v1")
+
+    with pytest.raises(ValueError, match="ChatOpenAICompletions"):
+        ChatOpenAI(base_url="https://my-proxy.example.com/v1")

--- a/tests/test_provider_openai.py
+++ b/tests/test_provider_openai.py
@@ -1,3 +1,5 @@
+import warnings
+
 import httpx
 import pytest
 from chatlas import ChatOpenAI, tool_web_search
@@ -248,14 +250,16 @@ def test_openai_web_search_call_action_types():
     assert turn.contents[0].query == "web search"
 
 
-def test_openai_custom_base_url_error():
+def test_openai_custom_base_url_warning():
     from chatlas._provider_openai import check_base_url
 
-    with pytest.raises(ValueError, match="ChatOpenAICompletions"):
-        ChatOpenAI(base_url="http://localhost:8000/v1")
+    with pytest.warns(UserWarning, match="ChatOpenAICompletions"):
+        check_base_url("http://localhost:8000/v1")
 
-    with pytest.raises(ValueError, match="ChatOpenAICompletions"):
-        ChatOpenAI(base_url="https://my-proxy.example.com/v1")
+    with pytest.warns(UserWarning, match="ChatOpenAICompletions"):
+        check_base_url("https://my-proxy.example.com/v1")
 
-    # Default URL should pass validation
-    check_base_url("https://api.openai.com/v1")
+    # Default URL should not warn
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        check_base_url("https://api.openai.com/v1")


### PR DESCRIPTION
Closes #285

## Summary

Users connecting `ChatOpenAI()` to third-party backends like vLLM, Ollama, or LiteLLM previously got a confusing 404 error because `ChatOpenAI()` uses OpenAI's proprietary Responses API. Now they get a clear warning pointing them to `ChatOpenAICompletions()`, which uses the standard Chat Completions API that these backends support. The warning (rather than an error) allows users with proxies that forward to OpenAI's Responses API to continue working.

The docs and provider docstrings were also corrected — they previously pointed users toward `ChatOpenAI()` for OpenAI-compatible backends, which was exactly the wrong advice.

## Test plan

- [ ] `uv run pytest tests/test_provider_openai.py -v` — new `test_openai_custom_base_url_warning` test verifies the warning for non-OpenAI URLs
- [ ] `uv run pyright` — type checking passes
- [ ] Verify existing tests still pass (no behavior change for default `base_url`)