### PR TITLE
Default Bedrock prompt caching to enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improvements
 
+* `ChatBedrockAnthropic()` now defaults to `cache="auto"`, which enables prompt caching with a 5-minute TTL — matching `ChatAnthropic()`'s default behavior. The `"1h"` TTL option has been removed since Bedrock only supports 5-minute caching. (#308)
 * When a stream is interrupted (closed early, cancelled, or errors), the accumulated content is now saved as a partial `AssistantTurn` so conversation state isn't lost. Partial turns display `[interrupted]` (or the cancellation reason) in the `Chat` repr and are excluded from token/cost accounting. (#279)
 * `ChatAnthropic()` and `ChatBedrockAnthropic()` now use Anthropic's native structured outputs API for Claude 4.5+ models, enabling streaming with `data_model`. Older models fall back to the tool-based approach. A new `structured_output_mode` parameter (`"auto"`, `"native"`, or `"tool"`) lets you override the auto-detection. (#263)
 * `ChatOpenAI()` now warns when `base_url` points to a non-OpenAI host, guiding users to `ChatOpenAICompletions()` for third-party backends like vLLM, Ollama, and LiteLLM. (#285)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improvements
 
-* `ChatBedrockAnthropic()` now defaults to `cache="auto"`, which enables prompt caching with a 5-minute TTL — matching `ChatAnthropic()`'s default behavior. The `"1h"` TTL option has been removed since Bedrock only supports 5-minute caching. (#308)
+* `ChatBedrockAnthropic()` now defaults to `cache="5m"`, enabling prompt caching by default — matching `ChatAnthropic()`'s behavior. The `"1h"` TTL option has been removed since Bedrock only supports 5-minute caching. (#308)
 * When a stream is interrupted (closed early, cancelled, or errors), the accumulated content is now saved as a partial `AssistantTurn` so conversation state isn't lost. Partial turns display `[interrupted]` (or the cancellation reason) in the `Chat` repr and are excluded from token/cost accounting. (#279)
 * `ChatAnthropic()` and `ChatBedrockAnthropic()` now use Anthropic's native structured outputs API for Claude 4.5+ models, enabling streaming with `data_model`. Older models fall back to the tool-based approach. A new `structured_output_mode` parameter (`"auto"`, `"native"`, or `"tool"`) lets you override the auto-detection. (#263)
 * `ChatOpenAI()` now warns when `base_url` points to a non-OpenAI host, guiding users to `ChatOpenAICompletions()` for third-party backends like vLLM, Ollama, and LiteLLM. (#285)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improvements
 
-* `ChatBedrockAnthropic()` now defaults to `cache="5m"`, enabling prompt caching by default — matching `ChatAnthropic()`'s behavior. The `"1h"` TTL option has been removed since Bedrock only supports 5-minute caching. (#308)
+* `ChatBedrockAnthropic()` now defaults to `cache="5m"`, enabling prompt caching by default — matching `ChatAnthropic()`'s behavior. (#308)
 * When a stream is interrupted (closed early, cancelled, or errors), the accumulated content is now saved as a partial `AssistantTurn` so conversation state isn't lost. Partial turns display `[interrupted]` (or the cancellation reason) in the `Chat` repr and are excluded from token/cost accounting. (#279)
 * `ChatAnthropic()` and `ChatBedrockAnthropic()` now use Anthropic's native structured outputs API for Claude 4.5+ models, enabling streaming with `data_model`. Older models fall back to the tool-based approach. A new `structured_output_mode` parameter (`"auto"`, `"native"`, or `"tool"`) lets you override the auto-detection. (#263)
 * `ChatOpenAI()` now warns when `base_url` points to a non-OpenAI host, guiding users to `ChatOpenAICompletions()` for third-party backends like vLLM, Ollama, and LiteLLM. (#285)

--- a/chatlas/_provider_anthropic.py
+++ b/chatlas/_provider_anthropic.py
@@ -426,9 +426,8 @@ class AnthropicProvider(
         tool_schemas = [self._anthropic_tool_schema(tool) for tool in tools.values()]
 
         mode = self._structured_output_mode
-        use_native = (
-            mode == "native"
-            or (mode == "auto" and supports_structured_outputs(self.model))
+        use_native = mode == "native" or (
+            mode == "auto" and supports_structured_outputs(self.model)
         )
 
         if data_model is not None and use_native:
@@ -1039,7 +1038,7 @@ def ChatBedrockAnthropic(
     model: Optional[str] = None,
     max_tokens: int = 4096,
     reasoning: Optional["int | ThinkingConfigEnabledParam"] = None,
-    cache: Literal["5m", "1h", "none"] = "none",
+    cache: Literal["auto", "5m", "none"] = "auto",
     structured_output_mode: StructuredOutputMode = "auto",
     aws_secret_key: Optional[str] = None,
     aws_access_key: Optional[str] = None,
@@ -1104,9 +1103,11 @@ def ChatBedrockAnthropic(
         thinking](https://docs.claude.com/en/docs/build-with-claude/extended-thinking)
         for details.
     cache
-        How long to cache inputs? Defaults to "none" (disabled).
-        Set to "5m" to cache for five minutes or "1h" to cache for one hour.
-        See the Caching section of `ChatAnthropic` for details.
+        How long to cache inputs? The default, "auto", enables caching with a
+        5-minute TTL (since all models available through Bedrock's Anthropic
+        client support caching). Set to "5m" to force caching on, or "none" to
+        disable it. Note that Bedrock only supports a 5-minute TTL (unlike the
+        direct Anthropic API which also offers "1h").
     structured_output_mode
         How to handle structured data extraction (i.e., `data_model`).
         See `ChatAnthropic` for details.
@@ -1223,12 +1224,15 @@ class AnthropicBedrockProvider(AnthropicProvider):
         aws_profile: str | None,
         aws_session_token: str | None,
         max_tokens: int = 4096,
-        cache: Literal["5m", "1h", "none"] = "none",
+        cache: Literal["auto", "5m", "none"] = "auto",
         structured_output_mode: StructuredOutputMode = "auto",
         base_url: str | None,
         name: str = "AWS/Bedrock",
         kwargs: Optional["ChatBedrockClientArgs"] = None,
     ):
+        if cache == "auto":
+            cache = "5m"
+
         super().__init__(
             name=name,
             model=model,

--- a/chatlas/_provider_anthropic.py
+++ b/chatlas/_provider_anthropic.py
@@ -1038,7 +1038,7 @@ def ChatBedrockAnthropic(
     model: Optional[str] = None,
     max_tokens: int = 4096,
     reasoning: Optional["int | ThinkingConfigEnabledParam"] = None,
-    cache: Literal["auto", "5m", "none"] = "auto",
+    cache: Literal["5m", "none"] = "5m",
     structured_output_mode: StructuredOutputMode = "auto",
     aws_secret_key: Optional[str] = None,
     aws_access_key: Optional[str] = None,
@@ -1103,11 +1103,10 @@ def ChatBedrockAnthropic(
         thinking](https://docs.claude.com/en/docs/build-with-claude/extended-thinking)
         for details.
     cache
-        How long to cache inputs? The default, "auto", enables caching with a
-        5-minute TTL (since all models available through Bedrock's Anthropic
-        client support caching). Set to "5m" to force caching on, or "none" to
-        disable it. Note that Bedrock only supports a 5-minute TTL (unlike the
-        direct Anthropic API which also offers "1h").
+        How long to cache inputs? Defaults to "5m" (5-minute TTL), matching
+        `ChatAnthropic`. Set to "none" to disable caching. Note that Bedrock
+        only supports a 5-minute TTL (unlike the direct Anthropic API which
+        also offers "1h").
     structured_output_mode
         How to handle structured data extraction (i.e., `data_model`).
         See `ChatAnthropic` for details.
@@ -1224,15 +1223,12 @@ class AnthropicBedrockProvider(AnthropicProvider):
         aws_profile: str | None,
         aws_session_token: str | None,
         max_tokens: int = 4096,
-        cache: Literal["auto", "5m", "none"] = "auto",
+        cache: Literal["5m", "none"] = "5m",
         structured_output_mode: StructuredOutputMode = "auto",
         base_url: str | None,
         name: str = "AWS/Bedrock",
         kwargs: Optional["ChatBedrockClientArgs"] = None,
     ):
-        if cache == "auto":
-            cache = "5m"
-
         super().__init__(
             name=name,
             model=model,

--- a/tests/test_provider_anthropic.py
+++ b/tests/test_provider_anthropic.py
@@ -10,7 +10,7 @@ from chatlas import (
     tool_web_fetch,
     tool_web_search,
 )
-from chatlas._provider_anthropic import AnthropicBedrockProvider, AnthropicProvider
+from chatlas._provider_anthropic import AnthropicProvider
 from pydantic import BaseModel, Field
 
 from .conftest import (
@@ -303,28 +303,3 @@ def test_anthropic_nested_data_model_extraction():
         assert 0.0 <= classification.score <= 1.0, (
             f"Score {classification.score} should be between 0 and 1"
         )
-
-
-def _make_bedrock_provider(**kwargs):
-    defaults = dict(
-        model="us.anthropic.claude-sonnet-4-6",
-        aws_secret_key="fake",
-        aws_access_key="fake",
-        aws_region="us-east-1",
-        aws_profile=None,
-        aws_session_token=None,
-        base_url=None,
-    )
-    return AnthropicBedrockProvider(**{**defaults, **kwargs})
-
-
-class TestBedrockCacheDefault:
-    def test_default_enables_caching(self):
-        provider = _make_bedrock_provider()
-        assert provider._cache == "5m"
-        assert provider._cache_control() == {"type": "ephemeral", "ttl": "5m"}
-
-    def test_none_disables_caching(self):
-        provider = _make_bedrock_provider(cache="none")
-        assert provider._cache == "none"
-        assert provider._cache_control() is None

--- a/tests/test_provider_anthropic.py
+++ b/tests/test_provider_anthropic.py
@@ -10,7 +10,7 @@ from chatlas import (
     tool_web_fetch,
     tool_web_search,
 )
-from chatlas._provider_anthropic import AnthropicProvider
+from chatlas._provider_anthropic import AnthropicBedrockProvider, AnthropicProvider
 from pydantic import BaseModel, Field
 
 from .conftest import (
@@ -117,9 +117,7 @@ def test_anthropic_web_search_citations():
     """Test that citations from web search are preserved on the completion."""
     chat = chat_func()
     chat.register_tool(tool_web_search())
-    chat.chat(
-        "When was ggplot2 1.0.0 released to CRAN? Answer in YYYY-MM-DD format."
-    )
+    chat.chat("When was ggplot2 1.0.0 released to CRAN? Answer in YYYY-MM-DD format.")
 
     # Get the turn and verify citations are on the completion
     turn = chat.get_last_turn()
@@ -131,9 +129,7 @@ def test_anthropic_web_search_citations():
     assert len(text_blocks) > 0
 
     # At least one text block should have citations from web search
-    has_citations = any(
-        getattr(block, "citations", None) for block in text_blocks
-    )
+    has_citations = any(getattr(block, "citations", None) for block in text_blocks)
     assert has_citations, "Expected citations on text blocks from web search"
 
 
@@ -287,7 +283,9 @@ def test_anthropic_nested_data_model_extraction():
 
         classifications: list[Classification]
 
-    text = "The new quantum computing breakthrough could revolutionize the tech industry."
+    text = (
+        "The new quantum computing breakthrough could revolutionize the tech industry."
+    )
 
     chat = chat_func(system_prompt="You are a friendly but terse assistant.")
     data = chat.chat_structured(text, data_model=Classifications)
@@ -305,3 +303,33 @@ def test_anthropic_nested_data_model_extraction():
         assert 0.0 <= classification.score <= 1.0, (
             f"Score {classification.score} should be between 0 and 1"
         )
+
+
+def _make_bedrock_provider(**kwargs):
+    defaults = dict(
+        model="us.anthropic.claude-sonnet-4-6",
+        aws_secret_key="fake",
+        aws_access_key="fake",
+        aws_region="us-east-1",
+        aws_profile=None,
+        aws_session_token=None,
+        base_url=None,
+    )
+    return AnthropicBedrockProvider(**{**defaults, **kwargs})
+
+
+class TestBedrockCacheDefault:
+    def test_auto_resolves_to_5m(self):
+        provider = _make_bedrock_provider()
+        assert provider._cache == "5m"
+        assert provider._cache_control() == {"type": "ephemeral", "ttl": "5m"}
+
+    def test_none_disables_caching(self):
+        provider = _make_bedrock_provider(cache="none")
+        assert provider._cache == "none"
+        assert provider._cache_control() is None
+
+    def test_explicit_5m(self):
+        provider = _make_bedrock_provider(cache="5m")
+        assert provider._cache == "5m"
+        assert provider._cache_control() == {"type": "ephemeral", "ttl": "5m"}

--- a/tests/test_provider_anthropic.py
+++ b/tests/test_provider_anthropic.py
@@ -319,7 +319,7 @@ def _make_bedrock_provider(**kwargs):
 
 
 class TestBedrockCacheDefault:
-    def test_auto_resolves_to_5m(self):
+    def test_default_enables_caching(self):
         provider = _make_bedrock_provider()
         assert provider._cache == "5m"
         assert provider._cache_control() == {"type": "ephemeral", "ttl": "5m"}
@@ -328,8 +328,3 @@ class TestBedrockCacheDefault:
         provider = _make_bedrock_provider(cache="none")
         assert provider._cache == "none"
         assert provider._cache_control() is None
-
-    def test_explicit_5m(self):
-        provider = _make_bedrock_provider(cache="5m")
-        assert provider._cache == "5m"
-        assert provider._cache_control() == {"type": "ephemeral", "ttl": "5m"}

--- a/tests/test_provider_bedrock.py
+++ b/tests/test_provider_bedrock.py
@@ -25,13 +25,46 @@ def vcr_config():
     config["before_record_request"] = _scrub_aws_request
     return config
 
+
+class TestBedrockCacheDefault:
+    def test_default_enables_caching(self):
+        chat = ChatBedrockAnthropic(
+            aws_secret_key="fake",
+            aws_access_key="fake",
+            aws_region="us-east-1",
+        )
+        assert chat.provider._cache == "5m"
+        assert chat.provider._cache_control() == {"type": "ephemeral", "ttl": "5m"}
+
+    def test_none_disables_caching(self):
+        chat = ChatBedrockAnthropic(
+            cache="none",
+            aws_secret_key="fake",
+            aws_access_key="fake",
+            aws_region="us-east-1",
+        )
+        assert chat.provider._cache == "none"
+        assert chat.provider._cache_control() is None
+
+
+# ---------------------------------------------------------------------------
+# Live API tests (require Bedrock credentials)
+# ---------------------------------------------------------------------------
+
+_has_bedrock_credentials = True
 try:
-    chat = ChatBedrockAnthropic()
-    chat.chat("What is 1 + 1?")
+    _chat = ChatBedrockAnthropic()
+    _chat.chat("What is 1 + 1?")
 except Exception:
-    pytest.skip("Bedrock credentials aren't configured", allow_module_level=True)
+    _has_bedrock_credentials = False
+
+requires_bedrock = pytest.mark.skipif(
+    not _has_bedrock_credentials,
+    reason="Bedrock credentials aren't configured",
+)
 
 
+@requires_bedrock
 @pytest.mark.vcr
 def test_anthropic_simple_request():
     chat = ChatBedrockAnthropic(
@@ -43,6 +76,7 @@ def test_anthropic_simple_request():
     assert turn.tokens == (26, 5, 0)
 
 
+@requires_bedrock
 @pytest.mark.vcr
 @pytest.mark.asyncio
 async def test_anthropic_simple_streaming_request():
@@ -59,6 +93,7 @@ async def test_anthropic_simple_streaming_request():
     assert turn.finish_reason == "end_turn"
 
 
+@requires_bedrock
 @pytest.mark.vcr
 def test_anthropic_respects_turns_interface():
     chat_fun = ChatBedrockAnthropic
@@ -66,6 +101,7 @@ def test_anthropic_respects_turns_interface():
     assert_turns_existing(chat_fun)
 
 
+@requires_bedrock
 @pytest.mark.vcr
 def test_anthropic_tool_variations():
     chat_fun = ChatBedrockAnthropic
@@ -74,17 +110,20 @@ def test_anthropic_tool_variations():
     assert_tools_sequential(chat_fun, total_calls=6)
 
 
+@requires_bedrock
 @pytest.mark.vcr
 @pytest.mark.asyncio
 async def test_anthropic_tool_variations_async():
     await assert_tools_async(ChatBedrockAnthropic)
 
 
+@requires_bedrock
 @pytest.mark.vcr
 def test_data_extraction():
     assert_data_extraction(ChatBedrockAnthropic)
 
 
+@requires_bedrock
 @pytest.mark.vcr
 def test_anthropic_images():
     chat_fun = ChatBedrockAnthropic
@@ -92,11 +131,13 @@ def test_anthropic_images():
     assert_images_remote_error(chat_fun)
 
 
+@requires_bedrock
 @pytest.mark.vcr
 def test_anthropic_models():
     assert_list_models(ChatBedrockAnthropic)
 
 
+@requires_bedrock
 @pytest.mark.vcr
 def test_reasoning():
     from chatlas._content import ContentThinking


### PR DESCRIPTION
## Summary

Bedrock users currently miss out on prompt caching cost savings because `ChatBedrockAnthropic` defaults to `cache="none"`, while `ChatAnthropic` defaults to `cache="5m"`. Since both providers use the same Anthropic Messages API format (with `cache_control` on content blocks), and all active Claude models support prompt caching, there's no reason for the asymmetry.

- Changes the default from `cache="none"` to `cache="5m"` — matching `ChatAnthropic`'s behavior
- Removes the `"1h"` TTL option since [Bedrock only supports 5-minute cache TTLs](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching)
- Prompts that are too short for caching are silently skipped by the API (no errors), so the worst case is a no-op

## Test plan

- [x] Unit tests verify default enables caching and `"none"` disables it
- [x] Unit tests run without Bedrock credentials (live-API tests skip via marker)
- [ ] Re-record Bedrock VCR cassettes with credentials (existing cassettes were recorded with `cache="none"`)