### PR TITLE
Add Chat.model and string reasoning effort for Google & Anthropic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 -->
 
+## [UNRELEASED]
+
+### New features
+
+* `Chat` gains a `model` property to get (or set) the model after the chat is created. Setting it does not validate the model name.
+* `ChatGoogle()`'s `reasoning` parameter now accepts a string thinking level (`"minimal"`, `"low"`, `"medium"`, or `"high"`) in addition to an integer token budget.
+* `ChatAnthropic()`'s `reasoning` parameter now accepts a string effort level (`"low"`, `"medium"`, `"high"`, `"xhigh"`, or `"max"`) to enable Claude's adaptive thinking, in addition to an integer token budget.
+
+### Bug fixes
+
+* OpenAI-compatible providers (e.g., `ChatOllama()` with models like qwen3) now capture thinking content returned in a `reasoning` field, not just `reasoning_content`. Previously this thinking content was silently dropped.
+
 ## [0.18.1] - 2026-05-21
 
 ### Improvements

--- a/chatlas/_chat.py
+++ b/chatlas/_chat.py
@@ -396,6 +396,26 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         if value is not None:
             self._turns.insert(0, SystemTurn(value))
 
+    @property
+    def model(self) -> str:
+        """
+        A property to get (or set) the model used by the chat.
+
+        Setting this updates the model for subsequent requests. The model name
+        is not validated, so make sure it's a valid model for the chat's
+        provider.
+
+        Returns
+        -------
+        str
+            The model currently used by the chat.
+        """
+        return self.provider.model
+
+    @model.setter
+    def model(self, value: str):
+        self.provider.model = value
+
     def get_tokens(self) -> list[TokensDict]:
         """
         Get the tokens for each turn in the chat.

--- a/chatlas/_provider.py
+++ b/chatlas/_provider.py
@@ -148,6 +148,10 @@ class Provider(
         """
         return self._model
 
+    @model.setter
+    def model(self, value: str):
+        self._model = value
+
     @abstractmethod
     def list_models(self) -> list[ModelInfo]:
         """

--- a/chatlas/_provider_anthropic.py
+++ b/chatlas/_provider_anthropic.py
@@ -103,7 +103,7 @@ def ChatAnthropic(
     system_prompt: Optional[str] = None,
     model: "Optional[ModelParam]" = None,
     max_tokens: int = 4096,
-    reasoning: Optional["int | ThinkingConfigEnabledParam"] = None,
+    reasoning: Optional["int | str | ThinkingConfigEnabledParam"] = None,
     cache: Literal["5m", "1h", "none"] = "5m",
     structured_output_mode: StructuredOutputMode = "auto",
     api_key: Optional[str] = None,
@@ -156,10 +156,12 @@ def ChatAnthropic(
     max_tokens
         Maximum number of tokens to generate before stopping.
     reasoning
-        Determines how many tokens Claude can be allocated to reasoning. Must be
-        ≥1024 and less than `max_tokens`. Larger budgets can enable more
-        thorough analysis for complex problems, improving response quality.  See
-        [extended
+        Controls Claude's extended thinking. Pass an integer to set a fixed
+        thinking budget (the number of tokens allocated to reasoning; must be
+        ≥1024 and less than `max_tokens`). Alternatively, pass a string effort
+        level (`"low"`, `"medium"`, `"high"`, `"xhigh"`, or `"max"`) to enable
+        adaptive thinking, where Claude decides how much to think based on the
+        requested effort. See [extended
         thinking](https://docs.claude.com/en/docs/build-with-claude/extended-thinking)
         for details.
     cache
@@ -268,9 +270,17 @@ def ChatAnthropic(
 
     kwargs_chat: "SubmitInputArgs" = {}
     if reasoning is not None:
-        if isinstance(reasoning, int):
-            reasoning = {"type": "enabled", "budget_tokens": reasoning}
-        kwargs_chat = {"thinking": reasoning}
+        if isinstance(reasoning, str):
+            # A string effort level enables Claude's adaptive thinking, where
+            # the model decides how much to think based on `output_config.effort`.
+            kwargs_chat = {
+                "thinking": {"type": "adaptive"},
+                "output_config": cast("OutputConfigParam", {"effort": reasoning}),
+            }
+        else:
+            if isinstance(reasoning, int):
+                reasoning = {"type": "enabled", "budget_tokens": reasoning}
+            kwargs_chat = {"thinking": reasoning}
 
     return Chat(
         provider=AnthropicProvider(
@@ -439,6 +449,13 @@ class AnthropicProvider(
                     "schema": transform_schema(data_model),
                 },
             }
+            # Preserve adaptive-thinking effort set via the `reasoning` param,
+            # since this output_config otherwise overwrites the one in kwargs.
+            kwargs_output_config = (kwargs or {}).get("output_config")
+            if isinstance(kwargs_output_config, dict):
+                effort = kwargs_output_config.get("effort")
+                if effort is not None:
+                    output_config["effort"] = effort
         elif data_model is not None:
             data_model_tool = self.create_data_model_tool(data_model)
             tool_schemas.append(self._anthropic_tool_schema(data_model_tool))

--- a/chatlas/_provider_anthropic.py
+++ b/chatlas/_provider_anthropic.py
@@ -97,13 +97,15 @@ def supports_structured_outputs(model: str) -> bool:
 
 StructuredOutputMode = Literal["auto", "native", "tool"]
 
+ReasoningEffort = Literal["low", "medium", "high", "xhigh", "max"]
+
 
 def ChatAnthropic(
     *,
     system_prompt: Optional[str] = None,
     model: "Optional[ModelParam]" = None,
     max_tokens: int = 4096,
-    reasoning: Optional["int | str | ThinkingConfigEnabledParam"] = None,
+    reasoning: Optional["int | ReasoningEffort | ThinkingConfigEnabledParam"] = None,
     cache: Literal["5m", "1h", "none"] = "5m",
     structured_output_mode: StructuredOutputMode = "auto",
     api_key: Optional[str] = None,
@@ -269,18 +271,16 @@ def ChatAnthropic(
         model = log_model_default("claude-sonnet-4-6")
 
     kwargs_chat: "SubmitInputArgs" = {}
-    if reasoning is not None:
-        if isinstance(reasoning, str):
-            # A string effort level enables Claude's adaptive thinking, where
-            # the model decides how much to think based on `output_config.effort`.
-            kwargs_chat = {
-                "thinking": {"type": "adaptive"},
-                "output_config": cast("OutputConfigParam", {"effort": reasoning}),
-            }
-        else:
-            if isinstance(reasoning, int):
-                reasoning = {"type": "enabled", "budget_tokens": reasoning}
-            kwargs_chat = {"thinking": reasoning}
+    if isinstance(reasoning, str):
+        output_config: "OutputConfigParam" = {"effort": reasoning}
+        kwargs_chat = {
+            "thinking": {"type": "adaptive"},
+            "output_config": output_config,
+        }
+    elif isinstance(reasoning, int):
+        kwargs_chat = {"thinking": {"type": "enabled", "budget_tokens": reasoning}}
+    elif reasoning is not None:
+        kwargs_chat = {"thinking": reasoning}
 
     return Chat(
         provider=AnthropicProvider(

--- a/chatlas/_provider_google.py
+++ b/chatlas/_provider_google.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
         Part,
         PartDict,
         ThinkingConfigDict,
+        ThinkingLevel,
     )
 
     from .types.google import ChatClientArgs, SubmitInputArgs
@@ -47,7 +48,7 @@ def ChatGoogle(
     *,
     system_prompt: Optional[str] = None,
     model: Optional[str] = None,
-    reasoning: Optional["int | ThinkingConfigDict"] = None,
+    reasoning: Optional["int | str | ThinkingConfigDict"] = None,
     api_key: Optional[str] = None,
     kwargs: Optional["ChatClientArgs"] = None,
 ) -> Chat["SubmitInputArgs", GenerateContentResponse]:
@@ -69,6 +70,7 @@ def ChatGoogle(
 
     ```python
     import google.auth
+
     credentials, _ = google.auth.default()
     chat = ChatGoogle(kwargs={"credentials": credentials})
     ```
@@ -101,8 +103,10 @@ def ChatGoogle(
         a model for all but the most casual use.
     reasoning
         If provided, enables reasoning (a.k.a. "thoughts") in the model's
-        responses. This can be an integer number of tokens to use for reasoning,
-        or a full `ThinkingConfigDict` to customize the reasoning behavior.
+        responses. This can be an integer number of tokens to use for reasoning
+        (a thinking budget), a string thinking level (`"minimal"`, `"low"`,
+        `"medium"`, or `"high"`), or a full `ThinkingConfigDict` to customize
+        the reasoning behavior.
     api_key
         The API key to use for authentication. You generally should not supply
         this directly, but instead set the `GOOGLE_API_KEY` environment variable.
@@ -156,9 +160,20 @@ def ChatGoogle(
 
     kwargs_chat: "SubmitInputArgs" = {}
     if reasoning is not None:
+        thinking_config: "ThinkingConfigDict"
         if isinstance(reasoning, int):
-            reasoning = {"thinking_budget": reasoning, "include_thoughts": True}
-        kwargs_chat["config"] = {"thinking_config": reasoning}
+            thinking_config = {
+                "thinking_budget": reasoning,
+                "include_thoughts": True,
+            }
+        elif isinstance(reasoning, str):
+            thinking_config = {
+                "thinking_level": cast("ThinkingLevel", reasoning),
+                "include_thoughts": True,
+            }
+        else:
+            thinking_config = reasoning
+        kwargs_chat["config"] = {"thinking_config": thinking_config}
 
     return Chat(
         provider=GoogleProvider(
@@ -715,6 +730,7 @@ def ChatVertex(
 
     ```python
     import google.auth
+
     credentials, project = google.auth.default()
     chat = ChatVertex(
         project=project,

--- a/chatlas/_provider_google.py
+++ b/chatlas/_provider_google.py
@@ -36,7 +36,6 @@ if TYPE_CHECKING:
         Part,
         PartDict,
         ThinkingConfigDict,
-        ThinkingLevel,
     )
 
     from .types.google import ChatClientArgs, SubmitInputArgs
@@ -44,11 +43,14 @@ else:
     GenerateContentResponse = object
 
 
+ReasoningEffort = Literal["minimal", "low", "medium", "high"]
+
+
 def ChatGoogle(
     *,
     system_prompt: Optional[str] = None,
     model: Optional[str] = None,
-    reasoning: Optional["int | str | ThinkingConfigDict"] = None,
+    reasoning: Optional["int | ReasoningEffort | ThinkingConfigDict"] = None,
     api_key: Optional[str] = None,
     kwargs: Optional["ChatClientArgs"] = None,
 ) -> Chat["SubmitInputArgs", GenerateContentResponse]:
@@ -167,8 +169,10 @@ def ChatGoogle(
                 "include_thoughts": True,
             }
         elif isinstance(reasoning, str):
+            from google.genai.types import ThinkingLevel
+
             thinking_config = {
-                "thinking_level": cast("ThinkingLevel", reasoning),
+                "thinking_level": ThinkingLevel(reasoning.upper()),
                 "include_thoughts": True,
             }
         else:

--- a/chatlas/_provider_openai_completions.py
+++ b/chatlas/_provider_openai_completions.py
@@ -226,7 +226,11 @@ class OpenAICompletionsProvider(
             return None
         delta = chunk.choices[0].delta
 
-        reasoning = getattr(delta, "reasoning_content", None)
+        # Some OpenAI-compatible providers (e.g. Ollama with qwen3) return
+        # thinking in a `reasoning` field rather than `reasoning_content`.
+        reasoning = getattr(delta, "reasoning", None) or getattr(
+            delta, "reasoning_content", None
+        )
         if reasoning is not None:
             return ContentThinkingDelta(thinking=reasoning)
 
@@ -404,7 +408,9 @@ class OpenAICompletionsProvider(
 
         contents: list[Content] = []
 
-        reasoning = getattr(message, "reasoning_content", None)
+        reasoning = getattr(message, "reasoning", None) or getattr(
+            message, "reasoning_content", None
+        )
         if reasoning:
             contents.append(ContentThinking(thinking=reasoning))
 

--- a/chatlas/data/prices.json
+++ b/chatlas/data/prices.json
@@ -1638,6 +1638,14 @@
   },
   {
     "provider": "Anthropic",
+    "model": "claude-opus-4-8",
+    "variant": "",
+    "input": 5,
+    "output": 25,
+    "cached_input": 0.5
+  },
+  {
+    "provider": "Anthropic",
     "model": "claude-sonnet-4-20250514",
     "variant": "",
     "input": 3,
@@ -3561,6 +3569,38 @@
   },
   {
     "provider": "Google/Gemini",
+    "model": "gemini-3.1-flash-lite",
+    "variant": "",
+    "input": 0.25,
+    "output": 1.5,
+    "cached_input": 0.025
+  },
+  {
+    "provider": "Google/Gemini",
+    "model": "gemini-3.1-flash-lite",
+    "variant": "batches",
+    "input": 0.125,
+    "output": 0.75,
+    "cached_input": 0.0125
+  },
+  {
+    "provider": "Google/Gemini",
+    "model": "gemini-3.1-flash-lite",
+    "variant": "flex",
+    "input": 0.125,
+    "output": 0.75,
+    "cached_input": 0.0125
+  },
+  {
+    "provider": "Google/Gemini",
+    "model": "gemini-3.1-flash-lite",
+    "variant": "priority",
+    "input": 0.45,
+    "output": 2.7,
+    "cached_input": 0.045
+  },
+  {
+    "provider": "Google/Gemini",
     "model": "gemini-3.1-flash-lite-preview",
     "variant": "",
     "input": 0.25,
@@ -3658,6 +3698,22 @@
     "input": 3.6,
     "output": 21.6,
     "cached_input": 0.36
+  },
+  {
+    "provider": "Google/Gemini",
+    "model": "gemini-3.5-flash",
+    "variant": "",
+    "input": 1.5,
+    "output": 9,
+    "cached_input": 0.15
+  },
+  {
+    "provider": "Google/Gemini",
+    "model": "gemini-3.5-flash",
+    "variant": "priority",
+    "input": 2.7,
+    "output": 16.2,
+    "cached_input": 0.27
   },
   {
     "provider": "Google/Gemini",
@@ -4000,6 +4056,38 @@
   },
   {
     "provider": "Google/Vertex",
+    "model": "gemini-3.1-flash-lite",
+    "variant": "",
+    "input": 0.25,
+    "output": 1.5,
+    "cached_input": 0.025
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-3.1-flash-lite",
+    "variant": "batches",
+    "input": 0.125,
+    "output": 0.75,
+    "cached_input": 0.0125
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-3.1-flash-lite",
+    "variant": "flex",
+    "input": 0.125,
+    "output": 0.75,
+    "cached_input": 0.0125
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-3.1-flash-lite",
+    "variant": "priority",
+    "input": 0.45,
+    "output": 2.7,
+    "cached_input": 0.045
+  },
+  {
+    "provider": "Google/Vertex",
     "model": "gemini-3.1-flash-lite-preview",
     "variant": "",
     "input": 0.25,
@@ -4070,6 +4158,22 @@
   },
   {
     "provider": "Google/Vertex",
+    "model": "gemini-3.5-flash",
+    "variant": "",
+    "input": 1.5,
+    "output": 9,
+    "cached_input": 0.15
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-3.5-flash",
+    "variant": "priority",
+    "input": 2.7,
+    "output": 16.2,
+    "cached_input": 0.27
+  },
+  {
+    "provider": "Google/Vertex",
     "model": "gemini-live-2.5-flash-preview-native-audio-09-2025",
     "variant": "",
     "input": 0.3,
@@ -4126,6 +4230,38 @@
     "variant": "",
     "input": 0.5,
     "output": 3
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "vertex_ai/gemini-3.1-flash-lite",
+    "variant": "",
+    "input": 0.25,
+    "output": 1.5,
+    "cached_input": 0.025
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "vertex_ai/gemini-3.1-flash-lite",
+    "variant": "batches",
+    "input": 0.125,
+    "output": 0.75,
+    "cached_input": 0.0125
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "vertex_ai/gemini-3.1-flash-lite",
+    "variant": "flex",
+    "input": 0.125,
+    "output": 0.75,
+    "cached_input": 0.0125
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "vertex_ai/gemini-3.1-flash-lite",
+    "variant": "priority",
+    "input": 0.45,
+    "output": 2.7,
+    "cached_input": 0.045
   },
   {
     "provider": "Google/Vertex",
@@ -4297,6 +4433,13 @@
   {
     "provider": "Mistral",
     "model": "ministral-3-8b-2512",
+    "variant": "",
+    "input": 0.15,
+    "output": 0.15
+  },
+  {
+    "provider": "Mistral",
+    "model": "ministral-8b-2512",
     "variant": "",
     "input": 0.15,
     "output": 0.15
@@ -6586,6 +6729,14 @@
   },
   {
     "provider": "OpenRouter",
+    "model": "google/gemini-3.1-flash-lite",
+    "variant": "",
+    "input": 0.25,
+    "output": 1.5,
+    "cached_input": 0.025
+  },
+  {
+    "provider": "OpenRouter",
     "model": "google/gemini-3.1-flash-lite-preview",
     "variant": "",
     "input": 0.25,
@@ -7027,9 +7178,25 @@
     "provider": "OpenRouter",
     "model": "xiaomi/mimo-v2-flash",
     "variant": "",
-    "input": 0.09,
-    "output": 0.29,
-    "cached_input": 0
+    "input": 0.1,
+    "output": 0.3,
+    "cached_input": 0.01
+  },
+  {
+    "provider": "OpenRouter",
+    "model": "xiaomi/mimo-v2.5",
+    "variant": "",
+    "input": 0.4,
+    "output": 2,
+    "cached_input": 0.08
+  },
+  {
+    "provider": "OpenRouter",
+    "model": "xiaomi/mimo-v2.5-pro",
+    "variant": "",
+    "input": 1,
+    "output": 3,
+    "cached_input": 0.2
   },
   {
     "provider": "OpenRouter",

--- a/chatlas/types/anthropic/_submit.py
+++ b/chatlas/types/anthropic/_submit.py
@@ -40,6 +40,7 @@ class SubmitInputArgs(TypedDict, total=False):
     messages: Iterable[anthropic.types.message_param.MessageParam]
     model: Union[
         Literal[
+            "claude-opus-4-8",
             "claude-opus-4-7",
             "claude-mythos-preview",
             "claude-opus-4-6",

--- a/chatlas/types/openai/_submit_responses.py
+++ b/chatlas/types/openai/_submit_responses.py
@@ -89,6 +89,7 @@ class SubmitInputArgs(TypedDict, total=False):
                 openai.types.responses.response_input_param.FunctionCallOutput,
                 openai.types.responses.response_input_param.ToolSearchCall,
                 openai.types.responses.response_tool_search_output_item_param_param.ResponseToolSearchOutputItemParamParam,
+                openai.types.responses.response_input_param.AdditionalTools,
                 openai.types.responses.response_reasoning_item_param.ResponseReasoningItemParam,
                 openai.types.responses.response_compaction_item_param_param.ResponseCompactionItemParamParam,
                 openai.types.responses.response_input_param.ImageGenerationCall,

--- a/chatlas/types/openai/_submit_responses.py
+++ b/chatlas/types/openai/_submit_responses.py
@@ -105,6 +105,7 @@ class SubmitInputArgs(TypedDict, total=False):
                 openai.types.responses.response_input_param.McpCall,
                 openai.types.responses.response_custom_tool_call_output_param.ResponseCustomToolCallOutputParam,
                 openai.types.responses.response_custom_tool_call_param.ResponseCustomToolCallParam,
+                openai.types.responses.response_input_param.CompactionTrigger,
                 openai.types.responses.response_input_param.ItemReference,
             ]
         ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ test = [
     "syrupy>=4",
     "vcrpy>=6.0.0",
     "pytest-recording>=0.13",
+    # vcrpy's aiohttp stub breaks on aiohttp 3.14+ (it references the removed
+    # `aiohttp.streams.AsyncStreamReaderMixin`). Cap until vcrpy supports it.
+    "aiohttp<3.14",
 ]
 dev = [
     "ruff>=0.6.5",

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -77,8 +77,7 @@ def test_model_property_get_and_set():
     assert chat.model == "gpt-4o"
     assert chat.provider.model == "gpt-4o"
 
-    # Setting the model updates both the Chat and the underlying provider.
-    # No validation is performed (matching ellmer's set_model()).
+    # The model name is intentionally not validated.
     chat.model = "some-unvalidated-model"
     assert chat.model == "some-unvalidated-model"
     assert chat.provider.model == "some-unvalidated-model"

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -72,6 +72,18 @@ async def test_simple_streaming_chat_async():
     assert re.match(rainbow_re, turn.text.lower())
 
 
+def test_model_property_get_and_set():
+    chat = ChatOpenAI(model="gpt-4o")
+    assert chat.model == "gpt-4o"
+    assert chat.provider.model == "gpt-4o"
+
+    # Setting the model updates both the Chat and the underlying provider.
+    # No validation is performed (matching ellmer's set_model()).
+    chat.model = "some-unvalidated-model"
+    assert chat.model == "some-unvalidated-model"
+    assert chat.provider.model == "some-unvalidated-model"
+
+
 def test_basic_repr(snapshot):
     chat = ChatOpenAI(
         system_prompt="You're a helpful assistant that returns very minimal output",

--- a/tests/test_provider_anthropic.py
+++ b/tests/test_provider_anthropic.py
@@ -303,3 +303,42 @@ def test_anthropic_nested_data_model_extraction():
         assert 0.0 <= classification.score <= 1.0, (
             f"Score {classification.score} should be between 0 and 1"
         )
+
+
+def test_anthropic_reasoning_int_budget():
+    """An int `reasoning` maps to a fixed thinking budget (regression)."""
+    chat = ChatAnthropic(reasoning=2048)
+    assert chat.kwargs_chat == {"thinking": {"type": "enabled", "budget_tokens": 2048}}
+
+
+def test_anthropic_reasoning_effort_string():
+    """A string `reasoning` enables adaptive thinking via output_config (#997)."""
+    chat = ChatAnthropic(reasoning="high")
+    assert chat.kwargs_chat == {
+        "thinking": {"type": "adaptive"},
+        "output_config": {"effort": "high"},
+    }
+
+
+def test_anthropic_adaptive_effort_merges_with_structured_output():
+    """When extracting data, adaptive effort merges into the native output_config."""
+
+    class Person(BaseModel):
+        name: str
+
+    provider = AnthropicProvider(
+        model="claude-sonnet-4-6", structured_output_mode="native"
+    )
+    args = provider._chat_perform_args(
+        stream=False,
+        turns=[],
+        tools={},
+        data_model=Person,
+        kwargs={
+            "thinking": {"type": "adaptive"},
+            "output_config": {"effort": "high"},
+        },
+    )
+    output_config = args["output_config"]
+    assert output_config["effort"] == "high"
+    assert output_config["format"]["type"] == "json_schema"

--- a/tests/test_provider_google.py
+++ b/tests/test_provider_google.py
@@ -27,6 +27,24 @@ def chat_func(vertex: bool = False, **kwargs):
     return chat
 
 
+def test_google_reasoning_effort_string():
+    """A string `reasoning` maps to thinking_level (#998)."""
+    chat = ChatGoogle(reasoning="low")
+    assert chat.kwargs_chat["config"]["thinking_config"] == {
+        "thinking_level": "low",
+        "include_thoughts": True,
+    }
+
+
+def test_google_reasoning_int_budget():
+    """An int `reasoning` still maps to thinking_budget."""
+    chat = ChatGoogle(reasoning=1024)
+    assert chat.kwargs_chat["config"]["thinking_config"] == {
+        "thinking_budget": 1024,
+        "include_thoughts": True,
+    }
+
+
 # https://github.com/googleapis/python-genai/issues/336
 def _is_retryable_error(exception: BaseException) -> bool:
     """

--- a/tests/test_provider_google.py
+++ b/tests/test_provider_google.py
@@ -28,10 +28,12 @@ def chat_func(vertex: bool = False, **kwargs):
 
 
 def test_google_reasoning_effort_string():
-    """A string `reasoning` maps to thinking_level (#998)."""
+    """A string `reasoning` maps to a `thinking_level` enum (#998)."""
+    from google.genai.types import ThinkingLevel
+
     chat = ChatGoogle(reasoning="low")
     assert chat.kwargs_chat["config"]["thinking_config"] == {
-        "thinking_level": "low",
+        "thinking_level": ThinkingLevel.LOW,
         "include_thoughts": True,
     }
 

--- a/tests/test_provider_openai_completions.py
+++ b/tests/test_provider_openai_completions.py
@@ -152,7 +152,52 @@ def test_response_as_turn_extracts_reasoning_content():
 
     completion = Mock()
     message = Mock()
+    message.reasoning = None
     message.reasoning_content = "Let me think..."
+    message.content = "The answer is 42."
+    message.tool_calls = None
+    completion.choices = [Mock(message=message, finish_reason="stop")]
+
+    turn = OpenAICompletionsProvider._response_as_turn(completion, has_data_model=False)
+    assert len(turn.contents) == 2
+    assert isinstance(turn.contents[0], ContentThinking)
+    assert turn.contents[0].thinking == "Let me think..."
+    assert isinstance(turn.contents[1], ContentText)
+    assert turn.contents[1].text == "The answer is 42."
+
+
+def test_stream_content_extracts_reasoning_field():
+    """Ollama (e.g. qwen3) returns thinking in a `reasoning` field (#981)."""
+    provider = OpenAICompletionsProvider(model="test")
+
+    class FakeDelta:
+        def __init__(self, reasoning=None, reasoning_content=None, content=None):
+            self.reasoning = reasoning
+            self.reasoning_content = reasoning_content
+            self.content = content
+
+    class FakeChoice:
+        def __init__(self, delta):
+            self.delta = delta
+
+    class FakeChunk:
+        def __init__(self, choices):
+            self.choices = choices
+
+    chunk = FakeChunk([FakeChoice(FakeDelta(reasoning="think"))])
+    result = provider.stream_content(chunk)
+    assert isinstance(result, ContentThinkingDelta)
+    assert result.thinking == "think"
+
+
+def test_response_as_turn_extracts_reasoning_field():
+    """Ollama (e.g. qwen3) returns thinking in a `reasoning` field (#981)."""
+    from unittest.mock import Mock
+
+    completion = Mock()
+    message = Mock()
+    message.reasoning = "Let me think..."
+    message.reasoning_content = None
     message.content = "The answer is 42."
     message.tool_calls = None
     completion.choices = [Mock(message=message, finish_reason="stop")]
@@ -208,6 +253,7 @@ def test_response_as_turn_treats_empty_content_as_none():
 
     completion = Mock()
     message = Mock()
+    message.reasoning = None
     message.reasoning_content = None
     message.content = ""
     message.tool_calls = [


### PR DESCRIPTION
## What this does

Three independent quality-of-life improvements:

**Switch models without rebuilding a chat.** `Chat` now exposes a `model` property you can read or assign:
```python
chat = ChatOpenAI(model="gpt-4o")
chat.model = "gpt-5"   # subsequent requests use the new model
```
The name isn't validated, so you're free to point at any model the provider accepts.

**Set reasoning effort by name on Google and Anthropic.** Both `reasoning=` parameters now accept a string effort level in addition to an integer token budget — matching how `ChatOpenAI(reasoning=)` already works:
```python
ChatGoogle(reasoning="low")       # maps to Gemini's thinking level
ChatAnthropic(reasoning="high")   # enables Claude's adaptive thinking
```
Integer token budgets and full config dicts continue to work unchanged.

**Stop silently dropping thinking from Ollama-style models.** Some OpenAI-compatible models (e.g. qwen3 via Ollama) return their reasoning in a `reasoning` field rather than `reasoning_content`. chatlas only read `reasoning_content`, so that thinking was lost. It's now captured in both streaming and non-streaming responses.

## Implementation notes

- Claude adaptive thinking is scoped to `ChatAnthropic` (not `ChatBedrockAnthropic`); the effort is merged into `output_config` so it coexists with native structured outputs.
- Existing behavior is unchanged: integer budgets and config dicts still work exactly as before.
- New unit tests cover each change; the affected test suites pass and `pyright` is clean.

## Provenance

These port recent improvements from the sibling R package, ellmer:

- `Chat.model` property — [tidyverse/ellmer#992](https://github.com/tidyverse/ellmer/pull/992)
- Google string reasoning level — [tidyverse/ellmer#998](https://github.com/tidyverse/ellmer/pull/998)
- Anthropic adaptive thinking — [tidyverse/ellmer#997](https://github.com/tidyverse/ellmer/pull/997)
- Ollama `reasoning` field capture — [tidyverse/ellmer#981](https://github.com/tidyverse/ellmer/pull/981)