### PR TITLE
ci: bump checkout to v5 and setup-uv to v6 for Node.js 24

### DIFF
--- a/.github/workflows/check-update-types.yml
+++ b/.github/workflows/check-update-types.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: 🚀 Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
 
       - name: 🐍 Set up Python ${{ env.PYTHON_VERSION }}
         run: uv python install ${{ env.PYTHON_VERSION }}

--- a/.github/workflows/check-update-types.yml
+++ b/.github/workflows/check-update-types.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: 🚀 Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v6
 
       - name: 🐍 Set up Python ${{ env.PYTHON_VERSION }}
         run: uv python install ${{ env.PYTHON_VERSION }}

--- a/.github/workflows/check-vcr-secrets.yml
+++ b/.github/workflows/check-vcr-secrets.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
 
       - name: Set up Python
         run: uv python install 3.12

--- a/.github/workflows/check-vcr-secrets.yml
+++ b/.github/workflows/check-vcr-secrets.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v6
 
       - name: Set up Python
         run: uv python install 3.12

--- a/.github/workflows/docs-freeze.yml
+++ b/.github/workflows/docs-freeze.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Check out repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -30,7 +30,7 @@ jobs:
         version: 1.9.37
 
     - name: 🚀 Install uv
-      uses: astral-sh/setup-uv@v3
+      uses: astral-sh/setup-uv@v6
       with:
         version: ${{ env.UV_VERSION }}
 

--- a/.github/workflows/docs-freeze.yml
+++ b/.github/workflows/docs-freeze.yml
@@ -30,7 +30,7 @@ jobs:
         version: 1.9.37
 
     - name: 🚀 Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v7
       with:
         version: ${{ env.UV_VERSION }}
 

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - name: Check out repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0 # full history needed for correct versioning of py pkg
 
@@ -37,7 +37,7 @@ jobs:
         version: 1.9.37
 
     - name: 🚀 Install uv
-      uses: astral-sh/setup-uv@v3
+      uses: astral-sh/setup-uv@v6
       with:
         version: ${{ env.UV_VERSION }}
 

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -37,7 +37,7 @@ jobs:
         version: 1.9.37
 
     - name: 🚀 Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v7
       with:
         version: ${{ env.UV_VERSION }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: 🚀 Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
 
       - name: 🐍 Set up Python ${{ env.PYTHON_VERSION }}
         run: uv python install ${{ env.PYTHON_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,10 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: 🚀 Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v6
 
       - name: 🐍 Set up Python ${{ env.PYTHON_VERSION }}
         run: uv python install ${{ env.PYTHON_VERSION }}

--- a/.github/workflows/test-live.yml
+++ b/.github/workflows/test-live.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
 
       - name: Set up Python
         run: uv python install 3.12

--- a/.github/workflows/test-live.yml
+++ b/.github/workflows/test-live.yml
@@ -33,10 +33,10 @@ jobs:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v6
 
       - name: Set up Python
         run: uv python install 3.12

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,10 +25,10 @@ jobs:
     # the test-live.yml workflow.
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v6
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}

--- a/.github/workflows/update-pricing.yml
+++ b/.github/workflows/update-pricing.yml
@@ -13,14 +13,14 @@ jobs:
         steps:
 
             - name: Checkout current prices.json in chatlas
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
               with:
                 sparse-checkout: /chatlas/data/prices.json
                 sparse-checkout-cone-mode: false
                 path: main
 
             - name: Get Ellmer prices.json
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
               with:
                 sparse-checkout: /data-raw/prices.json
                 sparse-checkout-cone-mode: false


### PR DESCRIPTION
## Summary

- Bumps `actions/checkout@v4` → `@v5` and `astral-sh/setup-uv@v3` → `@v6` across all 8 workflows.
- Resolves the `##[warning]Node.js 20 actions are deprecated` notice that appears at the end of every CI job. Node.js 20 will be forced off GitHub Actions runners starting June 2nd, 2026.
- We don't pass `python-version` to `setup-uv` anywhere, so the v6 `activate-environment` breaking change doesn't apply.

## Test plan

- [ ] CI green on this PR (all jobs run on Node 24; deprecation warning gone)