### PR TITLE
Release v0.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 -->
 
-## [UNRELEASED]
+## [0.18.1] - 2026-05-21
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Improvements
+
+* `Content.tagify()` implementations (`ContentToolRequest`, `ContentToolResult`, `ContentThinking`) now annotate their return type as `htmltools.Tagified` and fully tagify their output, complying with htmltools 0.7.0's tightened Tagifiable contract. Embedding these contents inside another `.tagify()` recursion no longer trips the new boundary check in htmltools 0.7.0. (#311)
+
 ### Bug fixes
 
 * `ContentPDF` is now exported from `chatlas.types`, matching all other `Content` subclasses. (#312)


### PR DESCRIPTION
## Summary

Cuts chatlas **0.18.1**, picking up the two PRs merged since 0.18.0:

- **#311** (Improvements) — `Content.tagify()` implementations now annotate as `htmltools.Tagified` and fully tagify their output, complying with htmltools 0.7.0's tightened Tagifiable contract.
- **#312** (Bug fixes) — `ContentPDF` is now exported from `chatlas.types`.

## Commits

1. `docs(changelog): add #311 Tagified contract entry under UNRELEASED` — backfills the missing changelog entry from #311.
2. `Release v0.18.1` — renames `## [UNRELEASED]` → `## [0.18.1] - 2026-05-21`.

## Release steps after merge

Per `.github/workflows/release.yml` (fires on `release: published` when the tag starts with `v`):

1. Tag the merge commit `v0.18.1`.
2. Publish a GitHub Release pointing at that tag.
3. `release.yml` runs `make check-types` / `make check-format` / `uv build`, then trusted-publishes to PyPI.

Version itself is computed by `hatch-vcs` from the tag; no `_version.py` to bump.