### PR TITLE
docs: self-provisioning doc-build targets + build-process docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,16 @@ Documentation is built with Quarto and quartodoc:
 - Guides and examples in `docs/` as `.qmd` files
 - Type definitions in `chatlas/types/` provide provider-specific parameter types
 
+Build commands: `make docs` (build), `make docs-preview` (serve locally), or
+`make quartodoc` (regenerate the API reference stubs only). All three require
+[Quarto](https://quarto.org/docs/get-started/) installed on your system.
+On a Mac, Quarto can be installed with homebrew (`quarto` cask).
+
+Note: `quartodoc` lives in the `docs` optional-dependency extra (not the base
+deps), so it isn't present after a plain `uv sync`. The doc targets depend on
+`setup` (`uv sync --all-extras`), so they install the extra automatically before
+running. See `docs/dev/building-docs.md` for the full build/publish walkthrough.
+
 
 ## Adding New Providers
 

--- a/Makefile
+++ b/Makefile
@@ -49,14 +49,14 @@ docs-preview: quartodoc
 	quarto preview docs
 
 .PHONY: quartodoc
-quartodoc: 
+quartodoc: setup
 	@echo "📖 Generating python docs with quartodoc"
 	@$(eval export IN_QUARTODOC=true)
 	cd docs && uv run quartodoc build
 	cd docs && uv run quartodoc interlinks
 
 .PHONY: quartodoc-watch
-quartodoc-watch:
+quartodoc-watch: setup
 	@echo "📖 Generating python docs with quartodoc"
 	@$(eval export IN_QUARTODOC=true)
 	uv run quartodoc build --config docs/_quarto.yml --watch

--- a/docs/dev/building-docs.md
+++ b/docs/dev/building-docs.md
@@ -1,0 +1,67 @@
+# Building the Documentation
+
+The chatlas documentation site is built with [Quarto](https://quarto.org/) and
+[quartodoc](https://machow.github.io/quartodoc/), and published to GitHub Pages.
+
+## Prerequisites
+
+1. **Quarto** must be installed on your system. See the
+   [Quarto install guide](https://quarto.org/docs/get-started/). CI currently
+   pins version `1.9.37`.
+2. **The `docs` dependency extra** from `pyproject.toml` must be installed.
+   `quartodoc` and the other doc-building tools live in the `docs`
+   optional-dependency group (see `[project.optional-dependencies]`
+   in `pyproject.toml`), *not* the base dependencies. The simplest way to
+   get everything is:
+
+   ```bash
+   make setup   # runs `uv sync --all-extras`
+   ```
+
+   Note, the `make quartodoc` target (and `make docs` / `make docs-preview`, which
+   depend on it) list `setup` as a prerequisite, so they run `uv sync
+   --all-extras` for you before building — you don't have to run `make setup`
+   by hand. You still need Quarto itself installed separately.
+
+## How it fits together
+
+- **quartodoc** reads docstrings from the `chatlas/` package and generates the
+  API reference pages under `docs/reference/`, plus the `docs/_sidebar.yml`
+  navigation file. Its configuration is the `quartodoc:` section of
+  `docs/_quarto.yml`, which lists every symbol to document.
+- **Quarto** renders the whole site (guides in `docs/*.qmd`, plus the generated
+  reference) into a static website. Site config lives in `docs/_quarto.yml`.
+- **interlinks** cross-link to Python, Pydantic, and chatlas's own API objects.
+
+## Common commands
+
+```bash
+make quartodoc      # generate API reference stubs + interlinks (prereq for the rest)
+make docs           # quartodoc, then `quarto render docs`  → build the full site
+make docs-preview   # quartodoc, then `quarto preview docs` → live-serve locally
+```
+
+`make docs` and `make docs-preview` both depend on `make quartodoc`, so you
+normally just run one of them. All three also depend on `setup`, so they run
+`uv sync --all-extras` to install/refresh dependencies before building — you
+don't need to run `make setup` first.
+
+## Executable code cells
+
+Several `.qmd` guides contain executable Python cells that make real API calls
+(OpenAI, Anthropic). Locally you'll need the relevant API keys set in your
+environment to render those pages from scratch. In CI these outputs are cached
+via Quarto's [freeze](https://quarto.org/docs/projects/code-execution.html#freeze)
+mechanism (`docs/_freeze/`).
+
+## Publishing (CI)
+
+Two GitHub Actions workflows handle the deployed site:
+
+- **`.github/workflows/docs-publish.yml`** — on push to `main` (when `docs/**`
+  changes) or manual dispatch. Installs Quarto + the `docs` extra, runs
+  `make quartodoc`, then renders and publishes to the `gh-pages` branch
+  (served at <https://posit-dev.github.io/chatlas/>).
+- **`.github/workflows/docs-freeze.yml`** — manual dispatch only. Re-renders the
+  docs to refresh the freeze cache (`docs/_freeze/`) and commits it back, so the
+  publish job doesn't need to re-execute code cells that hit live APIs.

--- a/docs/dev/building-docs.md
+++ b/docs/dev/building-docs.md
@@ -6,8 +6,7 @@ The chatlas documentation site is built with [Quarto](https://quarto.org/) and
 ## Prerequisites
 
 1. **Quarto** must be installed on your system. See the
-   [Quarto install guide](https://quarto.org/docs/get-started/). CI currently
-   pins version `1.9.37`.
+   [Quarto install guide](https://quarto.org/docs/get-started/).
 2. **The `docs` dependency extra** from `pyproject.toml` must be installed.
    `quartodoc` and the other doc-building tools live in the `docs`
    optional-dependency group (see `[project.optional-dependencies]`


### PR DESCRIPTION
## Why

Running `make quartodoc` (or `make docs` / `make docs-preview`) on a fresh venv fails with `Failed to spawn: quartodoc`. That's because `quartodoc` lives in the `docs` optional-dependency extra (`[project.optional-dependencies]` in `pyproject.toml`), and `uv run` only auto-syncs the default dependency set — not extras. CI works only because `docs-publish.yml` explicitly runs `uv sync --all-extras` first; there was nothing making the local targets or the requirement discoverable.

## What

- **`Makefile`**: `quartodoc` and `quartodoc-watch` now declare `setup` as a prerequisite, so `uv sync --all-extras` runs automatically before building. `make docs` / `make docs-preview` already depend on `quartodoc`, so they're covered transitively. (`make setup` is idempotent/fast when the env is already synced.)
- **`docs/dev/building-docs.md`** (new): full build/publish walkthrough — prerequisites (Quarto + the `docs` extra), how quartodoc/Quarto/interlinks fit together, common commands, the executable-code-cell/freeze caveat, and the two CI publish workflows. Kept as `.md` to match the sibling `docs/dev/vcr-tests.md` (dev-only, not rendered into the published site).
- **`CLAUDE.md`**: expanded the Documentation section with build commands and a note about the `docs` extra + `setup` prerequisite.

## Testing

`make quartodoc` now runs `uv sync --all-extras` then builds cleanly on a fresh venv (verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)