### PR TITLE
fix: drop empty ContentText in OpenAI-compatible serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes 
 
+* `ChatDatabricks()` (and other `ChatOpenAICompletions()` providers) no longer fail with HTTP 400 when the conversation history contains empty assistant content, which can occur during tool calling. (#305)
 * Fixed `model_dump(mode="json")` failing on `Turn`s containing `bytes` fields (e.g., `ContentPDF.data`, `thought_signature` in `ContentToolRequest`/`ContentThinking` extras). Bytes values are now base64-encoded during serialization and decoded on validation, so JSON round-trips work correctly.
 * Fixed thinking content being silently dropped during streaming for completions-based providers (DeepSeek, Groq, OpenRouter, etc.). The streaming path was returning finalized `ContentThinking` objects instead of `ContentThinkingDelta` fragments, which the `TurnAccumulator` didn't recognize. (#301)
 

--- a/chatlas/_provider_openai_completions.py
+++ b/chatlas/_provider_openai_completions.py
@@ -393,7 +393,7 @@ class OpenAICompletionsProvider(
         if reasoning:
             contents.append(ContentThinking(thinking=reasoning))
 
-        if message.content is not None and message.content != "":
+        if message.content:
             if has_data_model:
                 data = message.content
                 # Some providers (e.g., Cloudflare) may already provide a dict

--- a/chatlas/_provider_openai_completions.py
+++ b/chatlas/_provider_openai_completions.py
@@ -277,7 +277,8 @@ class OpenAICompletionsProvider(
                         if self._preserve_thinking:
                             reasoning_content = (reasoning_content or "") + x.thinking
                     elif isinstance(x, ContentText):
-                        content_parts.append({"type": "text", "text": x.text})
+                        if x.text:
+                            content_parts.append({"type": "text", "text": x.text})
                     elif isinstance(x, ContentJson):
                         text = orjson.dumps(x.value).decode("utf-8")
                         content_parts.append({"type": "text", "text": text})
@@ -392,7 +393,7 @@ class OpenAICompletionsProvider(
         if reasoning:
             contents.append(ContentThinking(thinking=reasoning))
 
-        if message.content is not None:
+        if message.content is not None and message.content != "":
             if has_data_model:
                 data = message.content
                 # Some providers (e.g., Cloudflare) may already provide a dict

--- a/chatlas/data/prices.json
+++ b/chatlas/data/prices.json
@@ -1,5 +1,1506 @@
 [
   {
+    "provider": "AWS/Bedrock",
+    "model": "ai21.j2-mid-v1",
+    "variant": "",
+    "input": 12.5,
+    "output": 12.5
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "ai21.j2-ultra-v1",
+    "variant": "",
+    "input": 18.8,
+    "output": 18.8
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "ai21.jamba-1-5-large-v1:0",
+    "variant": "",
+    "input": 2,
+    "output": 8
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "ai21.jamba-1-5-mini-v1:0",
+    "variant": "",
+    "input": 0.2,
+    "output": 0.4
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "ai21.jamba-instruct-v1:0",
+    "variant": "",
+    "input": 0.5,
+    "output": 0.7
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "amazon.nova-2-multimodal-embeddings-v1:0",
+    "variant": "",
+    "input": 0.135,
+    "output": 0
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "amazon.titan-embed-image-v1",
+    "variant": "",
+    "input": 0.8,
+    "output": 0
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "amazon.titan-embed-text-v1",
+    "variant": "",
+    "input": 0.1,
+    "output": 0
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "amazon.titan-embed-text-v2:0",
+    "variant": "",
+    "input": 0.2,
+    "output": 0
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "amazon.titan-text-express-v1",
+    "variant": "",
+    "input": 1.3,
+    "output": 1.7
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "amazon.titan-text-lite-v1",
+    "variant": "",
+    "input": 0.3,
+    "output": 0.4
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "amazon.titan-text-premier-v1:0",
+    "variant": "",
+    "input": 0.5,
+    "output": 1.5
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "anthropic.claude-3-5-haiku-20241022-v1:0",
+    "variant": "",
+    "input": 0.8,
+    "output": 4,
+    "cached_input": 0.08
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+    "variant": "",
+    "input": 3,
+    "output": 15,
+    "cached_input": 0.3
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+    "variant": "above_200k_tokens",
+    "input": 6,
+    "output": 30,
+    "cached_input": 0.6
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+    "variant": "",
+    "input": 3,
+    "output": 15,
+    "cached_input": 0.3
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+    "variant": "above_200k_tokens",
+    "input": 6,
+    "output": 30,
+    "cached_input": 0.6
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "anthropic.claude-3-7-sonnet-20240620-v1:0",
+    "variant": "",
+    "input": 3.6,
+    "output": 18,
+    "cached_input": 0.36
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "anthropic.claude-3-haiku-20240307-v1:0",
+    "variant": "",
+    "input": 0.25,
+    "output": 1.25,
+    "cached_input": 0.025
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "anthropic.claude-3-opus-20240229-v1:0",
+    "variant": "",
+    "input": 15,
+    "output": 75,
+    "cached_input": 1.5
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "anthropic.claude-3-sonnet-20240229-v1:0",
+    "variant": "",
+    "input": 3,
+    "output": 15,
+    "cached_input": 0.3
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "anthropic.claude-instant-v1",
+    "variant": "",
+    "input": 0.8,
+    "output": 2.4
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "anthropic.claude-v1",
+    "variant": "",
+    "input": 8,
+    "output": 24
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "anthropic.claude-v2:1",
+    "variant": "",
+    "input": 8,
+    "output": 24
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "ap-northeast-1/anthropic.claude-instant-v1",
+    "variant": "",
+    "input": 2.23,
+    "output": 7.55
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "ap-northeast-1/anthropic.claude-v1",
+    "variant": "",
+    "input": 8,
+    "output": 24
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "ap-northeast-1/anthropic.claude-v2:1",
+    "variant": "",
+    "input": 8,
+    "output": 24
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "ap-northeast-1/deepseek.v3.2",
+    "variant": "",
+    "input": 0.74,
+    "output": 2.22
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "ap-northeast-1/minimax.minimax-m2.1",
+    "variant": "",
+    "input": 0.36,
+    "output": 1.44
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "ap-northeast-1/minimax.minimax-m2.5",
+    "variant": "",
+    "input": 0.36,
+    "output": 1.44
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "ap-northeast-1/moonshotai.kimi-k2-thinking",
+    "variant": "",
+    "input": 0.73,
+    "output": 3.03
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "ap-northeast-1/moonshotai.kimi-k2.5",
+    "variant": "",
+    "input": 0.72,
+    "output": 3.6
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "ap-northeast-1/qwen.qwen3-coder-next",
+    "variant": "",
+    "input": 0.6,
+    "output": 1.44
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "ap-south-1/deepseek.v3.2",
+    "variant": "",
+    "input": 0.74,
+    "output": 2.22
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "ap-south-1/meta.llama3-70b-instruct-v1:0",
+    "variant": "",
+    "input": 3.18,
+    "output": 4.2
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "ap-south-1/meta.llama3-8b-instruct-v1:0",
+    "variant": "",
+    "input": 0.36,
+    "output": 0.72
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "ap-south-1/minimax.minimax-m2.1",
+    "variant": "",
+    "input": 0.36,
+    "output": 1.44
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "ap-south-1/minimax.minimax-m2.5",
+    "variant": "",
+    "input": 0.36,
+    "output": 1.44
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "ap-south-1/moonshotai.kimi-k2-thinking",
+    "variant": "",
+    "input": 0.71,
+    "output": 2.94
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "ap-south-1/moonshotai.kimi-k2.5",
+    "variant": "",
+    "input": 0.72,
+    "output": 3.6
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "ap-south-1/qwen.qwen3-coder-next",
+    "variant": "",
+    "input": 0.6,
+    "output": 1.44
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "ap-southeast-2/minimax.minimax-m2.5",
+    "variant": "",
+    "input": 0.309,
+    "output": 1.236
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "ap-southeast-3/deepseek.v3.2",
+    "variant": "",
+    "input": 0.74,
+    "output": 2.22
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "ap-southeast-3/minimax.minimax-m2.1",
+    "variant": "",
+    "input": 0.36,
+    "output": 1.44
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "ap-southeast-3/minimax.minimax-m2.5",
+    "variant": "",
+    "input": 0.36,
+    "output": 1.44
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "ap-southeast-3/moonshotai.kimi-k2.5",
+    "variant": "",
+    "input": 0.72,
+    "output": 3.6
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "ap-southeast-3/qwen.qwen3-coder-next",
+    "variant": "",
+    "input": 0.6,
+    "output": 1.44
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "apac.anthropic.claude-3-5-sonnet-20240620-v1:0",
+    "variant": "",
+    "input": 3,
+    "output": 15,
+    "cached_input": 0.3
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "apac.anthropic.claude-3-5-sonnet-20241022-v2:0",
+    "variant": "",
+    "input": 3,
+    "output": 15,
+    "cached_input": 0.3
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "apac.anthropic.claude-3-haiku-20240307-v1:0",
+    "variant": "",
+    "input": 0.25,
+    "output": 1.25,
+    "cached_input": 0.025
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "apac.anthropic.claude-3-sonnet-20240229-v1:0",
+    "variant": "",
+    "input": 3,
+    "output": 15,
+    "cached_input": 0.3
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "ca-central-1/meta.llama3-70b-instruct-v1:0",
+    "variant": "",
+    "input": 3.05,
+    "output": 4.03
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "ca-central-1/meta.llama3-8b-instruct-v1:0",
+    "variant": "",
+    "input": 0.35,
+    "output": 0.69
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "claude-sonnet-4-5-20250929-v1:0",
+    "variant": "",
+    "input": 3,
+    "output": 15,
+    "cached_input": 0.3
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "claude-sonnet-4-5-20250929-v1:0",
+    "variant": "above_200k_tokens",
+    "input": 6,
+    "output": 22.5,
+    "cached_input": 0.6
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "cohere.command-light-text-v14",
+    "variant": "",
+    "input": 0.3,
+    "output": 0.6
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "cohere.command-r-plus-v1:0",
+    "variant": "",
+    "input": 3,
+    "output": 15
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "cohere.command-r-v1:0",
+    "variant": "",
+    "input": 0.5,
+    "output": 1.5
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "cohere.command-text-v14",
+    "variant": "",
+    "input": 1.5,
+    "output": 2
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "cohere.embed-english-v3",
+    "variant": "",
+    "input": 0.1,
+    "output": 0
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "cohere.embed-multilingual-v3",
+    "variant": "",
+    "input": 0.1,
+    "output": 0
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "cohere.embed-v4:0",
+    "variant": "",
+    "input": 0.12,
+    "output": 0
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "eu-central-1/anthropic.claude-instant-v1",
+    "variant": "",
+    "input": 2.48,
+    "output": 8.38
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "eu-central-1/anthropic.claude-v1",
+    "variant": "",
+    "input": 8,
+    "output": 24
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "eu-central-1/anthropic.claude-v2:1",
+    "variant": "",
+    "input": 8,
+    "output": 24
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "eu-central-1/minimax.minimax-m2.1",
+    "variant": "",
+    "input": 0.36,
+    "output": 1.44
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "eu-central-1/minimax.minimax-m2.5",
+    "variant": "",
+    "input": 0.36,
+    "output": 1.44
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "eu-central-1/qwen.qwen3-coder-next",
+    "variant": "",
+    "input": 0.6,
+    "output": 1.44
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "eu-north-1/deepseek.v3.2",
+    "variant": "",
+    "input": 0.74,
+    "output": 2.22
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "eu-north-1/minimax.minimax-m2.1",
+    "variant": "",
+    "input": 0.36,
+    "output": 1.44
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "eu-north-1/minimax.minimax-m2.5",
+    "variant": "",
+    "input": 0.36,
+    "output": 1.44
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "eu-north-1/moonshotai.kimi-k2.5",
+    "variant": "",
+    "input": 0.72,
+    "output": 3.6
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "eu-south-1/minimax.minimax-m2.1",
+    "variant": "",
+    "input": 0.36,
+    "output": 1.44
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "eu-south-1/minimax.minimax-m2.5",
+    "variant": "",
+    "input": 0.36,
+    "output": 1.44
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "eu-south-1/qwen.qwen3-coder-next",
+    "variant": "",
+    "input": 0.6,
+    "output": 1.44
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "eu-west-1/meta.llama3-70b-instruct-v1:0",
+    "variant": "",
+    "input": 2.86,
+    "output": 3.78
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "eu-west-1/meta.llama3-8b-instruct-v1:0",
+    "variant": "",
+    "input": 0.32,
+    "output": 0.65
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "eu-west-1/minimax.minimax-m2.1",
+    "variant": "",
+    "input": 0.36,
+    "output": 1.44
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "eu-west-1/minimax.minimax-m2.5",
+    "variant": "",
+    "input": 0.36,
+    "output": 1.44
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "eu-west-1/qwen.qwen3-coder-next",
+    "variant": "",
+    "input": 0.6,
+    "output": 1.44
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "eu-west-2/meta.llama3-70b-instruct-v1:0",
+    "variant": "",
+    "input": 3.45,
+    "output": 4.55
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "eu-west-2/meta.llama3-8b-instruct-v1:0",
+    "variant": "",
+    "input": 0.39,
+    "output": 0.78
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "eu-west-2/minimax.minimax-m2.1",
+    "variant": "",
+    "input": 0.47,
+    "output": 1.86
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "eu-west-2/minimax.minimax-m2.5",
+    "variant": "",
+    "input": 0.47,
+    "output": 1.86
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "eu-west-2/qwen.qwen3-coder-next",
+    "variant": "",
+    "input": 0.78,
+    "output": 1.86
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "eu-west-3/mistral.mistral-7b-instruct-v0:2",
+    "variant": "",
+    "input": 0.2,
+    "output": 0.26
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "eu-west-3/mistral.mistral-large-2402-v1:0",
+    "variant": "",
+    "input": 10.4,
+    "output": 31.2
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "eu-west-3/mistral.mixtral-8x7b-instruct-v0:1",
+    "variant": "",
+    "input": 0.59,
+    "output": 0.91
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "eu.anthropic.claude-3-5-haiku-20241022-v1:0",
+    "variant": "",
+    "input": 0.25,
+    "output": 1.25,
+    "cached_input": 0.025
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "eu.anthropic.claude-3-5-sonnet-20240620-v1:0",
+    "variant": "",
+    "input": 3,
+    "output": 15,
+    "cached_input": 0.3
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "eu.anthropic.claude-3-5-sonnet-20241022-v2:0",
+    "variant": "",
+    "input": 3,
+    "output": 15,
+    "cached_input": 0.3
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "eu.anthropic.claude-3-7-sonnet-20250219-v1:0",
+    "variant": "",
+    "input": 3,
+    "output": 15,
+    "cached_input": 0.3
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "eu.anthropic.claude-3-haiku-20240307-v1:0",
+    "variant": "",
+    "input": 0.25,
+    "output": 1.25,
+    "cached_input": 0.025
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "eu.anthropic.claude-3-opus-20240229-v1:0",
+    "variant": "",
+    "input": 15,
+    "output": 75,
+    "cached_input": 1.5
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "eu.anthropic.claude-3-sonnet-20240229-v1:0",
+    "variant": "",
+    "input": 3,
+    "output": 15,
+    "cached_input": 0.3
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "eu.meta.llama3-2-1b-instruct-v1:0",
+    "variant": "",
+    "input": 0.13,
+    "output": 0.13
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "eu.meta.llama3-2-3b-instruct-v1:0",
+    "variant": "",
+    "input": 0.19,
+    "output": 0.19
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "eu.twelvelabs.marengo-embed-2-7-v1:0",
+    "variant": "",
+    "input": 70,
+    "output": 0
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "eu.twelvelabs.pegasus-1-2-v1:0",
+    "variant": "",
+    "output": 7.5
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "invoke/anthropic.claude-3-5-sonnet-20240620-v1:0",
+    "variant": "",
+    "input": 3,
+    "output": 15,
+    "cached_input": 0.3
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "meta.llama2-13b-chat-v1",
+    "variant": "",
+    "input": 0.75,
+    "output": 1
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "meta.llama2-70b-chat-v1",
+    "variant": "",
+    "input": 1.95,
+    "output": 2.56
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "meta.llama3-1-405b-instruct-v1:0",
+    "variant": "",
+    "input": 5.32,
+    "output": 16
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "meta.llama3-1-70b-instruct-v1:0",
+    "variant": "",
+    "input": 0.99,
+    "output": 0.99
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "meta.llama3-1-8b-instruct-v1:0",
+    "variant": "",
+    "input": 0.22,
+    "output": 0.22
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "meta.llama3-2-11b-instruct-v1:0",
+    "variant": "",
+    "input": 0.35,
+    "output": 0.35
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "meta.llama3-2-1b-instruct-v1:0",
+    "variant": "",
+    "input": 0.1,
+    "output": 0.1
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "meta.llama3-2-3b-instruct-v1:0",
+    "variant": "",
+    "input": 0.15,
+    "output": 0.15
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "meta.llama3-2-90b-instruct-v1:0",
+    "variant": "",
+    "input": 2,
+    "output": 2
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "meta.llama3-70b-instruct-v1:0",
+    "variant": "",
+    "input": 2.65,
+    "output": 3.5
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "meta.llama3-8b-instruct-v1:0",
+    "variant": "",
+    "input": 0.3,
+    "output": 0.6
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "mistral.mistral-7b-instruct-v0:2",
+    "variant": "",
+    "input": 0.15,
+    "output": 0.2
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "mistral.mistral-large-2402-v1:0",
+    "variant": "",
+    "input": 8,
+    "output": 24
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "mistral.mistral-large-2407-v1:0",
+    "variant": "",
+    "input": 3,
+    "output": 9
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "mistral.mistral-small-2402-v1:0",
+    "variant": "",
+    "input": 1,
+    "output": 3
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "mistral.mixtral-8x7b-instruct-v0:1",
+    "variant": "",
+    "input": 0.45,
+    "output": 0.7
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "moonshotai.kimi-k2-thinking",
+    "variant": "",
+    "input": 0.73,
+    "output": 3.03
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "moonshotai.kimi-k2.5",
+    "variant": "",
+    "input": 0.6,
+    "output": 3.03
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "sa-east-1/deepseek.v3.2",
+    "variant": "",
+    "input": 0.74,
+    "output": 2.22
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "sa-east-1/meta.llama3-70b-instruct-v1:0",
+    "variant": "",
+    "input": 4.45,
+    "output": 5.88
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "sa-east-1/meta.llama3-8b-instruct-v1:0",
+    "variant": "",
+    "input": 0.5,
+    "output": 1.01
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "sa-east-1/minimax.minimax-m2.1",
+    "variant": "",
+    "input": 0.36,
+    "output": 1.44
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "sa-east-1/minimax.minimax-m2.5",
+    "variant": "",
+    "input": 0.36,
+    "output": 1.44
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "sa-east-1/moonshotai.kimi-k2-thinking",
+    "variant": "",
+    "input": 0.73,
+    "output": 3.03
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "sa-east-1/moonshotai.kimi-k2.5",
+    "variant": "",
+    "input": 0.72,
+    "output": 3.6
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "sa-east-1/qwen.qwen3-coder-next",
+    "variant": "",
+    "input": 0.6,
+    "output": 1.44
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "twelvelabs.marengo-embed-2-7-v1:0",
+    "variant": "",
+    "input": 70,
+    "output": 0
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "twelvelabs.pegasus-1-2-v1:0",
+    "variant": "",
+    "output": 7.5
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-east-1/anthropic.claude-instant-v1",
+    "variant": "",
+    "input": 0.8,
+    "output": 2.4
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-east-1/anthropic.claude-v1",
+    "variant": "",
+    "input": 8,
+    "output": 24
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-east-1/anthropic.claude-v2:1",
+    "variant": "",
+    "input": 8,
+    "output": 24
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-east-1/deepseek.v3.2",
+    "variant": "",
+    "input": 0.62,
+    "output": 1.85
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-east-1/meta.llama3-70b-instruct-v1:0",
+    "variant": "",
+    "input": 2.65,
+    "output": 3.5
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-east-1/meta.llama3-8b-instruct-v1:0",
+    "variant": "",
+    "input": 0.3,
+    "output": 0.6
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-east-1/minimax.minimax-m2.1",
+    "variant": "",
+    "input": 0.3,
+    "output": 1.2
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-east-1/minimax.minimax-m2.5",
+    "variant": "",
+    "input": 0.3,
+    "output": 1.2
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-east-1/minimax.minimax-m2.5",
+    "variant": "",
+    "input": 0.3,
+    "output": 1.2
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-east-1/mistral.mistral-7b-instruct-v0:2",
+    "variant": "",
+    "input": 0.15,
+    "output": 0.2
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-east-1/mistral.mistral-large-2402-v1:0",
+    "variant": "",
+    "input": 8,
+    "output": 24
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-east-1/mistral.mixtral-8x7b-instruct-v0:1",
+    "variant": "",
+    "input": 0.45,
+    "output": 0.7
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-east-1/moonshotai.kimi-k2-thinking",
+    "variant": "",
+    "input": 0.6,
+    "output": 2.5
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-east-1/moonshotai.kimi-k2.5",
+    "variant": "",
+    "input": 0.6,
+    "output": 3
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-east-1/qwen.qwen3-coder-next",
+    "variant": "",
+    "input": 0.5,
+    "output": 1.2
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-east-1/zai.glm-5",
+    "variant": "",
+    "input": 1,
+    "output": 3.2
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-east-2/deepseek.v3.2",
+    "variant": "",
+    "input": 0.62,
+    "output": 1.85
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-east-2/minimax.minimax-m2.1",
+    "variant": "",
+    "input": 0.3,
+    "output": 1.2
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-east-2/minimax.minimax-m2.5",
+    "variant": "",
+    "input": 0.3,
+    "output": 1.2
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-east-2/moonshotai.kimi-k2-thinking",
+    "variant": "",
+    "input": 0.6,
+    "output": 2.5
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-east-2/moonshotai.kimi-k2.5",
+    "variant": "",
+    "input": 0.6,
+    "output": 3
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-east-2/qwen.qwen3-coder-next",
+    "variant": "",
+    "input": 0.5,
+    "output": 1.2
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-gov-east-1/amazon.nova-pro-v1:0",
+    "variant": "",
+    "input": 0.96,
+    "output": 3.84
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-gov-east-1/amazon.titan-embed-text-v1",
+    "variant": "",
+    "input": 0.1,
+    "output": 0
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-gov-east-1/amazon.titan-embed-text-v2:0",
+    "variant": "",
+    "input": 0.2,
+    "output": 0
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-gov-east-1/amazon.titan-text-express-v1",
+    "variant": "",
+    "input": 1.3,
+    "output": 1.7
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-gov-east-1/amazon.titan-text-lite-v1",
+    "variant": "",
+    "input": 0.3,
+    "output": 0.4
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-gov-east-1/amazon.titan-text-premier-v1:0",
+    "variant": "",
+    "input": 0.5,
+    "output": 1.5
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-gov-east-1/anthropic.claude-3-5-sonnet-20240620-v1:0",
+    "variant": "",
+    "input": 3.6,
+    "output": 18,
+    "cached_input": 0.36
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-gov-east-1/anthropic.claude-3-haiku-20240307-v1:0",
+    "variant": "",
+    "input": 0.3,
+    "output": 1.5,
+    "cached_input": 0.03
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-gov-east-1/anthropic.claude-haiku-4-5-20251001-v1:0",
+    "variant": "",
+    "input": 1.2,
+    "output": 6,
+    "cached_input": 0.12
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-gov-east-1/anthropic.claude-sonnet-4-5-20250929-v1:0",
+    "variant": "",
+    "input": 3.3,
+    "output": 16.5,
+    "cached_input": 0.33
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-gov-east-1/claude-sonnet-4-5-20250929-v1:0",
+    "variant": "",
+    "input": 3.3,
+    "output": 16.5,
+    "cached_input": 0.33
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-gov-east-1/meta.llama3-70b-instruct-v1:0",
+    "variant": "",
+    "input": 2.65,
+    "output": 3.5
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-gov-east-1/meta.llama3-8b-instruct-v1:0",
+    "variant": "",
+    "input": 0.3,
+    "output": 2.65
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-gov-west-1/amazon.nova-pro-v1:0",
+    "variant": "",
+    "input": 0.96,
+    "output": 3.84
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-gov-west-1/amazon.titan-embed-text-v1",
+    "variant": "",
+    "input": 0.1,
+    "output": 0
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-gov-west-1/amazon.titan-embed-text-v2:0",
+    "variant": "",
+    "input": 0.2,
+    "output": 0
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-gov-west-1/amazon.titan-text-express-v1",
+    "variant": "",
+    "input": 1.3,
+    "output": 1.7
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-gov-west-1/amazon.titan-text-lite-v1",
+    "variant": "",
+    "input": 0.3,
+    "output": 0.4
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-gov-west-1/amazon.titan-text-premier-v1:0",
+    "variant": "",
+    "input": 0.5,
+    "output": 1.5
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-gov-west-1/anthropic.claude-3-5-sonnet-20240620-v1:0",
+    "variant": "",
+    "input": 3.6,
+    "output": 18,
+    "cached_input": 0.36
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-gov-west-1/anthropic.claude-3-7-sonnet-20250219-v1:0",
+    "variant": "",
+    "input": 3.6,
+    "output": 18,
+    "cached_input": 0.36
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-gov-west-1/anthropic.claude-3-haiku-20240307-v1:0",
+    "variant": "",
+    "input": 0.3,
+    "output": 1.5,
+    "cached_input": 0.03
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-gov-west-1/anthropic.claude-haiku-4-5-20251001-v1:0",
+    "variant": "",
+    "input": 1.2,
+    "output": 6,
+    "cached_input": 0.12
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-gov-west-1/anthropic.claude-sonnet-4-5-20250929-v1:0",
+    "variant": "",
+    "input": 3.3,
+    "output": 16.5,
+    "cached_input": 0.33
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-gov-west-1/claude-sonnet-4-5-20250929-v1:0",
+    "variant": "",
+    "input": 3.3,
+    "output": 16.5,
+    "cached_input": 0.33
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-gov-west-1/meta.llama3-70b-instruct-v1:0",
+    "variant": "",
+    "input": 2.65,
+    "output": 3.5
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-gov-west-1/meta.llama3-8b-instruct-v1:0",
+    "variant": "",
+    "input": 0.3,
+    "output": 2.65
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-west-1/meta.llama3-70b-instruct-v1:0",
+    "variant": "",
+    "input": 2.65,
+    "output": 3.5
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-west-1/meta.llama3-8b-instruct-v1:0",
+    "variant": "",
+    "input": 0.3,
+    "output": 0.6
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-west-2/anthropic.claude-instant-v1",
+    "variant": "",
+    "input": 0.8,
+    "output": 2.4
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-west-2/anthropic.claude-v1",
+    "variant": "",
+    "input": 8,
+    "output": 24
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-west-2/anthropic.claude-v2:1",
+    "variant": "",
+    "input": 8,
+    "output": 24
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-west-2/deepseek.v3.2",
+    "variant": "",
+    "input": 0.62,
+    "output": 1.85
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-west-2/minimax.minimax-m2.1",
+    "variant": "",
+    "input": 0.3,
+    "output": 1.2
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-west-2/minimax.minimax-m2.5",
+    "variant": "",
+    "input": 0.3,
+    "output": 1.2
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-west-2/minimax.minimax-m2.5",
+    "variant": "",
+    "input": 0.3,
+    "output": 1.2
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-west-2/mistral.mistral-7b-instruct-v0:2",
+    "variant": "",
+    "input": 0.15,
+    "output": 0.2
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-west-2/mistral.mistral-large-2402-v1:0",
+    "variant": "",
+    "input": 8,
+    "output": 24
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-west-2/mistral.mixtral-8x7b-instruct-v0:1",
+    "variant": "",
+    "input": 0.45,
+    "output": 0.7
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-west-2/moonshotai.kimi-k2-thinking",
+    "variant": "",
+    "input": 0.6,
+    "output": 2.5
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-west-2/moonshotai.kimi-k2.5",
+    "variant": "",
+    "input": 0.6,
+    "output": 3
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-west-2/qwen.qwen3-coder-next",
+    "variant": "",
+    "input": 0.5,
+    "output": 1.2
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us-west-2/zai.glm-5",
+    "variant": "",
+    "input": 1,
+    "output": 3.2
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us.anthropic.claude-3-5-haiku-20241022-v1:0",
+    "variant": "",
+    "input": 0.8,
+    "output": 4,
+    "cached_input": 0.08
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us.anthropic.claude-3-5-haiku-20241022-v1:0",
+    "variant": "",
+    "input": 0.8,
+    "output": 4,
+    "cached_input": 0.08
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us.anthropic.claude-3-5-sonnet-20240620-v1:0",
+    "variant": "",
+    "input": 3,
+    "output": 15,
+    "cached_input": 0.3
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+    "variant": "",
+    "input": 3,
+    "output": 15,
+    "cached_input": 0.3
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us.anthropic.claude-3-haiku-20240307-v1:0",
+    "variant": "",
+    "input": 0.25,
+    "output": 1.25,
+    "cached_input": 0.025
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us.anthropic.claude-3-opus-20240229-v1:0",
+    "variant": "",
+    "input": 15,
+    "output": 75,
+    "cached_input": 1.5
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us.anthropic.claude-3-sonnet-20240229-v1:0",
+    "variant": "",
+    "input": 3,
+    "output": 15,
+    "cached_input": 0.3
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us.meta.llama3-1-405b-instruct-v1:0",
+    "variant": "",
+    "input": 5.32,
+    "output": 16
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us.meta.llama3-1-70b-instruct-v1:0",
+    "variant": "",
+    "input": 0.99,
+    "output": 0.99
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us.meta.llama3-1-8b-instruct-v1:0",
+    "variant": "",
+    "input": 0.22,
+    "output": 0.22
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us.meta.llama3-2-11b-instruct-v1:0",
+    "variant": "",
+    "input": 0.35,
+    "output": 0.35
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us.meta.llama3-2-1b-instruct-v1:0",
+    "variant": "",
+    "input": 0.1,
+    "output": 0.1
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us.meta.llama3-2-3b-instruct-v1:0",
+    "variant": "",
+    "input": 0.15,
+    "output": 0.15
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us.meta.llama3-2-90b-instruct-v1:0",
+    "variant": "",
+    "input": 2,
+    "output": 2
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us.twelvelabs.marengo-embed-2-7-v1:0",
+    "variant": "",
+    "input": 70,
+    "output": 0
+  },
+  {
+    "provider": "AWS/Bedrock",
+    "model": "us.twelvelabs.pegasus-1-2-v1:0",
+    "variant": "",
+    "output": 7.5
+  },
+  {
     "provider": "Anthropic",
     "model": "claude-3-7-sonnet-20250219",
     "variant": "",
@@ -212,6 +1713,13 @@
     "variant": "",
     "input": 3,
     "output": 15
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "computer-use-preview",
+    "variant": "",
+    "input": 3,
+    "output": 12
   },
   {
     "provider": "Azure/OpenAI",
@@ -1746,1589 +3254,6 @@
     "cached_input": 0.31
   },
   {
-    "provider": "Azure/OpenAI",
-    "model": "computer-use-preview",
-    "variant": "",
-    "input": 3,
-    "output": 12
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "ai21.j2-mid-v1",
-    "variant": "",
-    "input": 12.5,
-    "output": 12.5
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "ai21.j2-ultra-v1",
-    "variant": "",
-    "input": 18.8,
-    "output": 18.8
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "ai21.jamba-1-5-large-v1:0",
-    "variant": "",
-    "input": 2,
-    "output": 8
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "ai21.jamba-1-5-mini-v1:0",
-    "variant": "",
-    "input": 0.2,
-    "output": 0.4
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "ai21.jamba-instruct-v1:0",
-    "variant": "",
-    "input": 0.5,
-    "output": 0.7
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "amazon.nova-2-multimodal-embeddings-v1:0",
-    "variant": "",
-    "input": 0.135,
-    "output": 0
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "amazon.titan-embed-image-v1",
-    "variant": "",
-    "input": 0.8,
-    "output": 0
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "amazon.titan-embed-text-v1",
-    "variant": "",
-    "input": 0.1,
-    "output": 0
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "amazon.titan-embed-text-v2:0",
-    "variant": "",
-    "input": 0.2,
-    "output": 0
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "amazon.titan-text-express-v1",
-    "variant": "",
-    "input": 1.3,
-    "output": 1.7
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "amazon.titan-text-lite-v1",
-    "variant": "",
-    "input": 0.3,
-    "output": 0.4
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "amazon.titan-text-premier-v1:0",
-    "variant": "",
-    "input": 0.5,
-    "output": 1.5
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "anthropic.claude-3-5-haiku-20241022-v1:0",
-    "variant": "",
-    "input": 0.8,
-    "output": 4,
-    "cached_input": 0.08
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
-    "variant": "",
-    "input": 3,
-    "output": 15,
-    "cached_input": 0.3
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "anthropic.claude-3-5-sonnet-20240620-v1:0",
-    "variant": "above_200k_tokens",
-    "input": 6,
-    "output": 30,
-    "cached_input": 0.6
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "anthropic.claude-3-5-sonnet-20241022-v2:0",
-    "variant": "",
-    "input": 3,
-    "output": 15,
-    "cached_input": 0.3
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "anthropic.claude-3-5-sonnet-20241022-v2:0",
-    "variant": "above_200k_tokens",
-    "input": 6,
-    "output": 30,
-    "cached_input": 0.6
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "anthropic.claude-3-7-sonnet-20240620-v1:0",
-    "variant": "",
-    "input": 3.6,
-    "output": 18,
-    "cached_input": 0.36
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "anthropic.claude-3-haiku-20240307-v1:0",
-    "variant": "",
-    "input": 0.25,
-    "output": 1.25,
-    "cached_input": 0.025
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "anthropic.claude-3-opus-20240229-v1:0",
-    "variant": "",
-    "input": 15,
-    "output": 75,
-    "cached_input": 1.5
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "anthropic.claude-3-sonnet-20240229-v1:0",
-    "variant": "",
-    "input": 3,
-    "output": 15,
-    "cached_input": 0.3
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "anthropic.claude-instant-v1",
-    "variant": "",
-    "input": 0.8,
-    "output": 2.4
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "anthropic.claude-v1",
-    "variant": "",
-    "input": 8,
-    "output": 24
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "anthropic.claude-v2:1",
-    "variant": "",
-    "input": 8,
-    "output": 24
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "apac.anthropic.claude-3-5-sonnet-20240620-v1:0",
-    "variant": "",
-    "input": 3,
-    "output": 15,
-    "cached_input": 0.3
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "apac.anthropic.claude-3-5-sonnet-20241022-v2:0",
-    "variant": "",
-    "input": 3,
-    "output": 15,
-    "cached_input": 0.3
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "apac.anthropic.claude-3-haiku-20240307-v1:0",
-    "variant": "",
-    "input": 0.25,
-    "output": 1.25,
-    "cached_input": 0.025
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "apac.anthropic.claude-3-sonnet-20240229-v1:0",
-    "variant": "",
-    "input": 3,
-    "output": 15,
-    "cached_input": 0.3
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "ap-northeast-1/anthropic.claude-instant-v1",
-    "variant": "",
-    "input": 2.23,
-    "output": 7.55
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "ap-northeast-1/anthropic.claude-v1",
-    "variant": "",
-    "input": 8,
-    "output": 24
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "ap-northeast-1/anthropic.claude-v2:1",
-    "variant": "",
-    "input": 8,
-    "output": 24
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "ap-northeast-1/deepseek.v3.2",
-    "variant": "",
-    "input": 0.74,
-    "output": 2.22
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "ap-northeast-1/minimax.minimax-m2.1",
-    "variant": "",
-    "input": 0.36,
-    "output": 1.44
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "ap-northeast-1/minimax.minimax-m2.5",
-    "variant": "",
-    "input": 0.36,
-    "output": 1.44
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "ap-northeast-1/moonshotai.kimi-k2-thinking",
-    "variant": "",
-    "input": 0.73,
-    "output": 3.03
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "ap-northeast-1/moonshotai.kimi-k2.5",
-    "variant": "",
-    "input": 0.72,
-    "output": 3.6
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "ap-northeast-1/qwen.qwen3-coder-next",
-    "variant": "",
-    "input": 0.6,
-    "output": 1.44
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "ap-south-1/deepseek.v3.2",
-    "variant": "",
-    "input": 0.74,
-    "output": 2.22
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "ap-south-1/meta.llama3-70b-instruct-v1:0",
-    "variant": "",
-    "input": 3.18,
-    "output": 4.2
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "ap-south-1/meta.llama3-8b-instruct-v1:0",
-    "variant": "",
-    "input": 0.36,
-    "output": 0.72
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "ap-south-1/minimax.minimax-m2.1",
-    "variant": "",
-    "input": 0.36,
-    "output": 1.44
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "ap-south-1/minimax.minimax-m2.5",
-    "variant": "",
-    "input": 0.36,
-    "output": 1.44
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "ap-south-1/moonshotai.kimi-k2-thinking",
-    "variant": "",
-    "input": 0.71,
-    "output": 2.94
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "ap-south-1/moonshotai.kimi-k2.5",
-    "variant": "",
-    "input": 0.72,
-    "output": 3.6
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "ap-south-1/qwen.qwen3-coder-next",
-    "variant": "",
-    "input": 0.6,
-    "output": 1.44
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "ap-southeast-2/minimax.minimax-m2.5",
-    "variant": "",
-    "input": 0.309,
-    "output": 1.236
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "ap-southeast-3/deepseek.v3.2",
-    "variant": "",
-    "input": 0.74,
-    "output": 2.22
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "ap-southeast-3/minimax.minimax-m2.1",
-    "variant": "",
-    "input": 0.36,
-    "output": 1.44
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "ap-southeast-3/minimax.minimax-m2.5",
-    "variant": "",
-    "input": 0.36,
-    "output": 1.44
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "ap-southeast-3/moonshotai.kimi-k2.5",
-    "variant": "",
-    "input": 0.72,
-    "output": 3.6
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "ap-southeast-3/qwen.qwen3-coder-next",
-    "variant": "",
-    "input": 0.6,
-    "output": 1.44
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "ca-central-1/meta.llama3-70b-instruct-v1:0",
-    "variant": "",
-    "input": 3.05,
-    "output": 4.03
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "ca-central-1/meta.llama3-8b-instruct-v1:0",
-    "variant": "",
-    "input": 0.35,
-    "output": 0.69
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "eu-central-1/anthropic.claude-instant-v1",
-    "variant": "",
-    "input": 2.48,
-    "output": 8.38
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "eu-central-1/anthropic.claude-v1",
-    "variant": "",
-    "input": 8,
-    "output": 24
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "eu-central-1/anthropic.claude-v2:1",
-    "variant": "",
-    "input": 8,
-    "output": 24
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "eu-central-1/minimax.minimax-m2.1",
-    "variant": "",
-    "input": 0.36,
-    "output": 1.44
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "eu-central-1/minimax.minimax-m2.5",
-    "variant": "",
-    "input": 0.36,
-    "output": 1.44
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "eu-central-1/qwen.qwen3-coder-next",
-    "variant": "",
-    "input": 0.6,
-    "output": 1.44
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "eu-north-1/deepseek.v3.2",
-    "variant": "",
-    "input": 0.74,
-    "output": 2.22
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "eu-north-1/minimax.minimax-m2.1",
-    "variant": "",
-    "input": 0.36,
-    "output": 1.44
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "eu-north-1/minimax.minimax-m2.5",
-    "variant": "",
-    "input": 0.36,
-    "output": 1.44
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "eu-north-1/moonshotai.kimi-k2.5",
-    "variant": "",
-    "input": 0.72,
-    "output": 3.6
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "eu-south-1/minimax.minimax-m2.1",
-    "variant": "",
-    "input": 0.36,
-    "output": 1.44
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "eu-south-1/minimax.minimax-m2.5",
-    "variant": "",
-    "input": 0.36,
-    "output": 1.44
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "eu-south-1/qwen.qwen3-coder-next",
-    "variant": "",
-    "input": 0.6,
-    "output": 1.44
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "eu-west-1/meta.llama3-70b-instruct-v1:0",
-    "variant": "",
-    "input": 2.86,
-    "output": 3.78
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "eu-west-1/meta.llama3-8b-instruct-v1:0",
-    "variant": "",
-    "input": 0.32,
-    "output": 0.65
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "eu-west-1/minimax.minimax-m2.1",
-    "variant": "",
-    "input": 0.36,
-    "output": 1.44
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "eu-west-1/minimax.minimax-m2.5",
-    "variant": "",
-    "input": 0.36,
-    "output": 1.44
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "eu-west-1/qwen.qwen3-coder-next",
-    "variant": "",
-    "input": 0.6,
-    "output": 1.44
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "eu-west-2/meta.llama3-70b-instruct-v1:0",
-    "variant": "",
-    "input": 3.45,
-    "output": 4.55
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "eu-west-2/meta.llama3-8b-instruct-v1:0",
-    "variant": "",
-    "input": 0.39,
-    "output": 0.78
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "eu-west-2/minimax.minimax-m2.1",
-    "variant": "",
-    "input": 0.47,
-    "output": 1.86
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "eu-west-2/minimax.minimax-m2.5",
-    "variant": "",
-    "input": 0.47,
-    "output": 1.86
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "eu-west-2/qwen.qwen3-coder-next",
-    "variant": "",
-    "input": 0.78,
-    "output": 1.86
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "eu-west-3/mistral.mistral-7b-instruct-v0:2",
-    "variant": "",
-    "input": 0.2,
-    "output": 0.26
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "eu-west-3/mistral.mistral-large-2402-v1:0",
-    "variant": "",
-    "input": 10.4,
-    "output": 31.2
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "eu-west-3/mistral.mixtral-8x7b-instruct-v0:1",
-    "variant": "",
-    "input": 0.59,
-    "output": 0.91
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "invoke/anthropic.claude-3-5-sonnet-20240620-v1:0",
-    "variant": "",
-    "input": 3,
-    "output": 15,
-    "cached_input": 0.3
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "moonshotai.kimi-k2-thinking",
-    "variant": "",
-    "input": 0.73,
-    "output": 3.03
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "moonshotai.kimi-k2.5",
-    "variant": "",
-    "input": 0.6,
-    "output": 3.03
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "sa-east-1/deepseek.v3.2",
-    "variant": "",
-    "input": 0.74,
-    "output": 2.22
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "sa-east-1/meta.llama3-70b-instruct-v1:0",
-    "variant": "",
-    "input": 4.45,
-    "output": 5.88
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "sa-east-1/meta.llama3-8b-instruct-v1:0",
-    "variant": "",
-    "input": 0.5,
-    "output": 1.01
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "sa-east-1/minimax.minimax-m2.1",
-    "variant": "",
-    "input": 0.36,
-    "output": 1.44
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "sa-east-1/minimax.minimax-m2.5",
-    "variant": "",
-    "input": 0.36,
-    "output": 1.44
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "sa-east-1/moonshotai.kimi-k2-thinking",
-    "variant": "",
-    "input": 0.73,
-    "output": 3.03
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "sa-east-1/moonshotai.kimi-k2.5",
-    "variant": "",
-    "input": 0.72,
-    "output": 3.6
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "sa-east-1/qwen.qwen3-coder-next",
-    "variant": "",
-    "input": 0.6,
-    "output": 1.44
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-east-1/anthropic.claude-instant-v1",
-    "variant": "",
-    "input": 0.8,
-    "output": 2.4
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-east-1/anthropic.claude-v1",
-    "variant": "",
-    "input": 8,
-    "output": 24
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-east-1/anthropic.claude-v2:1",
-    "variant": "",
-    "input": 8,
-    "output": 24
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-east-1/deepseek.v3.2",
-    "variant": "",
-    "input": 0.62,
-    "output": 1.85
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-east-1/meta.llama3-70b-instruct-v1:0",
-    "variant": "",
-    "input": 2.65,
-    "output": 3.5
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-east-1/meta.llama3-8b-instruct-v1:0",
-    "variant": "",
-    "input": 0.3,
-    "output": 0.6
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-east-1/minimax.minimax-m2.1",
-    "variant": "",
-    "input": 0.3,
-    "output": 1.2
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-east-1/minimax.minimax-m2.5",
-    "variant": "",
-    "input": 0.3,
-    "output": 1.2
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-east-1/minimax.minimax-m2.5",
-    "variant": "",
-    "input": 0.3,
-    "output": 1.2
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-east-1/mistral.mistral-7b-instruct-v0:2",
-    "variant": "",
-    "input": 0.15,
-    "output": 0.2
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-east-1/mistral.mistral-large-2402-v1:0",
-    "variant": "",
-    "input": 8,
-    "output": 24
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-east-1/mistral.mixtral-8x7b-instruct-v0:1",
-    "variant": "",
-    "input": 0.45,
-    "output": 0.7
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-east-1/moonshotai.kimi-k2-thinking",
-    "variant": "",
-    "input": 0.6,
-    "output": 2.5
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-east-1/moonshotai.kimi-k2.5",
-    "variant": "",
-    "input": 0.6,
-    "output": 3
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-east-1/qwen.qwen3-coder-next",
-    "variant": "",
-    "input": 0.5,
-    "output": 1.2
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-east-1/zai.glm-5",
-    "variant": "",
-    "input": 1,
-    "output": 3.2
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-east-2/deepseek.v3.2",
-    "variant": "",
-    "input": 0.62,
-    "output": 1.85
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-east-2/minimax.minimax-m2.1",
-    "variant": "",
-    "input": 0.3,
-    "output": 1.2
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-east-2/minimax.minimax-m2.5",
-    "variant": "",
-    "input": 0.3,
-    "output": 1.2
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-east-2/moonshotai.kimi-k2-thinking",
-    "variant": "",
-    "input": 0.6,
-    "output": 2.5
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-east-2/moonshotai.kimi-k2.5",
-    "variant": "",
-    "input": 0.6,
-    "output": 3
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-east-2/qwen.qwen3-coder-next",
-    "variant": "",
-    "input": 0.5,
-    "output": 1.2
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-gov-east-1/amazon.nova-pro-v1:0",
-    "variant": "",
-    "input": 0.96,
-    "output": 3.84
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-gov-east-1/amazon.titan-embed-text-v1",
-    "variant": "",
-    "input": 0.1,
-    "output": 0
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-gov-east-1/amazon.titan-embed-text-v2:0",
-    "variant": "",
-    "input": 0.2,
-    "output": 0
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-gov-east-1/amazon.titan-text-express-v1",
-    "variant": "",
-    "input": 1.3,
-    "output": 1.7
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-gov-east-1/amazon.titan-text-lite-v1",
-    "variant": "",
-    "input": 0.3,
-    "output": 0.4
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-gov-east-1/amazon.titan-text-premier-v1:0",
-    "variant": "",
-    "input": 0.5,
-    "output": 1.5
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-gov-east-1/anthropic.claude-3-5-sonnet-20240620-v1:0",
-    "variant": "",
-    "input": 3.6,
-    "output": 18,
-    "cached_input": 0.36
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-gov-east-1/anthropic.claude-3-haiku-20240307-v1:0",
-    "variant": "",
-    "input": 0.3,
-    "output": 1.5,
-    "cached_input": 0.03
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-gov-east-1/anthropic.claude-haiku-4-5-20251001-v1:0",
-    "variant": "",
-    "input": 1.2,
-    "output": 6,
-    "cached_input": 0.12
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-gov-east-1/anthropic.claude-sonnet-4-5-20250929-v1:0",
-    "variant": "",
-    "input": 3.3,
-    "output": 16.5,
-    "cached_input": 0.33
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-gov-east-1/claude-sonnet-4-5-20250929-v1:0",
-    "variant": "",
-    "input": 3.3,
-    "output": 16.5,
-    "cached_input": 0.33
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-gov-east-1/meta.llama3-70b-instruct-v1:0",
-    "variant": "",
-    "input": 2.65,
-    "output": 3.5
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-gov-east-1/meta.llama3-8b-instruct-v1:0",
-    "variant": "",
-    "input": 0.3,
-    "output": 2.65
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-gov-west-1/amazon.nova-pro-v1:0",
-    "variant": "",
-    "input": 0.96,
-    "output": 3.84
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-gov-west-1/amazon.titan-embed-text-v1",
-    "variant": "",
-    "input": 0.1,
-    "output": 0
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-gov-west-1/amazon.titan-embed-text-v2:0",
-    "variant": "",
-    "input": 0.2,
-    "output": 0
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-gov-west-1/amazon.titan-text-express-v1",
-    "variant": "",
-    "input": 1.3,
-    "output": 1.7
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-gov-west-1/amazon.titan-text-lite-v1",
-    "variant": "",
-    "input": 0.3,
-    "output": 0.4
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-gov-west-1/amazon.titan-text-premier-v1:0",
-    "variant": "",
-    "input": 0.5,
-    "output": 1.5
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-gov-west-1/anthropic.claude-3-5-sonnet-20240620-v1:0",
-    "variant": "",
-    "input": 3.6,
-    "output": 18,
-    "cached_input": 0.36
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-gov-west-1/anthropic.claude-3-7-sonnet-20250219-v1:0",
-    "variant": "",
-    "input": 3.6,
-    "output": 18,
-    "cached_input": 0.36
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-gov-west-1/anthropic.claude-3-haiku-20240307-v1:0",
-    "variant": "",
-    "input": 0.3,
-    "output": 1.5,
-    "cached_input": 0.03
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-gov-west-1/anthropic.claude-haiku-4-5-20251001-v1:0",
-    "variant": "",
-    "input": 1.2,
-    "output": 6,
-    "cached_input": 0.12
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-gov-west-1/anthropic.claude-sonnet-4-5-20250929-v1:0",
-    "variant": "",
-    "input": 3.3,
-    "output": 16.5,
-    "cached_input": 0.33
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-gov-west-1/claude-sonnet-4-5-20250929-v1:0",
-    "variant": "",
-    "input": 3.3,
-    "output": 16.5,
-    "cached_input": 0.33
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-gov-west-1/meta.llama3-70b-instruct-v1:0",
-    "variant": "",
-    "input": 2.65,
-    "output": 3.5
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-gov-west-1/meta.llama3-8b-instruct-v1:0",
-    "variant": "",
-    "input": 0.3,
-    "output": 2.65
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-west-1/meta.llama3-70b-instruct-v1:0",
-    "variant": "",
-    "input": 2.65,
-    "output": 3.5
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-west-1/meta.llama3-8b-instruct-v1:0",
-    "variant": "",
-    "input": 0.3,
-    "output": 0.6
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-west-2/anthropic.claude-instant-v1",
-    "variant": "",
-    "input": 0.8,
-    "output": 2.4
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-west-2/anthropic.claude-v1",
-    "variant": "",
-    "input": 8,
-    "output": 24
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-west-2/anthropic.claude-v2:1",
-    "variant": "",
-    "input": 8,
-    "output": 24
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-west-2/deepseek.v3.2",
-    "variant": "",
-    "input": 0.62,
-    "output": 1.85
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-west-2/minimax.minimax-m2.1",
-    "variant": "",
-    "input": 0.3,
-    "output": 1.2
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-west-2/minimax.minimax-m2.5",
-    "variant": "",
-    "input": 0.3,
-    "output": 1.2
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-west-2/minimax.minimax-m2.5",
-    "variant": "",
-    "input": 0.3,
-    "output": 1.2
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-west-2/mistral.mistral-7b-instruct-v0:2",
-    "variant": "",
-    "input": 0.15,
-    "output": 0.2
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-west-2/mistral.mistral-large-2402-v1:0",
-    "variant": "",
-    "input": 8,
-    "output": 24
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-west-2/mistral.mixtral-8x7b-instruct-v0:1",
-    "variant": "",
-    "input": 0.45,
-    "output": 0.7
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-west-2/moonshotai.kimi-k2-thinking",
-    "variant": "",
-    "input": 0.6,
-    "output": 2.5
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-west-2/moonshotai.kimi-k2.5",
-    "variant": "",
-    "input": 0.6,
-    "output": 3
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-west-2/qwen.qwen3-coder-next",
-    "variant": "",
-    "input": 0.5,
-    "output": 1.2
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-west-2/zai.glm-5",
-    "variant": "",
-    "input": 1,
-    "output": 3.2
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us.anthropic.claude-3-5-haiku-20241022-v1:0",
-    "variant": "",
-    "input": 0.8,
-    "output": 4,
-    "cached_input": 0.08
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "claude-sonnet-4-5-20250929-v1:0",
-    "variant": "",
-    "input": 3,
-    "output": 15,
-    "cached_input": 0.3
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "claude-sonnet-4-5-20250929-v1:0",
-    "variant": "above_200k_tokens",
-    "input": 6,
-    "output": 22.5,
-    "cached_input": 0.6
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "cohere.command-light-text-v14",
-    "variant": "",
-    "input": 0.3,
-    "output": 0.6
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "cohere.command-r-plus-v1:0",
-    "variant": "",
-    "input": 3,
-    "output": 15
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "cohere.command-r-v1:0",
-    "variant": "",
-    "input": 0.5,
-    "output": 1.5
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "cohere.command-text-v14",
-    "variant": "",
-    "input": 1.5,
-    "output": 2
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "cohere.embed-english-v3",
-    "variant": "",
-    "input": 0.1,
-    "output": 0
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "cohere.embed-multilingual-v3",
-    "variant": "",
-    "input": 0.1,
-    "output": 0
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "cohere.embed-v4:0",
-    "variant": "",
-    "input": 0.12,
-    "output": 0
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "eu.anthropic.claude-3-5-haiku-20241022-v1:0",
-    "variant": "",
-    "input": 0.25,
-    "output": 1.25,
-    "cached_input": 0.025
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "eu.anthropic.claude-3-5-sonnet-20240620-v1:0",
-    "variant": "",
-    "input": 3,
-    "output": 15,
-    "cached_input": 0.3
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "eu.anthropic.claude-3-5-sonnet-20241022-v2:0",
-    "variant": "",
-    "input": 3,
-    "output": 15,
-    "cached_input": 0.3
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "eu.anthropic.claude-3-7-sonnet-20250219-v1:0",
-    "variant": "",
-    "input": 3,
-    "output": 15,
-    "cached_input": 0.3
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "eu.anthropic.claude-3-haiku-20240307-v1:0",
-    "variant": "",
-    "input": 0.25,
-    "output": 1.25,
-    "cached_input": 0.025
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "eu.anthropic.claude-3-opus-20240229-v1:0",
-    "variant": "",
-    "input": 15,
-    "output": 75,
-    "cached_input": 1.5
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "eu.anthropic.claude-3-sonnet-20240229-v1:0",
-    "variant": "",
-    "input": 3,
-    "output": 15,
-    "cached_input": 0.3
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "eu.meta.llama3-2-1b-instruct-v1:0",
-    "variant": "",
-    "input": 0.13,
-    "output": 0.13
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "eu.meta.llama3-2-3b-instruct-v1:0",
-    "variant": "",
-    "input": 0.19,
-    "output": 0.19
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "eu.twelvelabs.marengo-embed-2-7-v1:0",
-    "variant": "",
-    "input": 70,
-    "output": 0
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "eu.twelvelabs.pegasus-1-2-v1:0",
-    "variant": "",
-    "output": 7.5
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "meta.llama2-13b-chat-v1",
-    "variant": "",
-    "input": 0.75,
-    "output": 1
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "meta.llama2-70b-chat-v1",
-    "variant": "",
-    "input": 1.95,
-    "output": 2.56
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "meta.llama3-1-405b-instruct-v1:0",
-    "variant": "",
-    "input": 5.32,
-    "output": 16
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "meta.llama3-1-70b-instruct-v1:0",
-    "variant": "",
-    "input": 0.99,
-    "output": 0.99
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "meta.llama3-1-8b-instruct-v1:0",
-    "variant": "",
-    "input": 0.22,
-    "output": 0.22
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "meta.llama3-2-11b-instruct-v1:0",
-    "variant": "",
-    "input": 0.35,
-    "output": 0.35
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "meta.llama3-2-1b-instruct-v1:0",
-    "variant": "",
-    "input": 0.1,
-    "output": 0.1
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "meta.llama3-2-3b-instruct-v1:0",
-    "variant": "",
-    "input": 0.15,
-    "output": 0.15
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "meta.llama3-2-90b-instruct-v1:0",
-    "variant": "",
-    "input": 2,
-    "output": 2
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "meta.llama3-70b-instruct-v1:0",
-    "variant": "",
-    "input": 2.65,
-    "output": 3.5
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "meta.llama3-8b-instruct-v1:0",
-    "variant": "",
-    "input": 0.3,
-    "output": 0.6
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "mistral.mistral-7b-instruct-v0:2",
-    "variant": "",
-    "input": 0.15,
-    "output": 0.2
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "mistral.mistral-large-2402-v1:0",
-    "variant": "",
-    "input": 8,
-    "output": 24
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "mistral.mistral-large-2407-v1:0",
-    "variant": "",
-    "input": 3,
-    "output": 9
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "mistral.mistral-small-2402-v1:0",
-    "variant": "",
-    "input": 1,
-    "output": 3
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "mistral.mixtral-8x7b-instruct-v0:1",
-    "variant": "",
-    "input": 0.45,
-    "output": 0.7
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "twelvelabs.marengo-embed-2-7-v1:0",
-    "variant": "",
-    "input": 70,
-    "output": 0
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "twelvelabs.pegasus-1-2-v1:0",
-    "variant": "",
-    "output": 7.5
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us.anthropic.claude-3-5-haiku-20241022-v1:0",
-    "variant": "",
-    "input": 0.8,
-    "output": 4,
-    "cached_input": 0.08
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us.anthropic.claude-3-5-sonnet-20240620-v1:0",
-    "variant": "",
-    "input": 3,
-    "output": 15,
-    "cached_input": 0.3
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
-    "variant": "",
-    "input": 3,
-    "output": 15,
-    "cached_input": 0.3
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us.anthropic.claude-3-haiku-20240307-v1:0",
-    "variant": "",
-    "input": 0.25,
-    "output": 1.25,
-    "cached_input": 0.025
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us.anthropic.claude-3-opus-20240229-v1:0",
-    "variant": "",
-    "input": 15,
-    "output": 75,
-    "cached_input": 1.5
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us.anthropic.claude-3-sonnet-20240229-v1:0",
-    "variant": "",
-    "input": 3,
-    "output": 15,
-    "cached_input": 0.3
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us.meta.llama3-1-405b-instruct-v1:0",
-    "variant": "",
-    "input": 5.32,
-    "output": 16
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us.meta.llama3-1-70b-instruct-v1:0",
-    "variant": "",
-    "input": 0.99,
-    "output": 0.99
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us.meta.llama3-1-8b-instruct-v1:0",
-    "variant": "",
-    "input": 0.22,
-    "output": 0.22
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us.meta.llama3-2-11b-instruct-v1:0",
-    "variant": "",
-    "input": 0.35,
-    "output": 0.35
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us.meta.llama3-2-1b-instruct-v1:0",
-    "variant": "",
-    "input": 0.1,
-    "output": 0.1
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us.meta.llama3-2-3b-instruct-v1:0",
-    "variant": "",
-    "input": 0.15,
-    "output": 0.15
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us.meta.llama3-2-90b-instruct-v1:0",
-    "variant": "",
-    "input": 2,
-    "output": 2
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us.twelvelabs.marengo-embed-2-7-v1:0",
-    "variant": "",
-    "input": 70,
-    "output": 0
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us.twelvelabs.pegasus-1-2-v1:0",
-    "variant": "",
-    "output": 7.5
-  },
-  {
-    "provider": "Google/Gemini",
-    "model": "gemini-2.5-flash-native-audio-latest",
-    "variant": "",
-    "input": 0.3,
-    "output": 2.5
-  },
-  {
-    "provider": "Google/Gemini",
-    "model": "gemini-2.5-flash-native-audio-preview-09-2025",
-    "variant": "",
-    "input": 0.3,
-    "output": 2.5
-  },
-  {
-    "provider": "Google/Gemini",
-    "model": "gemini-2.5-flash-native-audio-preview-12-2025",
-    "variant": "",
-    "input": 0.3,
-    "output": 2.5
-  },
-  {
-    "provider": "Google/Gemini",
-    "model": "gemini-2.5-flash-preview-tts",
-    "variant": "",
-    "input": 0.3,
-    "output": 2.5
-  },
-  {
-    "provider": "Google/Gemini",
-    "model": "gemini-3.1-flash-live-preview",
-    "variant": "",
-    "input": 0.75,
-    "output": 4.5
-  },
-  {
-    "provider": "Google/Gemini",
-    "model": "gemini-exp-1206",
-    "variant": "",
-    "input": 0.3,
-    "output": 2.5,
-    "cached_input": 0.03
-  },
-  {
-    "provider": "Google/Gemini",
-    "model": "gemini-flash-latest",
-    "variant": "",
-    "input": 0.3,
-    "output": 2.5,
-    "cached_input": 0.03
-  },
-  {
-    "provider": "Google/Gemini",
-    "model": "gemini-flash-lite-latest",
-    "variant": "",
-    "input": 0.1,
-    "output": 0.4,
-    "cached_input": 0.01
-  },
-  {
-    "provider": "Google/Gemini",
-    "model": "gemini-pro-latest",
-    "variant": "",
-    "input": 1.25,
-    "output": 10,
-    "cached_input": 0.125
-  },
-  {
-    "provider": "Google/Gemini",
-    "model": "gemini-pro-latest",
-    "variant": "above_200k_tokens",
-    "input": 2.5,
-    "output": 15,
-    "cached_input": 0.25
-  },
-  {
     "provider": "Google/Gemini",
     "model": "deep-research-pro-preview-12-2025",
     "variant": "",
@@ -3450,7 +3375,28 @@
   },
   {
     "provider": "Google/Gemini",
+    "model": "gemini-2.5-flash-native-audio-latest",
+    "variant": "",
+    "input": 0.3,
+    "output": 2.5
+  },
+  {
+    "provider": "Google/Gemini",
     "model": "gemini-2.5-flash-native-audio-preview-09-2025",
+    "variant": "",
+    "input": 0.3,
+    "output": 2.5
+  },
+  {
+    "provider": "Google/Gemini",
+    "model": "gemini-2.5-flash-native-audio-preview-09-2025",
+    "variant": "",
+    "input": 0.3,
+    "output": 2.5
+  },
+  {
+    "provider": "Google/Gemini",
+    "model": "gemini-2.5-flash-native-audio-preview-12-2025",
     "variant": "",
     "input": 0.3,
     "output": 2.5
@@ -3469,6 +3415,13 @@
     "input": 0.3,
     "output": 2.5,
     "cached_input": 0.075
+  },
+  {
+    "provider": "Google/Gemini",
+    "model": "gemini-2.5-flash-preview-tts",
+    "variant": "",
+    "input": 0.3,
+    "output": 2.5
   },
   {
     "provider": "Google/Gemini",
@@ -3623,6 +3576,13 @@
   },
   {
     "provider": "Google/Gemini",
+    "model": "gemini-3.1-flash-live-preview",
+    "variant": "",
+    "input": 0.75,
+    "output": 4.5
+  },
+  {
+    "provider": "Google/Gemini",
     "model": "gemini-3.1-pro-preview",
     "variant": "",
     "input": 2,
@@ -3722,11 +3682,35 @@
   },
   {
     "provider": "Google/Gemini",
+    "model": "gemini-exp-1206",
+    "variant": "",
+    "input": 0.3,
+    "output": 2.5,
+    "cached_input": 0.03
+  },
+  {
+    "provider": "Google/Gemini",
+    "model": "gemini-flash-latest",
+    "variant": "",
+    "input": 0.3,
+    "output": 2.5,
+    "cached_input": 0.03
+  },
+  {
+    "provider": "Google/Gemini",
     "model": "gemini-flash-latest",
     "variant": "",
     "input": 0.3,
     "output": 2.5,
     "cached_input": 0.075
+  },
+  {
+    "provider": "Google/Gemini",
+    "model": "gemini-flash-lite-latest",
+    "variant": "",
+    "input": 0.1,
+    "output": 0.4,
+    "cached_input": 0.01
   },
   {
     "provider": "Google/Gemini",
@@ -3769,6 +3753,22 @@
   {
     "provider": "Google/Gemini",
     "model": "gemini-pro-latest",
+    "variant": "",
+    "input": 1.25,
+    "output": 10,
+    "cached_input": 0.125
+  },
+  {
+    "provider": "Google/Gemini",
+    "model": "gemini-pro-latest",
+    "variant": "above_200k_tokens",
+    "input": 2.5,
+    "output": 15,
+    "cached_input": 0.25
+  },
+  {
+    "provider": "Google/Gemini",
+    "model": "gemini-pro-latest",
     "variant": "above_200k_tokens",
     "input": 2.5,
     "output": 15,
@@ -3781,6 +3781,359 @@
     "input": 0.3,
     "output": 2.5,
     "cached_input": 0
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "deep-research-pro-preview-12-2025",
+    "variant": "",
+    "input": 2,
+    "output": 12
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "deep-research-pro-preview-12-2025",
+    "variant": "batches",
+    "input": 1,
+    "output": 6
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-2.0-flash",
+    "variant": "",
+    "input": 0.1,
+    "output": 0.4,
+    "cached_input": 0.025
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-2.0-flash-001",
+    "variant": "",
+    "input": 0.15,
+    "output": 0.6,
+    "cached_input": 0.0375
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-2.0-flash-lite",
+    "variant": "",
+    "input": 0.075,
+    "output": 0.3,
+    "cached_input": 0.0188
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-2.0-flash-lite-001",
+    "variant": "",
+    "input": 0.075,
+    "output": 0.3,
+    "cached_input": 0.0188
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-2.5-computer-use-preview-10-2025",
+    "variant": "",
+    "input": 1.25,
+    "output": 10
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-2.5-computer-use-preview-10-2025",
+    "variant": "above_200k_tokens",
+    "input": 2.5,
+    "output": 15
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-2.5-flash",
+    "variant": "",
+    "input": 0.3,
+    "output": 2.5,
+    "cached_input": 0.03
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-2.5-flash-image",
+    "variant": "",
+    "input": 0.3,
+    "output": 2.5,
+    "cached_input": 0.03
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-2.5-flash-lite",
+    "variant": "",
+    "input": 0.1,
+    "output": 0.4,
+    "cached_input": 0.01
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-2.5-flash-lite-preview-06-17",
+    "variant": "",
+    "input": 0.1,
+    "output": 0.4,
+    "cached_input": 0.025
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-2.5-flash-lite-preview-09-2025",
+    "variant": "",
+    "input": 0.1,
+    "output": 0.4,
+    "cached_input": 0.01
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-2.5-flash-preview-09-2025",
+    "variant": "",
+    "input": 0.3,
+    "output": 2.5,
+    "cached_input": 0.075
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-2.5-pro",
+    "variant": "",
+    "input": 1.25,
+    "output": 10,
+    "cached_input": 0.125
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-2.5-pro",
+    "variant": "above_200k_tokens",
+    "input": 2.5,
+    "output": 15,
+    "cached_input": 0.25
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-2.5-pro-preview-tts",
+    "variant": "",
+    "input": 1.25,
+    "output": 10,
+    "cached_input": 0.125
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-2.5-pro-preview-tts",
+    "variant": "above_200k_tokens",
+    "input": 2.5,
+    "output": 15,
+    "cached_input": 0.25
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-3-flash-preview",
+    "variant": "",
+    "input": 0.5,
+    "output": 3,
+    "cached_input": 0.05
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-3-flash-preview",
+    "variant": "priority",
+    "input": 0.9,
+    "output": 5.4,
+    "cached_input": 0.09
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-3-pro-image-preview",
+    "variant": "",
+    "input": 2,
+    "output": 12
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-3-pro-image-preview",
+    "variant": "batches",
+    "input": 1,
+    "output": 6
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-3-pro-preview",
+    "variant": "",
+    "input": 2,
+    "output": 12,
+    "cached_input": 0.2
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-3-pro-preview",
+    "variant": "above_200k_tokens",
+    "input": 4,
+    "output": 18,
+    "cached_input": 0.4
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-3-pro-preview",
+    "variant": "above_200k_tokens_priority",
+    "input": 7.2,
+    "output": 32.4,
+    "cached_input": 0.72
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-3-pro-preview",
+    "variant": "batches",
+    "input": 1,
+    "output": 6
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-3-pro-preview",
+    "variant": "priority",
+    "input": 3.6,
+    "output": 21.6,
+    "cached_input": 0.36
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-3.1-flash-image-preview",
+    "variant": "",
+    "input": 0.5,
+    "output": 3
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-3.1-flash-lite-preview",
+    "variant": "",
+    "input": 0.25,
+    "output": 1.5,
+    "cached_input": 0.025
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-3.1-pro-preview",
+    "variant": "",
+    "input": 2,
+    "output": 12,
+    "cached_input": 0.2
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-3.1-pro-preview",
+    "variant": "above_200k_tokens",
+    "input": 4,
+    "output": 18,
+    "cached_input": 0.4
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-3.1-pro-preview",
+    "variant": "above_200k_tokens_priority",
+    "input": 7.2,
+    "output": 32.4,
+    "cached_input": 0.72
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-3.1-pro-preview",
+    "variant": "batches",
+    "input": 1,
+    "output": 6
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-3.1-pro-preview",
+    "variant": "priority",
+    "input": 3.6,
+    "output": 21.6,
+    "cached_input": 0.36
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-3.1-pro-preview-customtools",
+    "variant": "",
+    "input": 2,
+    "output": 12,
+    "cached_input": 0.2
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-3.1-pro-preview-customtools",
+    "variant": "above_200k_tokens",
+    "input": 4,
+    "output": 18,
+    "cached_input": 0.4
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-3.1-pro-preview-customtools",
+    "variant": "batches",
+    "input": 1,
+    "output": 6
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-live-2.5-flash-preview-native-audio-09-2025",
+    "variant": "",
+    "input": 0.3,
+    "output": 2,
+    "cached_input": 0.075
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-robotics-er-1.5-preview",
+    "variant": "",
+    "input": 0.3,
+    "output": 2.5,
+    "cached_input": 0
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "vertex_ai/deep-research-pro-preview-12-2025",
+    "variant": "",
+    "input": 2,
+    "output": 12
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "vertex_ai/deep-research-pro-preview-12-2025",
+    "variant": "batches",
+    "input": 1,
+    "output": 6
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "vertex_ai/gemini-2.5-flash-image",
+    "variant": "",
+    "input": 0.3,
+    "output": 2.5,
+    "cached_input": 0.03
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "vertex_ai/gemini-3-pro-image-preview",
+    "variant": "",
+    "input": 2,
+    "output": 12
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "vertex_ai/gemini-3-pro-image-preview",
+    "variant": "batches",
+    "input": 1,
+    "output": 6
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "vertex_ai/gemini-3.1-flash-image-preview",
+    "variant": "",
+    "input": 0.5,
+    "output": 3
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "vertex_ai/gemini-3.1-flash-lite-preview",
+    "variant": "",
+    "input": 0.25,
+    "output": 1.5,
+    "cached_input": 0.025
   },
   {
     "provider": "Mistral",
@@ -6636,6 +6989,13 @@
   },
   {
     "provider": "OpenRouter",
+    "model": "qwen/qwen3.6-plus",
+    "variant": "",
+    "input": 0.325,
+    "output": 1.95
+  },
+  {
+    "provider": "OpenRouter",
     "model": "switchpoint/router",
     "variant": "",
     "input": 0.85,
@@ -6699,358 +7059,5 @@
     "variant": "",
     "input": 0.8,
     "output": 2.56
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "deep-research-pro-preview-12-2025",
-    "variant": "",
-    "input": 2,
-    "output": 12
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "deep-research-pro-preview-12-2025",
-    "variant": "batches",
-    "input": 1,
-    "output": 6
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "gemini-2.0-flash",
-    "variant": "",
-    "input": 0.1,
-    "output": 0.4,
-    "cached_input": 0.025
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "gemini-2.0-flash-001",
-    "variant": "",
-    "input": 0.15,
-    "output": 0.6,
-    "cached_input": 0.0375
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "gemini-2.0-flash-lite",
-    "variant": "",
-    "input": 0.075,
-    "output": 0.3,
-    "cached_input": 0.0188
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "gemini-2.0-flash-lite-001",
-    "variant": "",
-    "input": 0.075,
-    "output": 0.3,
-    "cached_input": 0.0188
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "gemini-2.5-computer-use-preview-10-2025",
-    "variant": "",
-    "input": 1.25,
-    "output": 10
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "gemini-2.5-computer-use-preview-10-2025",
-    "variant": "above_200k_tokens",
-    "input": 2.5,
-    "output": 15
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "gemini-2.5-flash",
-    "variant": "",
-    "input": 0.3,
-    "output": 2.5,
-    "cached_input": 0.03
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "gemini-2.5-flash-image",
-    "variant": "",
-    "input": 0.3,
-    "output": 2.5,
-    "cached_input": 0.03
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "gemini-2.5-flash-lite",
-    "variant": "",
-    "input": 0.1,
-    "output": 0.4,
-    "cached_input": 0.01
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "gemini-2.5-flash-lite-preview-06-17",
-    "variant": "",
-    "input": 0.1,
-    "output": 0.4,
-    "cached_input": 0.025
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "gemini-2.5-flash-lite-preview-09-2025",
-    "variant": "",
-    "input": 0.1,
-    "output": 0.4,
-    "cached_input": 0.01
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "gemini-2.5-flash-preview-09-2025",
-    "variant": "",
-    "input": 0.3,
-    "output": 2.5,
-    "cached_input": 0.075
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "gemini-2.5-pro",
-    "variant": "",
-    "input": 1.25,
-    "output": 10,
-    "cached_input": 0.125
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "gemini-2.5-pro",
-    "variant": "above_200k_tokens",
-    "input": 2.5,
-    "output": 15,
-    "cached_input": 0.25
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "gemini-2.5-pro-preview-tts",
-    "variant": "",
-    "input": 1.25,
-    "output": 10,
-    "cached_input": 0.125
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "gemini-2.5-pro-preview-tts",
-    "variant": "above_200k_tokens",
-    "input": 2.5,
-    "output": 15,
-    "cached_input": 0.25
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "gemini-3-flash-preview",
-    "variant": "",
-    "input": 0.5,
-    "output": 3,
-    "cached_input": 0.05
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "gemini-3-flash-preview",
-    "variant": "priority",
-    "input": 0.9,
-    "output": 5.4,
-    "cached_input": 0.09
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "gemini-3-pro-image-preview",
-    "variant": "",
-    "input": 2,
-    "output": 12
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "gemini-3-pro-image-preview",
-    "variant": "batches",
-    "input": 1,
-    "output": 6
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "gemini-3-pro-preview",
-    "variant": "",
-    "input": 2,
-    "output": 12,
-    "cached_input": 0.2
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "gemini-3-pro-preview",
-    "variant": "above_200k_tokens",
-    "input": 4,
-    "output": 18,
-    "cached_input": 0.4
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "gemini-3-pro-preview",
-    "variant": "above_200k_tokens_priority",
-    "input": 7.2,
-    "output": 32.4,
-    "cached_input": 0.72
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "gemini-3-pro-preview",
-    "variant": "batches",
-    "input": 1,
-    "output": 6
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "gemini-3-pro-preview",
-    "variant": "priority",
-    "input": 3.6,
-    "output": 21.6,
-    "cached_input": 0.36
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "gemini-3.1-flash-image-preview",
-    "variant": "",
-    "input": 0.5,
-    "output": 3
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "gemini-3.1-flash-lite-preview",
-    "variant": "",
-    "input": 0.25,
-    "output": 1.5,
-    "cached_input": 0.025
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "gemini-3.1-pro-preview",
-    "variant": "",
-    "input": 2,
-    "output": 12,
-    "cached_input": 0.2
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "gemini-3.1-pro-preview",
-    "variant": "above_200k_tokens",
-    "input": 4,
-    "output": 18,
-    "cached_input": 0.4
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "gemini-3.1-pro-preview",
-    "variant": "above_200k_tokens_priority",
-    "input": 7.2,
-    "output": 32.4,
-    "cached_input": 0.72
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "gemini-3.1-pro-preview",
-    "variant": "batches",
-    "input": 1,
-    "output": 6
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "gemini-3.1-pro-preview",
-    "variant": "priority",
-    "input": 3.6,
-    "output": 21.6,
-    "cached_input": 0.36
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "gemini-3.1-pro-preview-customtools",
-    "variant": "",
-    "input": 2,
-    "output": 12,
-    "cached_input": 0.2
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "gemini-3.1-pro-preview-customtools",
-    "variant": "above_200k_tokens",
-    "input": 4,
-    "output": 18,
-    "cached_input": 0.4
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "gemini-3.1-pro-preview-customtools",
-    "variant": "batches",
-    "input": 1,
-    "output": 6
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "gemini-live-2.5-flash-preview-native-audio-09-2025",
-    "variant": "",
-    "input": 0.3,
-    "output": 2,
-    "cached_input": 0.075
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "gemini-robotics-er-1.5-preview",
-    "variant": "",
-    "input": 0.3,
-    "output": 2.5,
-    "cached_input": 0
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "vertex_ai/deep-research-pro-preview-12-2025",
-    "variant": "",
-    "input": 2,
-    "output": 12
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "vertex_ai/deep-research-pro-preview-12-2025",
-    "variant": "batches",
-    "input": 1,
-    "output": 6
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "vertex_ai/gemini-2.5-flash-image",
-    "variant": "",
-    "input": 0.3,
-    "output": 2.5,
-    "cached_input": 0.03
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "vertex_ai/gemini-3-pro-image-preview",
-    "variant": "",
-    "input": 2,
-    "output": 12
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "vertex_ai/gemini-3-pro-image-preview",
-    "variant": "batches",
-    "input": 1,
-    "output": 6
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "vertex_ai/gemini-3.1-flash-image-preview",
-    "variant": "",
-    "input": 0.5,
-    "output": 3
-  },
-  {
-    "provider": "Google/Vertex",
-    "model": "vertex_ai/gemini-3.1-flash-lite-preview",
-    "variant": "",
-    "input": 0.25,
-    "output": 1.5,
-    "cached_input": 0.025
   }
 ]

--- a/tests/_vcr/test_provider_deepseek/test_deepseek_tool_variations.yaml
+++ b/tests/_vcr/test_provider_deepseek/test_deepseek_tool_variations.yaml
@@ -107,8 +107,7 @@ interactions:
 - request:
     body: '{"messages": [{"content": "Always use a tool to help you answer. Reply
       with ''It is ____.''.", "role": "system"}, {"content": "What''s the current
-      date in YYYY-MM-DD format?", "role": "user"}, {"role": "assistant", "content":
-      "[empty string]", "tool_calls": [{"id": "call_00_tz6Vq4aG59EtpFCVbpoY3635",
+      date in YYYY-MM-DD format?", "role": "user"}, {"role": "assistant", "tool_calls": [{"id": "call_00_tz6Vq4aG59EtpFCVbpoY3635",
       "function": {"name": "get_date", "arguments": "{}"}, "type": "function"}], "reasoning_content":
       "Let me get the current date."}, {"content": "2024-01-01", "tool_call_id": "call_00_tz6Vq4aG59EtpFCVbpoY3635",
       "role": "tool"}], "model": "deepseek-v4-flash", "seed": 1014, "stream": true,
@@ -255,8 +254,7 @@ interactions:
 - request:
     body: '{"messages": [{"content": "Always use a tool to help you answer. Reply
       with ''It is ____.''.", "role": "system"}, {"content": "What''s the current
-      date in YYYY-MM-DD format?", "role": "user"}, {"role": "assistant", "content":
-      "[empty string]", "tool_calls": [{"id": "call_00_tz6Vq4aG59EtpFCVbpoY3635",
+      date in YYYY-MM-DD format?", "role": "user"}, {"role": "assistant", "tool_calls": [{"id": "call_00_tz6Vq4aG59EtpFCVbpoY3635",
       "function": {"name": "get_date", "arguments": "{}"}, "type": "function"}], "reasoning_content":
       "Let me get the current date."}, {"content": "2024-01-01", "tool_call_id": "call_00_tz6Vq4aG59EtpFCVbpoY3635",
       "role": "tool"}, {"role": "assistant", "content": "It is 2024-01-01.", "reasoning_content":

--- a/tests/_vcr/test_provider_deepseek/test_deepseek_tool_variations_async.yaml
+++ b/tests/_vcr/test_provider_deepseek/test_deepseek_tool_variations_async.yaml
@@ -160,7 +160,7 @@ interactions:
 - request:
     body: '{"messages": [{"content": "Be very terse, not even punctuation.", "role":
       "system"}, {"content": "What''s the current date in YYYY-MM-DD format?", "role":
-      "user"}, {"role": "assistant", "content": "[empty string]", "tool_calls": [{"id":
+      "user"}, {"role": "assistant", "tool_calls": [{"id":
       "call_00_Goi29zurEz35bAcAgwDP4901", "function": {"name": "get_current_date",
       "arguments": "{}"}, "type": "function"}], "reasoning_content": "The user wants
       the current date in YYYY-MM-DD format. Let me get the current date."}, {"content":
@@ -469,7 +469,7 @@ interactions:
 - request:
     body: '{"messages": [{"content": "Be very terse, not even punctuation.", "role":
       "system"}, {"content": "What''s the current date in YYYY-MM-DD format?", "role":
-      "user"}, {"role": "assistant", "content": "[empty string]", "tool_calls": [{"id":
+      "user"}, {"role": "assistant", "tool_calls": [{"id":
       "call_00_dTTMe84vrYVi0IrrxM172804", "function": {"name": "get_current_date2",
       "arguments": "{}"}, "type": "function"}], "reasoning_content": "The user wants
       the current date in YYYY-MM-DD format. Let me call the function to get the current

--- a/tests/_vcr/test_provider_openrouter/test_openrouter_tool_variations.yaml
+++ b/tests/_vcr/test_provider_openrouter/test_openrouter_tool_variations.yaml
@@ -84,7 +84,7 @@ interactions:
     body: '{"messages": [{"content": "Always use a tool to help you answer. Reply
       with ''It is ____.''.", "role": "system"}, {"content": [{"type": "text", "text":
       "What''s the current date in YYYY-MM-DD format?"}], "role": "user"}, {"role":
-      "assistant", "content": [{"type": "text", "text": "[empty string]"}], "tool_calls":
+      "assistant", "tool_calls":
       [{"id": "call_eJmyO5ANyXc20sPeLSuWSngc", "function": {"name": "get_date", "arguments":
       "{}"}, "type": "function"}]}, {"content": "2024-01-01", "tool_call_id": "call_eJmyO5ANyXc20sPeLSuWSngc",
       "role": "tool"}], "model": "openai/gpt-4o-mini-2024-07-18", "seed": 1014, "stream":
@@ -195,7 +195,7 @@ interactions:
     body: '{"messages": [{"content": "Always use a tool to help you answer. Reply
       with ''It is ____.''.", "role": "system"}, {"content": [{"type": "text", "text":
       "What''s the current date in YYYY-MM-DD format?"}], "role": "user"}, {"role":
-      "assistant", "content": [{"type": "text", "text": "[empty string]"}], "tool_calls":
+      "assistant", "tool_calls":
       [{"id": "call_eJmyO5ANyXc20sPeLSuWSngc", "function": {"name": "get_date", "arguments":
       "{}"}, "type": "function"}]}, {"content": "2024-01-01", "tool_call_id": "call_eJmyO5ANyXc20sPeLSuWSngc",
       "role": "tool"}, {"role": "assistant", "content": [{"type": "text", "text":
@@ -282,13 +282,12 @@ interactions:
     body: '{"messages": [{"content": "Always use a tool to help you answer. Reply
       with ''It is ____.''.", "role": "system"}, {"content": [{"type": "text", "text":
       "What''s the current date in YYYY-MM-DD format?"}], "role": "user"}, {"role":
-      "assistant", "content": [{"type": "text", "text": "[empty string]"}], "tool_calls":
+      "assistant", "tool_calls":
       [{"id": "call_eJmyO5ANyXc20sPeLSuWSngc", "function": {"name": "get_date", "arguments":
       "{}"}, "type": "function"}]}, {"content": "2024-01-01", "tool_call_id": "call_eJmyO5ANyXc20sPeLSuWSngc",
       "role": "tool"}, {"role": "assistant", "content": [{"type": "text", "text":
       "It is 2024-01-01."}]}, {"content": [{"type": "text", "text": "What month is
-      it? Provide the full name."}], "role": "user"}, {"role": "assistant", "content":
-      [{"type": "text", "text": "[empty string]"}], "tool_calls": [{"id": "call_q1N9SHfpem9UaAXphuRACH4i",
+      it? Provide the full name."}], "role": "user"}, {"role": "assistant", "tool_calls": [{"id": "call_q1N9SHfpem9UaAXphuRACH4i",
       "function": {"name": "get_date", "arguments": "{}"}, "type": "function"}]},
       {"content": "2024-01-01", "tool_call_id": "call_q1N9SHfpem9UaAXphuRACH4i", "role":
       "tool"}], "model": "openai/gpt-4o-mini-2024-07-18", "seed": 1014, "stream":

--- a/tests/test_provider_openai_completions.py
+++ b/tests/test_provider_openai_completions.py
@@ -1,7 +1,12 @@
 import httpx
 import pytest
 from chatlas import ChatOpenAICompletions
-from chatlas._content import ContentText, ContentThinking, ContentThinkingDelta
+from chatlas._content import (
+    ContentText,
+    ContentThinking,
+    ContentThinkingDelta,
+    ContentToolRequest,
+)
 from chatlas._provider_openai_completions import OpenAICompletionsProvider
 from chatlas._turn import AssistantTurn
 
@@ -192,3 +197,59 @@ def test_turns_as_inputs_preserves_thinking_when_enabled():
     assert msg["role"] == "assistant"
     assert msg["reasoning_content"] == "Let me think..."
     assert msg["content"] == [{"type": "text", "text": "The answer is 42."}]
+
+
+def test_response_as_turn_treats_empty_content_as_none():
+    """Databricks returns content: '' for tool-only turns (#932 in ellmer)."""
+    from unittest.mock import Mock
+
+    mock_func = Mock(arguments="{}")
+    mock_func.name = "fn"
+
+    completion = Mock()
+    message = Mock()
+    message.reasoning_content = None
+    message.content = ""
+    message.tool_calls = [
+        Mock(type="function", id="call_1", function=mock_func)
+    ]
+    completion.choices = [Mock(message=message, finish_reason="stop")]
+
+    turn = OpenAICompletionsProvider._response_as_turn(completion, has_data_model=False)
+    assert not any(isinstance(c, ContentText) for c in turn.contents)
+    assert len(turn.contents) == 1
+    assert isinstance(turn.contents[0], ContentToolRequest)
+
+
+def test_turns_as_inputs_drops_empty_content_text():
+    """Empty ContentText (via model_construct) should be filtered during serialization."""
+    provider = OpenAICompletionsProvider(model="test")
+
+    # model_construct bypasses __init__, so text stays as ""
+    turn = AssistantTurn([ContentText.model_construct(text="")])
+    result = provider._turns_as_inputs([turn])
+    assert len(result) == 1
+    assert "content" not in result[0]
+
+    turn = AssistantTurn(
+        [ContentText.model_construct(text=""), ContentText(text="Hello")]
+    )
+    result = provider._turns_as_inputs([turn])
+    assert result[0]["content"] == [{"type": "text", "text": "Hello"}]
+
+
+def test_turns_as_inputs_empty_text_with_tool_request():
+    """Empty ContentText is stripped but tool requests are preserved."""
+    provider = OpenAICompletionsProvider(model="test")
+
+    turn = AssistantTurn(
+        [
+            ContentText.model_construct(text=""),
+            ContentToolRequest(id="call_1", name="fn", arguments={}),
+        ]
+    )
+    result = provider._turns_as_inputs([turn])
+    assert len(result) == 1
+    assert result[0]["role"] == "assistant"
+    assert "content" not in result[0]
+    assert len(result[0]["tool_calls"]) == 1


### PR DESCRIPTION
## Summary

Databricks (and potentially other OpenAI-compatible providers) return `content: ""` for tool-only assistant turns. When this empty content is replayed back to the provider, it causes HTTP 400 errors because the API rejects empty text content blocks.

This was discovered and fixed in ellmer ([tidyverse/ellmer#935](https://github.com/tidyverse/ellmer/pull/935), closing [tidyverse/ellmer#932](https://github.com/tidyverse/ellmer/issues/932)). The same bug exists in chatlas at two points:

1. **Ingestion** (`_response_as_turn`): `message.content == ""` passes the `is not None` check, creating a `ContentText` from the empty string.
2. **Serialization** (`_turns_as_inputs`): If a `ContentText` with empty text exists (e.g. via `model_construct()`), it produces `{"type": "text", "text": ""}` which some providers reject.

**Fixes:**
- Ingestion: treat `content: ""` the same as `content: None` — no `ContentText` is created.
- Serialization: skip `ContentText` with falsy `.text` when building `content_parts`.

## Test plan

- [ ] `test_response_as_turn_treats_empty_content_as_none` — verifies ingestion skips empty content
- [ ] `test_turns_as_inputs_drops_empty_content_text` — verifies serialization filters empty text
- [ ] `test_turns_as_inputs_empty_text_with_tool_request` — verifies tool requests survive when empty text is stripped