### PR TITLE
Add ChatPosit provider for Posit AI gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### New features
 
+* Added `ChatPosit()` for chatting via the [Posit AI](https://posit.ai/) gateway. (#323)
 
 ## [0.19.0] - 2026-06-15
 

--- a/chatlas/__init__.py
+++ b/chatlas/__init__.py
@@ -33,6 +33,7 @@ from ._provider_openai_completions import ChatOpenAICompletions
 from ._provider_openrouter import ChatOpenRouter
 from ._provider_perplexity import ChatPerplexity
 from ._provider_portkey import ChatPortkey
+from ._provider_posit import ChatPosit
 from ._provider_snowflake import ChatSnowflake
 from ._stream_controller import StreamController
 from ._tokens import token_usage
@@ -73,6 +74,7 @@ __all__ = (
     "ChatAzureOpenAICompletions",
     "ChatPerplexity",
     "ChatPortkey",
+    "ChatPosit",
     "ChatSnowflake",
     "ChatVertex",
     "Chat",

--- a/chatlas/_auto.py
+++ b/chatlas/_auto.py
@@ -24,6 +24,7 @@ from ._provider_openai_completions import ChatOpenAICompletions
 from ._provider_openrouter import ChatOpenRouter
 from ._provider_perplexity import ChatPerplexity
 from ._provider_portkey import ChatPortkey
+from ._provider_posit import ChatPosit
 from ._provider_snowflake import ChatSnowflake
 from ._utils import MISSING_TYPE as DEPRECATED_TYPE
 
@@ -48,6 +49,7 @@ AutoProviders = Literal[
     "open-router",
     "perplexity",
     "portkey",
+    "posit",
     "snowflake",
     "vertex",
 ]
@@ -73,6 +75,7 @@ _provider_chat_model_map: dict[AutoProviders, Callable[..., Chat]] = {
     "open-router": ChatOpenRouter,
     "perplexity": ChatPerplexity,
     "portkey": ChatPortkey,
+    "posit": ChatPosit,
     "snowflake": ChatSnowflake,
     "vertex": ChatVertex,
 }

--- a/chatlas/_provider_posit.py
+++ b/chatlas/_provider_posit.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import sys
 import time
 import webbrowser
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
+import httpx
 import requests
 from platformdirs import user_cache_dir
 
@@ -135,3 +137,81 @@ class PositCredentials:
                 resp.raise_for_status()
 
         raise TimeoutError("Timed out waiting for Posit AI device-flow login.")
+
+
+def _safe_json(response: Any) -> Optional[dict[str, Any]]:
+    try:
+        return response.json()
+    except ValueError:
+        return None
+
+
+def _posit_error_message(
+    status_code: int, body: Optional[dict[str, Any]]
+) -> Optional[str]:
+    if status_code == 402:
+        return "Your Posit AI credits are depleted."
+
+    if body is None:
+        return None
+
+    error = body.get("error")
+    error_type = body.get("error_type")
+    if error_type is None and isinstance(error, dict):
+        error_type = error.get("error_type")
+
+    if error_type == "prism_account_not_found":
+        return (
+            "You must finish setting up your Posit AI account before using the "
+            "API. Visit https://posit.ai/ to accept the service agreement."
+        )
+
+    return None
+
+
+class PositAuth(httpx.Auth):
+    """
+    Turns a bearer-token callable into `Authorization: Bearer` headers on
+    every request, overriding any `x-api-key` header a client set by default.
+    """
+
+    def __init__(self, credentials: Callable[[], str]):
+        self._credentials = credentials
+
+    def _apply(self, request: httpx.Request, token: str) -> None:
+        request.headers.pop("x-api-key", None)
+        request.headers["Authorization"] = f"Bearer {token}"
+
+    def sync_auth_flow(self, request: httpx.Request):
+        token = self._credentials()
+        self._apply(request, token)
+        yield request
+
+    async def async_auth_flow(self, request: httpx.Request):
+        token = await asyncio.to_thread(self._credentials)
+        self._apply(request, token)
+        yield request
+
+
+def _make_posit_error_hook(error_cls: type[Exception]):
+    def hook(response: httpx.Response) -> None:
+        if response.status_code < 400:
+            return
+        response.read()
+        message = _posit_error_message(response.status_code, _safe_json(response))
+        if message is not None:
+            raise error_cls(message)
+
+    return hook
+
+
+def _make_posit_error_hook_async(error_cls: type[Exception]):
+    async def hook(response: httpx.Response) -> None:
+        if response.status_code < 400:
+            return
+        await response.aread()
+        message = _posit_error_message(response.status_code, _safe_json(response))
+        if message is not None:
+            raise error_cls(message)
+
+    return hook

--- a/chatlas/_provider_posit.py
+++ b/chatlas/_provider_posit.py
@@ -13,6 +13,8 @@ import httpx
 import requests
 from platformdirs import user_cache_dir
 
+from ._chat import Chat
+from ._logging import log_model_default
 from ._provider import ModelInfo
 from ._provider_anthropic import AnthropicProvider, StructuredOutputMode
 from ._provider_openai_completions import OpenAICompletionsProvider
@@ -338,3 +340,99 @@ class PositOpenAIProvider(OpenAICompletionsProvider):
 
     def list_models(self) -> list[ModelInfo]:
         return list_models_posit(self._gateway_base_url, self._credentials)
+
+
+def ChatPosit(
+    *,
+    system_prompt: Optional[str] = None,
+    base_url: str = "https://gateway.posit.ai",
+    model: Optional[str] = None,
+    credentials: Optional[Callable[[], str]] = None,
+    cache: Literal["5m", "1h", "none"] = "5m",
+) -> "Chat[Any, Any]":
+    """
+    Chat with a model hosted by Posit AI.
+
+    [Posit AI](https://posit.ai) provides access to a curated set of models
+    for Posit subscribers. The gateway exposes two API flavors: Claude models
+    are served via the Anthropic Messages API and all other models are
+    served via an OpenAI-compatible API. `ChatPosit()` automatically picks
+    the appropriate flavor based on the model name.
+
+    Prerequisites
+    -------------
+
+    ::: {.callout-note}
+    ## Python requirements
+
+    `ChatPosit` requires the `anthropic` package: `pip install "chatlas[posit]"`.
+    :::
+
+    ::: {.callout-note}
+    ## Authentication
+
+    By default, `ChatPosit()` authenticates with an OAuth device flow
+    against `login.posit.cloud`: the first time you use it, you'll be
+    prompted to visit a URL and enter a code. The resulting tokens are
+    cached on disk and refreshed automatically, so you should only need to
+    do this once per machine.
+    :::
+
+    Examples
+    --------
+
+    ```python
+    from chatlas import ChatPosit
+
+    chat = ChatPosit()
+    chat.chat("Tell me three jokes about statisticians")
+    ```
+
+    Parameters
+    ----------
+    system_prompt
+        A system prompt to set the behavior of the assistant.
+    base_url
+        The base URL of the Posit AI gateway.
+    model
+        The model to use for the chat. The default, None, will pick a
+        reasonable default, and warn you about it. We strongly recommend
+        explicitly choosing a model for all but the most casual use.
+    credentials
+        A zero-argument function that returns a bearer token string. If
+        omitted, `ChatPosit()` manages the OAuth device-flow login and its
+        on-disk token cache automatically.
+    cache
+        How long to cache inputs? Defaults to "5m" (five minutes). Only
+        applies when a Claude model is selected. See `ChatAnthropic` for
+        details.
+
+    Returns
+    -------
+    Chat
+        A chat object that retains the state of the conversation. Note that
+        the concrete provider (and hence some response-object typing
+        precision) depends on whether a Claude model or another model was
+        selected.
+    """
+    if model is None:
+        model = log_model_default("claude-sonnet-4-6")
+
+    token_provider = credentials or PositCredentials().get_token
+
+    provider: "PositAnthropicProvider | PositOpenAIProvider"
+    if model.startswith("claude"):
+        provider = PositAnthropicProvider(
+            base_url=base_url,
+            model=model,
+            credentials=token_provider,
+            cache=cache,
+        )
+    else:
+        provider = PositOpenAIProvider(
+            base_url=base_url,
+            model=model,
+            credentials=token_provider,
+        )
+
+    return Chat(provider=provider, system_prompt=system_prompt)

--- a/chatlas/_provider_posit.py
+++ b/chatlas/_provider_posit.py
@@ -7,11 +7,15 @@ import sys
 import time
 import webbrowser
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Literal, Optional
 
 import httpx
 import requests
 from platformdirs import user_cache_dir
+
+from ._provider import ModelInfo
+from ._provider_anthropic import AnthropicProvider, StructuredOutputMode
+from ._provider_openai_completions import OpenAICompletionsProvider
 
 DEVICE_AUTHORIZE_URL = "https://login.posit.cloud/oauth/device/authorize"
 TOKEN_URL = "https://login.posit.cloud/oauth/token"
@@ -215,3 +219,122 @@ def _make_posit_error_hook_async(error_cls: type[Exception]):
             raise error_cls(message)
 
     return hook
+
+
+def list_models_posit(
+    base_url: str = "https://gateway.posit.ai",
+    credentials: Optional[Callable[[], str]] = None,
+) -> list[ModelInfo]:
+    token_provider = credentials or PositCredentials().get_token
+
+    resp = requests.get(
+        f"{base_url.rstrip('/')}/models",
+        headers={"Authorization": f"Bearer {token_provider()}"},
+    )
+
+    if not resp.ok:
+        message = _posit_error_message(resp.status_code, _safe_json(resp))
+        if message is not None:
+            raise RuntimeError(message)
+        resp.raise_for_status()
+
+    data = resp.json()
+
+    res: list[ModelInfo] = []
+    for m in data.get("chat", []):
+        info: ModelInfo = {"id": m["id"], "name": m.get("display_name", m["id"])}
+        res.append(info)
+
+    return res
+
+
+class PositAnthropicProvider(AnthropicProvider):
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        model: str,
+        credentials: Callable[[], str],
+        max_tokens: int = 4096,
+        cache: Literal["5m", "1h", "none"] = "5m",
+        structured_output_mode: StructuredOutputMode = "auto",
+        name: str = "Posit",
+    ):
+        super().__init__(
+            model=model,
+            api_key="not-used",
+            max_tokens=max_tokens,
+            cache=cache,
+            structured_output_mode=structured_output_mode,
+            name=name,
+        )
+
+        from anthropic import Anthropic, AnthropicError, AsyncAnthropic
+
+        self._gateway_base_url = base_url.rstrip("/")
+        self._credentials = credentials
+
+        auth = PositAuth(credentials)
+        flavor_base_url = f"{self._gateway_base_url}/anthropic/v1"
+
+        self._client = Anthropic(
+            api_key="not-used",
+            base_url=flavor_base_url,
+            http_client=httpx.Client(
+                auth=auth,
+                event_hooks={"response": [_make_posit_error_hook(AnthropicError)]},
+            ),
+        )
+        self._async_client = AsyncAnthropic(
+            api_key="not-used",
+            base_url=flavor_base_url,
+            http_client=httpx.AsyncClient(
+                auth=auth,
+                event_hooks={
+                    "response": [_make_posit_error_hook_async(AnthropicError)]
+                },
+            ),
+        )
+
+    def list_models(self) -> list[ModelInfo]:
+        return list_models_posit(self._gateway_base_url, self._credentials)
+
+
+class PositOpenAIProvider(OpenAICompletionsProvider):
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        model: str,
+        credentials: Callable[[], str],
+        name: str = "Posit",
+    ):
+        super().__init__(model=model, api_key="not-used", name=name)
+
+        from openai import AsyncOpenAI, OpenAI, OpenAIError
+
+        self._gateway_base_url = base_url.rstrip("/")
+        self._credentials = credentials
+
+        auth = PositAuth(credentials)
+        flavor_base_url = f"{self._gateway_base_url}/openai/v1"
+
+        self._client = OpenAI(
+            api_key="not-used",
+            base_url=flavor_base_url,
+            http_client=httpx.Client(
+                auth=auth,
+                event_hooks={"response": [_make_posit_error_hook(OpenAIError)]},
+            ),
+        )
+        self._async_client = AsyncOpenAI(
+            api_key="not-used",
+            base_url=flavor_base_url,
+            http_client=httpx.AsyncClient(
+                auth=auth,
+                event_hooks={"response": [_make_posit_error_hook_async(OpenAIError)]},
+            ),
+        )
+
+    def list_models(self) -> list[ModelInfo]:
+        return list_models_posit(self._gateway_base_url, self._credentials)

--- a/chatlas/_provider_posit.py
+++ b/chatlas/_provider_posit.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import webbrowser
+from pathlib import Path
+from typing import Any, Optional
+
+import requests
+from platformdirs import user_cache_dir
+
+DEVICE_AUTHORIZE_URL = "https://login.posit.cloud/oauth/device/authorize"
+TOKEN_URL = "https://login.posit.cloud/oauth/token"
+OAUTH_CLIENT_ID = "rstudio-ide"
+OAUTH_SCOPE = "prism"
+
+
+def is_interactive() -> bool:
+    return sys.stdin.isatty()
+
+
+def token_from_response(data: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "access_token": data["access_token"],
+        "refresh_token": data.get("refresh_token"),
+        "expires_at": time.time() + data.get("expires_in", 3600),
+    }
+
+
+class PositCredentials:
+    """
+    Manages a cached OAuth (RFC 8628 device-flow) access token for the Posit
+    AI gateway, refreshing or re-authenticating as needed.
+    """
+
+    def __init__(self, cache_path: Optional[Path] = None):
+        self._cache_path = cache_path or (
+            Path(user_cache_dir("chatlas")) / "posit-credentials.json"
+        )
+
+    def get_token(self) -> str:
+        cached = self._read_cache()
+
+        if cached is not None and cached.get("expires_at", 0) - time.time() > 60:
+            return cached["access_token"]
+
+        if cached is not None and cached.get("refresh_token"):
+            try:
+                token = self._refresh(cached["refresh_token"])
+                self._write_cache(token)
+                return token["access_token"]
+            except requests.HTTPError:
+                pass
+
+        token = self._device_flow()
+        self._write_cache(token)
+        return token["access_token"]
+
+    def _read_cache(self) -> Optional[dict[str, Any]]:
+        if not self._cache_path.exists():
+            return None
+        try:
+            return json.loads(self._cache_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            return None
+
+    def _write_cache(self, token: dict[str, Any]) -> None:
+        self._cache_path.parent.mkdir(parents=True, exist_ok=True)
+        self._cache_path.write_text(json.dumps(token))
+        os.chmod(self._cache_path, 0o600)
+
+    def _refresh(self, refresh_token: str) -> dict[str, Any]:
+        resp = requests.post(
+            TOKEN_URL,
+            data={
+                "grant_type": "refresh_token",
+                "refresh_token": refresh_token,
+                "client_id": OAUTH_CLIENT_ID,
+            },
+        )
+        resp.raise_for_status()
+        return token_from_response(resp.json())
+
+    def _device_flow(self) -> dict[str, Any]:
+        resp = requests.post(
+            DEVICE_AUTHORIZE_URL,
+            data={"client_id": OAUTH_CLIENT_ID, "scope": OAUTH_SCOPE},
+        )
+        resp.raise_for_status()
+        device = resp.json()
+
+        verification_uri = (
+            device.get("verification_uri_complete") or device["verification_uri"]
+        )
+        print(f"Visit {verification_uri} and enter code {device['user_code']}")
+        if is_interactive():
+            try:
+                webbrowser.open(verification_uri)
+            except Exception:
+                pass
+
+        interval = device.get("interval", 5)
+        deadline = time.time() + device.get("expires_in", 600)
+
+        while time.time() < deadline:
+            time.sleep(interval)
+
+            resp = requests.post(
+                TOKEN_URL,
+                data={
+                    "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+                    "device_code": device["device_code"],
+                    "client_id": OAUTH_CLIENT_ID,
+                },
+            )
+            body = resp.json()
+
+            if resp.status_code == 200:
+                return token_from_response(body)
+
+            error = body.get("error")
+            if error == "slow_down":
+                interval += 5
+            elif error == "authorization_pending":
+                continue
+            elif error == "expired_token":
+                raise TimeoutError(
+                    "Posit AI device-flow login expired before it was confirmed."
+                )
+            elif error == "access_denied":
+                raise PermissionError("Posit AI device-flow login was denied.")
+            else:
+                resp.raise_for_status()
+
+        raise TimeoutError("Timed out waiting for Posit AI device-flow login.")

--- a/chatlas/_provider_posit.py
+++ b/chatlas/_provider_posit.py
@@ -373,7 +373,8 @@ def ChatPosit(
     ::: {.callout-note}
     ## Python requirements
 
-    `ChatPosit` requires the `anthropic` package: `pip install "chatlas[posit]"`.
+    Claude models require the `anthropic` package: `pip install "chatlas[posit]"`.
+    OpenAI-compatible models work with the base `chatlas` install.
     :::
 
     ::: {.callout-note}

--- a/chatlas/_provider_posit.py
+++ b/chatlas/_provider_posit.py
@@ -22,6 +22,9 @@ from ._provider_openai_completions import OpenAICompletionsProvider
 DEVICE_AUTHORIZE_URL = "https://login.posit.cloud/oauth/device/authorize"
 TOKEN_URL = "https://login.posit.cloud/oauth/token"
 OAUTH_CLIENT_ID = "rstudio-ide"
+# posit.cloud only mints a gateway-authorized token when this is sent on
+# every token exchange (device-code poll and refresh), not just the
+# initial device authorize request.
 OAUTH_SCOPE = "prism"
 
 
@@ -86,6 +89,7 @@ class PositCredentials:
                 "grant_type": "refresh_token",
                 "refresh_token": refresh_token,
                 "client_id": OAUTH_CLIENT_ID,
+                "scope": OAUTH_SCOPE,
             },
         )
         resp.raise_for_status()
@@ -121,6 +125,7 @@ class PositCredentials:
                     "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
                     "device_code": device["device_code"],
                     "client_id": OAUTH_CLIENT_ID,
+                    "scope": OAUTH_SCOPE,
                 },
             )
             body = resp.json()
@@ -277,7 +282,10 @@ class PositAnthropicProvider(AnthropicProvider):
         self._credentials = credentials
 
         auth = PositAuth(credentials)
-        flavor_base_url = f"{self._gateway_base_url}/anthropic/v1"
+        # The anthropic SDK appends "/v1/messages" to base_url itself, so
+        # this must not also include "/v1" (unlike the OpenAI flavor below,
+        # whose SDK already includes "/v1" in its default base_url).
+        flavor_base_url = f"{self._gateway_base_url}/anthropic"
 
         self._client = Anthropic(
             api_key="not-used",

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -159,6 +159,7 @@ quartodoc:
         - ChatOpenRouter
         - ChatPerplexity
         - ChatPortkey
+        - ChatPosit
         - ChatSnowflake
         - ChatVertex
     - title: The chat object

--- a/docs/_sidebar.yml
+++ b/docs/_sidebar.yml
@@ -20,6 +20,7 @@ website:
       - reference/ChatOpenRouter.qmd
       - reference/ChatPerplexity.qmd
       - reference/ChatPortkey.qmd
+      - reference/ChatPosit.qmd
       - reference/ChatSnowflake.qmd
       - reference/ChatVertex.qmd
       section: Chat model providers

--- a/docs/get-started/models.qmd
+++ b/docs/get-started/models.qmd
@@ -34,6 +34,7 @@ To see the pre-requisites for a given provider, visit the relevant usage page in
 | perplexity.ai            | [`ChatPerplexity()`](../reference/ChatPerplexity.qmd)   |    |
 | Cloudflare               | [`ChatCloudflare()`](../reference/ChatCloudflare.qmd)   |    |
 | Portkey                  | [`ChatPortkey()`](../reference/ChatPortkey.qmd)         | ✅ |
+| Posit AI                 | [`ChatPosit()`](../reference/ChatPosit.qmd)             | ✅ |
 
 
 ::: callout-tip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ ollama = []
 openai = []
 azure-openai = []
 perplexity = []
+posit = ["anthropic>=0.109.1"]
 # Version requirement avoids an install issue with recent Python versions.
 # Remove it when snowflake-ml-python can be installed without a requirement.
 snowflake = ["snowflake-ml-python<=1.9.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
   "requests",
+  "platformdirs",
   "pydantic>=2.0",
   "jinja2",
   "orjson",

--- a/tests/test_provider_posit.py
+++ b/tests/test_provider_posit.py
@@ -1,0 +1,208 @@
+import json
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+import pytest
+import requests
+
+from chatlas._provider_posit import PositCredentials
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, json_data: dict[str, Any]):
+        self.status_code = status_code
+        self._json_data = json_data
+
+    def json(self) -> dict[str, Any]:
+        return self._json_data
+
+    @property
+    def ok(self) -> bool:
+        return self.status_code < 400
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"status {self.status_code}")
+
+
+def test_get_token_returns_cached_token_when_not_expired(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    cache_path = tmp_path / "posit-credentials.json"
+    cache_path.write_text(
+        json.dumps(
+            {
+                "access_token": "cached-token",
+                "refresh_token": "cached-refresh",
+                "expires_at": time.time() + 3600,
+            }
+        )
+    )
+
+    def fail_if_called(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("should not make a network call for a fresh token")
+
+    monkeypatch.setattr("chatlas._provider_posit.requests.post", fail_if_called)
+
+    creds = PositCredentials(cache_path=cache_path)
+    assert creds.get_token() == "cached-token"
+
+
+def test_get_token_refreshes_expired_token(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    cache_path = tmp_path / "posit-credentials.json"
+    cache_path.write_text(
+        json.dumps(
+            {
+                "access_token": "old-token",
+                "refresh_token": "old-refresh",
+                "expires_at": time.time() - 10,
+            }
+        )
+    )
+
+    calls: list[dict[str, Any]] = []
+
+    def fake_post(url: str, data: Optional[dict[str, Any]] = None, **kwargs: Any):
+        calls.append({"url": url, "data": data})
+        return _FakeResponse(
+            200,
+            {
+                "access_token": "new-token",
+                "refresh_token": "new-refresh",
+                "expires_in": 3600,
+            },
+        )
+
+    monkeypatch.setattr("chatlas._provider_posit.requests.post", fake_post)
+
+    creds = PositCredentials(cache_path=cache_path)
+    assert creds.get_token() == "new-token"
+
+    assert len(calls) == 1
+    assert calls[0]["data"]["grant_type"] == "refresh_token"
+    assert calls[0]["data"]["refresh_token"] == "old-refresh"
+
+    cached = json.loads(cache_path.read_text())
+    assert cached["access_token"] == "new-token"
+
+
+def test_get_token_falls_back_to_device_flow_when_refresh_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    cache_path = tmp_path / "posit-credentials.json"
+    cache_path.write_text(
+        json.dumps(
+            {
+                "access_token": "old-token",
+                "refresh_token": "old-refresh",
+                "expires_at": time.time() - 10,
+            }
+        )
+    )
+
+    device_response = _FakeResponse(
+        200,
+        {
+            "device_code": "device-abc",
+            "user_code": "ABCD-1234",
+            "verification_uri": "https://login.posit.cloud/device",
+            "interval": 1,
+            "expires_in": 60,
+        },
+    )
+    poll_response = _FakeResponse(
+        200,
+        {"access_token": "fresh-token", "refresh_token": "fresh-refresh", "expires_in": 3600},
+    )
+
+    def fake_post(url: str, data: Optional[dict[str, Any]] = None, **kwargs: Any):
+        if data and data.get("grant_type") == "refresh_token":
+            raise requests.HTTPError("refresh failed")
+        if url.endswith("/device/authorize"):
+            return device_response
+        return poll_response
+
+    monkeypatch.setattr("chatlas._provider_posit.requests.post", fake_post)
+    monkeypatch.setattr("chatlas._provider_posit.time.sleep", lambda _: None)
+    monkeypatch.setattr("chatlas._provider_posit.is_interactive", lambda: False)
+
+    creds = PositCredentials(cache_path=cache_path)
+    assert creds.get_token() == "fresh-token"
+
+
+def test_get_token_runs_device_flow_when_no_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    cache_path = tmp_path / "posit-credentials.json"
+
+    device_response = _FakeResponse(
+        200,
+        {
+            "device_code": "device-abc",
+            "user_code": "ABCD-1234",
+            "verification_uri": "https://login.posit.cloud/device",
+            "interval": 1,
+            "expires_in": 60,
+        },
+    )
+    poll_response = _FakeResponse(
+        200, {"access_token": "new-token", "refresh_token": "new-refresh", "expires_in": 3600}
+    )
+    calls = {"count": 0}
+
+    def fake_post(url: str, data: Optional[dict[str, Any]] = None, **kwargs: Any):
+        calls["count"] += 1
+        if url.endswith("/device/authorize"):
+            return device_response
+        return poll_response
+
+    monkeypatch.setattr("chatlas._provider_posit.requests.post", fake_post)
+    monkeypatch.setattr("chatlas._provider_posit.time.sleep", lambda _: None)
+    monkeypatch.setattr("chatlas._provider_posit.is_interactive", lambda: False)
+
+    creds = PositCredentials(cache_path=cache_path)
+    assert creds.get_token() == "new-token"
+    assert calls["count"] == 2  # one authorize call, one poll call
+
+    assert cache_path.exists()
+    assert (cache_path.stat().st_mode & 0o777) == 0o600
+    cached = json.loads(cache_path.read_text())
+    assert cached["access_token"] == "new-token"
+
+
+def test_device_flow_handles_pending_and_slow_down(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    cache_path = tmp_path / "posit-credentials.json"
+
+    device_response = _FakeResponse(
+        200,
+        {
+            "device_code": "device-abc",
+            "user_code": "ABCD-1234",
+            "verification_uri": "https://login.posit.cloud/device",
+            "interval": 1,
+            "expires_in": 60,
+        },
+    )
+    responses = [
+        device_response,
+        _FakeResponse(400, {"error": "authorization_pending"}),
+        _FakeResponse(400, {"error": "slow_down"}),
+        _FakeResponse(200, {"access_token": "final-token", "expires_in": 3600}),
+    ]
+
+    def fake_post(url: str, data: Optional[dict[str, Any]] = None, **kwargs: Any):
+        return responses.pop(0)
+
+    sleep_calls: list[float] = []
+    monkeypatch.setattr("chatlas._provider_posit.requests.post", fake_post)
+    monkeypatch.setattr("chatlas._provider_posit.time.sleep", sleep_calls.append)
+    monkeypatch.setattr("chatlas._provider_posit.is_interactive", lambda: False)
+
+    creds = PositCredentials(cache_path=cache_path)
+    assert creds.get_token() == "final-token"
+    assert sleep_calls == [1, 1, 6]  # interval starts at 1s, +5s after slow_down

--- a/tests/test_provider_posit.py
+++ b/tests/test_provider_posit.py
@@ -127,7 +127,11 @@ def test_get_token_falls_back_to_device_flow_when_refresh_fails(
     )
     poll_response = _FakeResponse(
         200,
-        {"access_token": "fresh-token", "refresh_token": "fresh-refresh", "expires_in": 3600},
+        {
+            "access_token": "fresh-token",
+            "refresh_token": "fresh-refresh",
+            "expires_in": 3600,
+        },
     )
 
     def fake_post(url: str, data: Optional[dict[str, Any]] = None, **kwargs: Any):
@@ -161,7 +165,12 @@ def test_get_token_runs_device_flow_when_no_cache(
         },
     )
     poll_response = _FakeResponse(
-        200, {"access_token": "new-token", "refresh_token": "new-refresh", "expires_in": 3600}
+        200,
+        {
+            "access_token": "new-token",
+            "refresh_token": "new-refresh",
+            "expires_in": 3600,
+        },
     )
     calls = {"count": 0}
 
@@ -479,12 +488,16 @@ def test_chat_posit_custom_credentials_bypasses_device_flow(
     monkeypatch: pytest.MonkeyPatch,
 ):
     def fail_if_called(*args: Any, **kwargs: Any) -> Any:
-        raise AssertionError(
-            "should not hit the network when credentials= is supplied"
-        )
+        raise AssertionError("should not hit the network when credentials= is supplied")
 
     monkeypatch.setattr("chatlas._provider_posit.requests.post", fail_if_called)
 
     chat = ChatPosit(model="claude-sonnet-4-6", credentials=lambda: "test-token")
     assert isinstance(chat.provider, PositAnthropicProvider)
     assert chat.provider._credentials() == "test-token"
+
+
+def test_chat_posit_importable_from_package_root():
+    import chatlas
+
+    assert chatlas.ChatPosit is ChatPosit

--- a/tests/test_provider_posit.py
+++ b/tests/test_provider_posit.py
@@ -9,6 +9,7 @@ import pytest
 import requests
 from chatlas._provider import ModelInfo
 from chatlas._provider_posit import (
+    OAUTH_SCOPE,
     ChatPosit,
     PositAnthropicProvider,
     PositAuth,
@@ -96,6 +97,7 @@ def test_get_token_refreshes_expired_token(
     assert len(calls) == 1
     assert calls[0]["data"]["grant_type"] == "refresh_token"
     assert calls[0]["data"]["refresh_token"] == "old-refresh"
+    assert calls[0]["data"]["scope"] == OAUTH_SCOPE
 
     cached = json.loads(cache_path.read_text())
     assert cached["access_token"] == "new-token"
@@ -172,12 +174,12 @@ def test_get_token_runs_device_flow_when_no_cache(
             "expires_in": 3600,
         },
     )
-    calls = {"count": 0}
+    poll_calls: list[dict[str, Any]] = []
 
     def fake_post(url: str, data: Optional[dict[str, Any]] = None, **kwargs: Any):
-        calls["count"] += 1
         if url.endswith("/device/authorize"):
             return device_response
+        poll_calls.append({"url": url, "data": data})
         return poll_response
 
     monkeypatch.setattr("chatlas._provider_posit.requests.post", fake_post)
@@ -186,7 +188,8 @@ def test_get_token_runs_device_flow_when_no_cache(
 
     creds = PositCredentials(cache_path=cache_path)
     assert creds.get_token() == "new-token"
-    assert calls["count"] == 2  # one authorize call, one poll call
+    assert len(poll_calls) == 1
+    assert poll_calls[0]["data"]["scope"] == OAUTH_SCOPE
 
     assert cache_path.exists()
     assert (cache_path.stat().st_mode & 0o777) == 0o600
@@ -385,9 +388,11 @@ def test_posit_anthropic_provider_uses_anthropic_flavor_base_url():
         model="claude-sonnet-4-6",
         credentials=lambda: "test-token",
     )
+    # The anthropic SDK appends "/v1/messages" itself, so the base_url must
+    # not also include "/v1" or requests 404 against the gateway.
     assert (
         str(provider._client.base_url).rstrip("/")
-        == "https://gateway.posit.ai/anthropic/v1"
+        == "https://gateway.posit.ai/anthropic"
     )
 
 

--- a/tests/test_provider_posit.py
+++ b/tests/test_provider_posit.py
@@ -9,6 +9,7 @@ import pytest
 import requests
 from chatlas._provider import ModelInfo
 from chatlas._provider_posit import (
+    ChatPosit,
     PositAnthropicProvider,
     PositAuth,
     PositCredentials,
@@ -457,3 +458,33 @@ def test_list_models_posit_raises_friendly_error(monkeypatch: pytest.MonkeyPatch
 
     with pytest.raises(RuntimeError, match="credits are depleted"):
         list_models_posit(credentials=lambda: "test-token")
+
+
+def test_chat_posit_dispatches_to_anthropic_flavor():
+    chat = ChatPosit(model="claude-sonnet-4-6", credentials=lambda: "test-token")
+    assert isinstance(chat.provider, PositAnthropicProvider)
+
+
+def test_chat_posit_dispatches_to_openai_flavor():
+    chat = ChatPosit(model="qwen3-8b", credentials=lambda: "test-token")
+    assert isinstance(chat.provider, PositOpenAIProvider)
+
+
+def test_chat_posit_defaults_to_claude_sonnet():
+    chat = ChatPosit(credentials=lambda: "test-token")
+    assert chat.provider.model == "claude-sonnet-4-6"
+
+
+def test_chat_posit_custom_credentials_bypasses_device_flow(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    def fail_if_called(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError(
+            "should not hit the network when credentials= is supplied"
+        )
+
+    monkeypatch.setattr("chatlas._provider_posit.requests.post", fail_if_called)
+
+    chat = ChatPosit(model="claude-sonnet-4-6", credentials=lambda: "test-token")
+    assert isinstance(chat.provider, PositAnthropicProvider)
+    assert chat.provider._credentials() == "test-token"

--- a/tests/test_provider_posit.py
+++ b/tests/test_provider_posit.py
@@ -1,12 +1,19 @@
+import asyncio
 import json
 import time
 from pathlib import Path
 from typing import Any, Optional
 
+import httpx
 import pytest
 import requests
-
-from chatlas._provider_posit import PositCredentials
+from chatlas._provider_posit import (
+    PositAuth,
+    PositCredentials,
+    _make_posit_error_hook,
+    _make_posit_error_hook_async,
+    _posit_error_message,
+)
 
 
 class _FakeResponse:
@@ -206,3 +213,153 @@ def test_device_flow_handles_pending_and_slow_down(
     creds = PositCredentials(cache_path=cache_path)
     assert creds.get_token() == "final-token"
     assert sleep_calls == [1, 1, 6]  # interval starts at 1s, +5s after slow_down
+
+
+def test_posit_error_message_for_credits_depleted():
+    assert _posit_error_message(402, None) == "Your Posit AI credits are depleted."
+
+
+def test_posit_error_message_for_account_not_found():
+    message = _posit_error_message(403, {"error_type": "prism_account_not_found"})
+    assert message is not None
+    assert "service agreement" in message
+
+
+def test_posit_error_message_for_nested_account_not_found():
+    message = _posit_error_message(
+        403, {"error": {"error_type": "prism_account_not_found"}}
+    )
+    assert message is not None
+    assert "service agreement" in message
+
+
+def test_posit_error_message_returns_none_for_unrecognized_errors():
+    assert _posit_error_message(400, {"error": "bad request"}) is None
+    assert _posit_error_message(500, None) is None
+    assert _posit_error_message(403, {"error_type": "something_else"}) is None
+
+
+def test_posit_auth_sets_bearer_token_and_strips_api_key():
+    auth = PositAuth(lambda: "test-token")
+    request = httpx.Request("GET", "https://gateway.posit.ai/anthropic/v1/messages")
+    request.headers["x-api-key"] = "not-used"
+
+    flow = auth.sync_auth_flow(request)
+    sent_request = next(flow)
+
+    assert sent_request.headers["Authorization"] == "Bearer test-token"
+    assert "x-api-key" not in sent_request.headers
+
+
+def test_posit_auth_async_sets_bearer_token():
+    async def run() -> httpx.Request:
+        auth = PositAuth(lambda: "test-token")
+        request = httpx.Request(
+            "GET", "https://gateway.posit.ai/openai/v1/chat/completions"
+        )
+        flow = auth.async_auth_flow(request)
+        return await flow.__anext__()
+
+    sent_request = asyncio.run(run())
+    assert sent_request.headers["Authorization"] == "Bearer test-token"
+
+
+def test_anthropic_error_hook_propagates_through_client_send():
+    from anthropic import Anthropic, AnthropicError
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            403, json={"error_type": "prism_account_not_found"}, request=request
+        )
+
+    client = Anthropic(
+        api_key="not-used",
+        base_url="https://gateway.posit.ai/anthropic/v1",
+        http_client=httpx.Client(
+            auth=PositAuth(lambda: "test-token"),
+            transport=httpx.MockTransport(handler),
+            event_hooks={"response": [_make_posit_error_hook(AnthropicError)]},
+        ),
+    )
+
+    with pytest.raises(AnthropicError, match="service agreement"):
+        client.messages.create(
+            model="claude-sonnet-4-6",
+            max_tokens=10,
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+
+@pytest.mark.asyncio
+async def test_anthropic_error_hook_propagates_through_async_client_send():
+    from anthropic import AnthropicError, AsyncAnthropic
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            403, json={"error_type": "prism_account_not_found"}, request=request
+        )
+
+    client = AsyncAnthropic(
+        api_key="not-used",
+        base_url="https://gateway.posit.ai/anthropic/v1",
+        http_client=httpx.AsyncClient(
+            auth=PositAuth(lambda: "test-token"),
+            transport=httpx.MockTransport(handler),
+            event_hooks={"response": [_make_posit_error_hook_async(AnthropicError)]},
+        ),
+    )
+
+    with pytest.raises(AnthropicError, match="service agreement"):
+        await client.messages.create(
+            model="claude-sonnet-4-6",
+            max_tokens=10,
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+
+def test_openai_error_hook_propagates_through_client_send():
+    from openai import OpenAI, OpenAIError
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(402, json={}, request=request)
+
+    client = OpenAI(
+        api_key="not-used",
+        base_url="https://gateway.posit.ai/openai/v1",
+        http_client=httpx.Client(
+            auth=PositAuth(lambda: "test-token"),
+            transport=httpx.MockTransport(handler),
+            event_hooks={"response": [_make_posit_error_hook(OpenAIError)]},
+        ),
+    )
+
+    with pytest.raises(OpenAIError, match="credits are depleted"):
+        client.chat.completions.create(
+            model="qwen3-8b", messages=[{"role": "user", "content": "hi"}]
+        )
+
+
+def test_unrecognized_gateway_error_passes_through_unchanged():
+    from anthropic import Anthropic, APIStatusError
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"error": {"message": "boom"}}, request=request)
+
+    from anthropic import AnthropicError
+
+    client = Anthropic(
+        api_key="not-used",
+        base_url="https://gateway.posit.ai/anthropic/v1",
+        http_client=httpx.Client(
+            auth=PositAuth(lambda: "test-token"),
+            transport=httpx.MockTransport(handler),
+            event_hooks={"response": [_make_posit_error_hook(AnthropicError)]},
+        ),
+    )
+
+    with pytest.raises(APIStatusError):
+        client.messages.create(
+            model="claude-sonnet-4-6",
+            max_tokens=10,
+            messages=[{"role": "user", "content": "hi"}],
+        )

--- a/tests/test_provider_posit.py
+++ b/tests/test_provider_posit.py
@@ -7,12 +7,16 @@ from typing import Any, Optional
 import httpx
 import pytest
 import requests
+from chatlas._provider import ModelInfo
 from chatlas._provider_posit import (
+    PositAnthropicProvider,
     PositAuth,
     PositCredentials,
+    PositOpenAIProvider,
     _make_posit_error_hook,
     _make_posit_error_hook_async,
     _posit_error_message,
+    list_models_posit,
 )
 
 
@@ -363,3 +367,93 @@ def test_unrecognized_gateway_error_passes_through_unchanged():
             max_tokens=10,
             messages=[{"role": "user", "content": "hi"}],
         )
+
+
+def test_posit_anthropic_provider_uses_anthropic_flavor_base_url():
+    provider = PositAnthropicProvider(
+        base_url="https://gateway.posit.ai",
+        model="claude-sonnet-4-6",
+        credentials=lambda: "test-token",
+    )
+    assert (
+        str(provider._client.base_url).rstrip("/")
+        == "https://gateway.posit.ai/anthropic/v1"
+    )
+
+
+def test_posit_openai_provider_uses_openai_flavor_base_url():
+    provider = PositOpenAIProvider(
+        base_url="https://gateway.posit.ai",
+        model="qwen3-8b",
+        credentials=lambda: "test-token",
+    )
+    assert (
+        str(provider._client.base_url).rstrip("/")
+        == "https://gateway.posit.ai/openai/v1"
+    )
+
+
+def test_posit_provider_list_models_delegates_to_list_models_posit(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    provider = PositAnthropicProvider(
+        base_url="https://gateway.posit.ai",
+        model="claude-sonnet-4-6",
+        credentials=lambda: "test-token",
+    )
+
+    captured: dict[str, Any] = {}
+
+    def fake_list_models_posit(base_url: str, credentials: Any) -> list[ModelInfo]:
+        captured["base_url"] = base_url
+        captured["credentials"] = credentials
+        return [{"id": "claude-sonnet-4-6", "name": "Claude Sonnet 4.6"}]
+
+    monkeypatch.setattr(
+        "chatlas._provider_posit.list_models_posit", fake_list_models_posit
+    )
+
+    models = provider.list_models()
+
+    assert models == [{"id": "claude-sonnet-4-6", "name": "Claude Sonnet 4.6"}]
+    assert captured["base_url"] == "https://gateway.posit.ai"
+    assert captured["credentials"]() == "test-token"
+
+
+def test_list_models_posit_parses_response(monkeypatch: pytest.MonkeyPatch):
+    response = _FakeResponse(
+        200,
+        {
+            "chat": [
+                {"id": "claude-sonnet-4-6", "display_name": "Claude Sonnet 4.6"},
+                {"id": "qwen3-8b", "display_name": "Qwen3 8B"},
+            ]
+        },
+    )
+    captured_headers: dict[str, str] = {}
+
+    def fake_get(url: str, headers: Optional[dict[str, str]] = None, **kwargs: Any):
+        captured_headers.update(headers or {})
+        return response
+
+    monkeypatch.setattr("chatlas._provider_posit.requests.get", fake_get)
+
+    models = list_models_posit(
+        base_url="https://gateway.posit.ai", credentials=lambda: "test-token"
+    )
+
+    assert models == [
+        {"id": "claude-sonnet-4-6", "name": "Claude Sonnet 4.6"},
+        {"id": "qwen3-8b", "name": "Qwen3 8B"},
+    ]
+    assert captured_headers["Authorization"] == "Bearer test-token"
+
+
+def test_list_models_posit_raises_friendly_error(monkeypatch: pytest.MonkeyPatch):
+    response = _FakeResponse(402, {})
+    monkeypatch.setattr(
+        "chatlas._provider_posit.requests.get", lambda *a, **k: response
+    )
+
+    with pytest.raises(RuntimeError, match="credits are depleted"):
+        list_models_posit(credentials=lambda: "test-token")


### PR DESCRIPTION
## Summary
- Adds `ChatPosit()` so chatlas users with a Posit AI subscription can chat with gateway-hosted models using the same OAuth device-flow login already used by RStudio/Posit Cloud — no manual API key management.
- Automatically dispatches to the Anthropic or OpenAI-compatible API flavor based on the chosen model, and surfaces friendly, actionable messages (e.g. "finish setting up your Posit AI account") instead of raw gateway errors.
- Mirrors ellmer's `chat_posit()` so behavior stays consistent across the two packages.

## Test plan
- [x] `uv run pytest tests/test_provider_posit.py` (25 tests, mocked HTTP — OAuth device flow can't be captured in a VCR cassette)
- [x] Manually verified live end-to-end against the real Posit AI gateway: device-flow login, `list_models_posit`, sync/streaming/tool-calling chat via the Claude flavor, chat via the OpenAI-compatible flavor, and async chat
- [x] `make check-types`, `make check-format`