### PR TITLE
fix: annotate .tagify() return types per htmltools Tagified contract

### DIFF
--- a/chatlas/_content.py
+++ b/chatlas/_content.py
@@ -18,6 +18,8 @@ from pydantic import (
 from ._typing_extensions import TypedDict
 
 if TYPE_CHECKING:
+    from htmltools import Tagified
+
     from ._tools import Tool, ToolBuiltIn
 
 
@@ -316,7 +318,7 @@ class ContentToolRequest(Content):
     def _repr_html_(self) -> str:
         return str(self.tagify())
 
-    def tagify(self):
+    def tagify(self) -> Tagified:
         "Returns an HTML string suitable for passing to htmltools/shiny's `Chat()` component."
         try:
             from htmltools import HTML, TagList, head_content, tags
@@ -331,7 +333,7 @@ class ContentToolRequest(Content):
         return TagList(
             HTML(html),
             head_content(tags.style(TOOL_CSS)),
-        )
+        ).tagify()
 
 
 class ContentToolResult(Content):
@@ -523,7 +525,7 @@ class ContentToolResult(Content):
     def _repr_html_(self):
         return str(self.tagify())
 
-    def tagify(self):
+    def tagify(self) -> Tagified:
         "A method for rendering this object via htmltools/shiny."
         try:
             from htmltools import HTML, html_escape
@@ -694,7 +696,7 @@ class ContentThinking(Content):
     def _repr_html_(self):
         return str(self.tagify())
 
-    def tagify(self):
+    def tagify(self) -> Tagified:
         try:
             from htmltools import HTML
         except ImportError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dev = [
     "matplotlib",
     "Pillow",
     "shiny",
-    "htmltools>=0.7.0;python_version>='3.10'",
+    "htmltools>=0.7.0",
     "shinychat",
     "narwhals",
     "pandas",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,3 +208,11 @@ skip-magic-trailing-comma = false
 line-ending = "auto"
 docstring-code-format = true
 docstring-code-line-length = "dynamic"
+
+
+# TODO(htmltools-105): remove this source override before merging.
+# Pins htmltools to the PR branch that adds the `Tagified` alias
+# (posit-dev/py-htmltools#106). Flip back to the released htmltools
+# once it ships.
+[tool.uv.sources]
+htmltools = { git = "https://github.com/posit-dev/py-htmltools.git", branch = "schloerke/tagify-tag-class-issue" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dev = [
     "matplotlib",
     "Pillow",
     "shiny",
-    "htmltools",
+    "htmltools>=0.7.0",
     "shinychat",
     "narwhals",
     "pandas",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,4 +215,4 @@ docstring-code-line-length = "dynamic"
 # tagified content). Flip back to the released htmltools once 0.7.0
 # ships.
 [tool.uv.sources]
-htmltools = { git = "https://github.com/posit-dev/py-htmltools.git", branch = "schloerke/issue-116-sibling-classes" }
+htmltools = { git = "https://github.com/posit-dev/py-htmltools.git", branch = "main" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,9 +210,9 @@ docstring-code-format = true
 docstring-code-line-length = "dynamic"
 
 
-# TODO(htmltools-105): remove this source override before merging.
-# Pins htmltools to the PR branch that adds the `Tagified` alias
-# (posit-dev/py-htmltools#106). Flip back to the released htmltools
-# once it ships.
+# TODO(htmltools-116): remove this source override before merging.
+# Pins htmltools to PR #120 (the sibling-classes refactor for
+# tagified content). Flip back to the released htmltools once 0.7.0
+# ships.
 [tool.uv.sources]
-htmltools = { git = "https://github.com/posit-dev/py-htmltools.git", branch = "main" }
+htmltools = { git = "https://github.com/posit-dev/py-htmltools.git", branch = "schloerke/issue-116-sibling-classes" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,11 +208,3 @@ skip-magic-trailing-comma = false
 line-ending = "auto"
 docstring-code-format = true
 docstring-code-line-length = "dynamic"
-
-
-# TODO(htmltools-116): remove this source override before merging.
-# Pins htmltools to PR #120 (the sibling-classes refactor for
-# tagified content). Flip back to the released htmltools once 0.7.0
-# ships.
-[tool.uv.sources]
-htmltools = { git = "https://github.com/posit-dev/py-htmltools.git", branch = "main" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dev = [
     "matplotlib",
     "Pillow",
     "shiny",
-    "htmltools>=0.7.0",
+    "htmltools>=0.7.0;python_version>='3.10'",
     "shinychat",
     "narwhals",
     "pandas",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,4 +215,4 @@ docstring-code-line-length = "dynamic"
 # (posit-dev/py-htmltools#106). Flip back to the released htmltools
 # once it ships.
 [tool.uv.sources]
-htmltools = { git = "https://github.com/posit-dev/py-htmltools.git", branch = "schloerke/tagify-tag-class-issue" }
+htmltools = { git = "https://github.com/posit-dev/py-htmltools.git", branch = "main" }


### PR DESCRIPTION
## Summary

The upcoming htmltools 0.7.0 release ([posit-dev/py-htmltools#120](https://github.com/posit-dev/py-htmltools/pull/120), closes posit-dev/py-htmltools#116) refactors tagified content into immutable sibling classes and tightens the `Tagifiable.tagify()` Protocol return type from a bare `TagList | Tag | MetadataNode | str | HTML` to the new `Tagified` union — the only tagified-shape alias exported by htmltools. Downstream `.tagify()` implementations should annotate `-> Tagified` exclusively.

Annotate the three custom `.tagify()` methods in `chatlas/_content.py` with `-> Tagified`. Since `htmltools` is an optional runtime dep, the import lives behind `TYPE_CHECKING` (the existing `from __future__ import annotations` defers annotation evaluation).

For the `ContentToolRequest.tagify()` method that returns a `TagList`, append `.tagify()` so the value is properly tagified (matches the recursive invariant the protocol now expresses). The two methods that return `HTML(...)` directly are already in `Tagified` (the leaf-string arm of the union).

## Dependency

Depends on [posit-dev/py-htmltools#120](https://github.com/posit-dev/py-htmltools/pull/120). The `[tool.uv.sources]` git pin currently points at the PR branch; revert to released `htmltools>=0.7.0` once it ships on PyPI.

## Test plan

- [x] Pyright against the new htmltools → 0 errors
- [x] Runtime behavior unchanged: `.tagify()` on a `TagList` containing only `HTML` / `head_content` is structurally idempotent