### PR TITLE
Regenerate OpenAI types for new moderation param

### DIFF
--- a/chatlas/types/openai/_submit.py
+++ b/chatlas/types/openai/_submit.py
@@ -141,6 +141,9 @@ class SubmitInputArgs(TypedDict, total=False):
     max_tokens: Union[int, None, openai.Omit]
     metadata: Union[dict[str, str], None, openai.Omit]
     modalities: Union[list[Literal["text", "audio"]], None, openai.Omit]
+    moderation: Union[
+        openai.types.chat.completion_create_params.Moderation, None, openai.Omit
+    ]
     n: Union[int, None, openai.Omit]
     parallel_tool_calls: bool | openai.Omit
     prediction: Union[

--- a/chatlas/types/openai/_submit_responses.py
+++ b/chatlas/types/openai/_submit_responses.py
@@ -216,6 +216,9 @@ class SubmitInputArgs(TypedDict, total=False):
         ],
         openai.Omit,
     ]
+    moderation: Union[
+        openai.types.responses.response_create_params.Moderation, None, openai.Omit
+    ]
     parallel_tool_calls: Union[bool, None, openai.Omit]
     previous_response_id: Union[str, None, openai.Omit]
     prompt: Union[


### PR DESCRIPTION
## Why this matters

The **Check Provider Types** CI gate is currently red on `main`. `openai` 2.41.0 (released 2026-06-04) added a `moderation` create-param to both the chat-completions and responses APIs. Because `uv.lock` is gitignored, CI always resolves dependencies fresh and now installs 2.41.0, so its `make update-types` run produces a diff against the committed stubs and fails the build.

This regenerates the affected stubs so the gate passes again — and so the generated parameter types stay in sync with the SDK callers actually get.

## What changed

`make update-types` output for `openai` 2.41.0: a `moderation` field added to `SubmitInputArgs` in both `chatlas/types/openai/_submit.py` and `_submit_responses.py`. Nothing else.