### PR TITLE
fix: bump Gemini default model to gemini-3.5-flash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -->
 
 
+## [UNRELEASED]
+
+### Bug fixes
+
+* `ChatGoogle()` and `ChatVertex()` now default to `gemini-3.5-flash` instead of the older `gemini-2.5-flash`.
+
 ## [0.19.2] - 2026-07-08
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -->
 
 
-## [UNRELEASED]
+## [0.19.2] - 2026-07-08
 
 ### New features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
-### Bug fixes
+### Improvements
 
 * `ChatGoogle()` and `ChatVertex()` now default to `gemini-3.5-flash` instead of the older `gemini-2.5-flash`.
 

--- a/chatlas/_provider_google.py
+++ b/chatlas/_provider_google.py
@@ -158,7 +158,7 @@ def ChatGoogle(
     """
 
     if model is None:
-        model = log_model_default("gemini-2.5-flash")
+        model = log_model_default("gemini-3.5-flash")
 
     kwargs_chat: "SubmitInputArgs" = {}
     if reasoning is not None:
@@ -787,7 +787,7 @@ def ChatVertex(
     kwargs["location"] = location
 
     if model is None:
-        model = log_model_default("gemini-2.5-flash")
+        model = log_model_default("gemini-3.5-flash")
 
     return Chat(
         provider=GoogleProvider(

--- a/chatlas/data/prices.json
+++ b/chatlas/data/prices.json
@@ -981,13 +981,6 @@
   },
   {
     "provider": "AWS/Bedrock",
-    "model": "us-east-1/minimax.minimax-m2.5",
-    "variant": "",
-    "input": 0.3,
-    "output": 1.2
-  },
-  {
-    "provider": "AWS/Bedrock",
     "model": "us-east-1/mistral.mistral-7b-instruct-v0:2",
     "variant": "",
     "input": 0.15,
@@ -1322,13 +1315,6 @@
   {
     "provider": "AWS/Bedrock",
     "model": "us-west-2/minimax.minimax-m2.1",
-    "variant": "",
-    "input": 0.3,
-    "output": 1.2
-  },
-  {
-    "provider": "AWS/Bedrock",
-    "model": "us-west-2/minimax.minimax-m2.5",
     "variant": "",
     "input": 0.3,
     "output": 1.2
@@ -1716,6 +1702,14 @@
     "cached_input": 0.3
   },
   {
+    "provider": "Anthropic",
+    "model": "claude-sonnet-5",
+    "variant": "",
+    "input": 2,
+    "output": 10,
+    "cached_input": 0.2
+  },
+  {
     "provider": "Azure/OpenAI",
     "model": "ada",
     "variant": "",
@@ -1853,6 +1847,182 @@
     "input": 0.275,
     "output": 2.2,
     "cached_input": 0.028
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "eu/gpt-5.4",
+    "variant": "",
+    "input": 2.75,
+    "output": 16.5,
+    "cached_input": 0.28
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "eu/gpt-5.4",
+    "variant": "priority",
+    "input": 5.5,
+    "output": 33,
+    "cached_input": 0.55
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "eu/gpt-5.4-2026-03-05",
+    "variant": "",
+    "input": 2.75,
+    "output": 16.5,
+    "cached_input": 0.28
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "eu/gpt-5.4-2026-03-05",
+    "variant": "priority",
+    "input": 5.5,
+    "output": 33,
+    "cached_input": 0.55
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "eu/gpt-5.5",
+    "variant": "",
+    "input": 5.5,
+    "output": 33,
+    "cached_input": 0.55
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "eu/gpt-5.5",
+    "variant": "above_272k_tokens",
+    "input": 11,
+    "output": 49.5,
+    "cached_input": 1.1
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "eu/gpt-5.5",
+    "variant": "priority",
+    "input": 13.75,
+    "output": 82.5,
+    "cached_input": 1.38
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "eu/gpt-5.5-2026-04-23",
+    "variant": "",
+    "input": 5.5,
+    "output": 33,
+    "cached_input": 0.55
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "eu/gpt-5.5-2026-04-23",
+    "variant": "above_272k_tokens",
+    "input": 11,
+    "output": 49.5,
+    "cached_input": 1.1
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "eu/gpt-5.5-2026-04-23",
+    "variant": "priority",
+    "input": 13.75,
+    "output": 82.5,
+    "cached_input": 1.38
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "eu/gpt-5.6",
+    "variant": "",
+    "input": 5.5,
+    "output": 33,
+    "cached_input": 0.55
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "eu/gpt-5.6",
+    "variant": "above_272k_tokens",
+    "input": 11,
+    "output": 49.5,
+    "cached_input": 1.1
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "eu/gpt-5.6",
+    "variant": "priority",
+    "input": 13.75,
+    "output": 82.5,
+    "cached_input": 1.375
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "eu/gpt-5.6-luna",
+    "variant": "",
+    "input": 1.1,
+    "output": 6.6,
+    "cached_input": 0.11
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "eu/gpt-5.6-luna",
+    "variant": "above_272k_tokens",
+    "input": 2.2,
+    "output": 9.9,
+    "cached_input": 0.22
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "eu/gpt-5.6-luna",
+    "variant": "priority",
+    "input": 2.75,
+    "output": 16.5,
+    "cached_input": 0.275
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "eu/gpt-5.6-sol",
+    "variant": "",
+    "input": 5.5,
+    "output": 33,
+    "cached_input": 0.55
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "eu/gpt-5.6-sol",
+    "variant": "above_272k_tokens",
+    "input": 11,
+    "output": 49.5,
+    "cached_input": 1.1
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "eu/gpt-5.6-sol",
+    "variant": "priority",
+    "input": 13.75,
+    "output": 82.5,
+    "cached_input": 1.375
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "eu/gpt-5.6-terra",
+    "variant": "",
+    "input": 2.75,
+    "output": 16.5,
+    "cached_input": 0.275
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "eu/gpt-5.6-terra",
+    "variant": "above_272k_tokens",
+    "input": 5.5,
+    "output": 24.75,
+    "cached_input": 0.55
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "eu/gpt-5.6-terra",
+    "variant": "priority",
+    "input": 6.875,
+    "output": 41.25,
+    "cached_input": 0.6875
   },
   {
     "provider": "Azure/OpenAI",
@@ -2812,6 +2982,134 @@
   },
   {
     "provider": "Azure/OpenAI",
+    "model": "gpt-5.6",
+    "variant": "",
+    "input": 5,
+    "output": 30,
+    "cached_input": 0.5
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "gpt-5.6",
+    "variant": "above_272k_tokens",
+    "input": 10,
+    "output": 45,
+    "cached_input": 1
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "gpt-5.6",
+    "variant": "above_272k_tokens_priority",
+    "input": 20,
+    "output": 90,
+    "cached_input": 2
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "gpt-5.6",
+    "variant": "priority",
+    "input": 10,
+    "output": 60,
+    "cached_input": 1
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "gpt-5.6-luna",
+    "variant": "",
+    "input": 1,
+    "output": 6,
+    "cached_input": 0.1
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "gpt-5.6-luna",
+    "variant": "above_272k_tokens",
+    "input": 2,
+    "output": 9,
+    "cached_input": 0.2
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "gpt-5.6-luna",
+    "variant": "above_272k_tokens_priority",
+    "input": 4,
+    "output": 18,
+    "cached_input": 0.4
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "gpt-5.6-luna",
+    "variant": "priority",
+    "input": 2,
+    "output": 12,
+    "cached_input": 0.2
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "gpt-5.6-sol",
+    "variant": "",
+    "input": 5,
+    "output": 30,
+    "cached_input": 0.5
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "gpt-5.6-sol",
+    "variant": "above_272k_tokens",
+    "input": 10,
+    "output": 45,
+    "cached_input": 1
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "gpt-5.6-sol",
+    "variant": "above_272k_tokens_priority",
+    "input": 20,
+    "output": 90,
+    "cached_input": 2
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "gpt-5.6-sol",
+    "variant": "priority",
+    "input": 10,
+    "output": 60,
+    "cached_input": 1
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "gpt-5.6-terra",
+    "variant": "",
+    "input": 2.5,
+    "output": 15,
+    "cached_input": 0.25
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "gpt-5.6-terra",
+    "variant": "above_272k_tokens",
+    "input": 5,
+    "output": 22.5,
+    "cached_input": 0.5
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "gpt-5.6-terra",
+    "variant": "above_272k_tokens_priority",
+    "input": 10,
+    "output": 45,
+    "cached_input": 1
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "gpt-5.6-terra",
+    "variant": "priority",
+    "input": 5,
+    "output": 30,
+    "cached_input": 0.5
+  },
+  {
+    "provider": "Azure/OpenAI",
     "model": "gpt-audio-1.5-2026-02-23",
     "variant": "",
     "input": 2.5,
@@ -3213,6 +3511,182 @@
     "input": 0.275,
     "output": 2.2,
     "cached_input": 0.028
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "us/gpt-5.4",
+    "variant": "",
+    "input": 2.75,
+    "output": 16.5,
+    "cached_input": 0.28
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "us/gpt-5.4",
+    "variant": "priority",
+    "input": 5.5,
+    "output": 33,
+    "cached_input": 0.55
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "us/gpt-5.4-2026-03-05",
+    "variant": "",
+    "input": 2.75,
+    "output": 16.5,
+    "cached_input": 0.28
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "us/gpt-5.4-2026-03-05",
+    "variant": "priority",
+    "input": 5.5,
+    "output": 33,
+    "cached_input": 0.55
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "us/gpt-5.5",
+    "variant": "",
+    "input": 5.5,
+    "output": 33,
+    "cached_input": 0.55
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "us/gpt-5.5",
+    "variant": "above_272k_tokens",
+    "input": 11,
+    "output": 49.5,
+    "cached_input": 1.1
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "us/gpt-5.5",
+    "variant": "priority",
+    "input": 13.75,
+    "output": 82.5,
+    "cached_input": 1.38
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "us/gpt-5.5-2026-04-23",
+    "variant": "",
+    "input": 5.5,
+    "output": 33,
+    "cached_input": 0.55
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "us/gpt-5.5-2026-04-23",
+    "variant": "above_272k_tokens",
+    "input": 11,
+    "output": 49.5,
+    "cached_input": 1.1
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "us/gpt-5.5-2026-04-23",
+    "variant": "priority",
+    "input": 13.75,
+    "output": 82.5,
+    "cached_input": 1.38
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "us/gpt-5.6",
+    "variant": "",
+    "input": 5.5,
+    "output": 33,
+    "cached_input": 0.55
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "us/gpt-5.6",
+    "variant": "above_272k_tokens",
+    "input": 11,
+    "output": 49.5,
+    "cached_input": 1.1
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "us/gpt-5.6",
+    "variant": "priority",
+    "input": 13.75,
+    "output": 82.5,
+    "cached_input": 1.375
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "us/gpt-5.6-luna",
+    "variant": "",
+    "input": 1.1,
+    "output": 6.6,
+    "cached_input": 0.11
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "us/gpt-5.6-luna",
+    "variant": "above_272k_tokens",
+    "input": 2.2,
+    "output": 9.9,
+    "cached_input": 0.22
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "us/gpt-5.6-luna",
+    "variant": "priority",
+    "input": 2.75,
+    "output": 16.5,
+    "cached_input": 0.275
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "us/gpt-5.6-sol",
+    "variant": "",
+    "input": 5.5,
+    "output": 33,
+    "cached_input": 0.55
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "us/gpt-5.6-sol",
+    "variant": "above_272k_tokens",
+    "input": 11,
+    "output": 49.5,
+    "cached_input": 1.1
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "us/gpt-5.6-sol",
+    "variant": "priority",
+    "input": 13.75,
+    "output": 82.5,
+    "cached_input": 1.375
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "us/gpt-5.6-terra",
+    "variant": "",
+    "input": 2.75,
+    "output": 16.5,
+    "cached_input": 0.275
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "us/gpt-5.6-terra",
+    "variant": "above_272k_tokens",
+    "input": 5.5,
+    "output": 24.75,
+    "cached_input": 0.55
+  },
+  {
+    "provider": "Azure/OpenAI",
+    "model": "us/gpt-5.6-terra",
+    "variant": "priority",
+    "input": 6.875,
+    "output": 41.25,
+    "cached_input": 0.6875
   },
   {
     "provider": "Azure/OpenAI",
@@ -3842,6 +4316,13 @@
   },
   {
     "provider": "Google/Gemini",
+    "model": "gemini-omni-flash-preview",
+    "variant": "",
+    "input": 1.5,
+    "output": 9
+  },
+  {
+    "provider": "Google/Gemini",
     "model": "gemini-pro-latest",
     "variant": "",
     "input": 1.25,
@@ -4241,6 +4722,13 @@
     "input": 0.3,
     "output": 2,
     "cached_input": 0.075
+  },
+  {
+    "provider": "Google/Vertex",
+    "model": "gemini-omni-flash-preview",
+    "variant": "",
+    "input": 1.5,
+    "output": 9
   },
   {
     "provider": "Google/Vertex",
@@ -6257,6 +6745,162 @@
   },
   {
     "provider": "OpenAI",
+    "model": "gpt-5.6",
+    "variant": "",
+    "input": 5,
+    "output": 30,
+    "cached_input": 0.5
+  },
+  {
+    "provider": "OpenAI",
+    "model": "gpt-5.6",
+    "variant": "above_272k_tokens",
+    "input": 10,
+    "output": 45,
+    "cached_input": 1
+  },
+  {
+    "provider": "OpenAI",
+    "model": "gpt-5.6",
+    "variant": "batches",
+    "input": 2.5,
+    "output": 15
+  },
+  {
+    "provider": "OpenAI",
+    "model": "gpt-5.6",
+    "variant": "flex",
+    "input": 2.5,
+    "output": 15,
+    "cached_input": 0.25
+  },
+  {
+    "provider": "OpenAI",
+    "model": "gpt-5.6",
+    "variant": "priority",
+    "input": 10,
+    "output": 60,
+    "cached_input": 1
+  },
+  {
+    "provider": "OpenAI",
+    "model": "gpt-5.6-luna",
+    "variant": "",
+    "input": 1,
+    "output": 6,
+    "cached_input": 0.1
+  },
+  {
+    "provider": "OpenAI",
+    "model": "gpt-5.6-luna",
+    "variant": "above_272k_tokens",
+    "input": 2,
+    "output": 9,
+    "cached_input": 0.2
+  },
+  {
+    "provider": "OpenAI",
+    "model": "gpt-5.6-luna",
+    "variant": "batches",
+    "input": 0.5,
+    "output": 3
+  },
+  {
+    "provider": "OpenAI",
+    "model": "gpt-5.6-luna",
+    "variant": "flex",
+    "input": 0.5,
+    "output": 3,
+    "cached_input": 0.05
+  },
+  {
+    "provider": "OpenAI",
+    "model": "gpt-5.6-luna",
+    "variant": "priority",
+    "input": 2,
+    "output": 12,
+    "cached_input": 0.2
+  },
+  {
+    "provider": "OpenAI",
+    "model": "gpt-5.6-sol",
+    "variant": "",
+    "input": 5,
+    "output": 30,
+    "cached_input": 0.5
+  },
+  {
+    "provider": "OpenAI",
+    "model": "gpt-5.6-sol",
+    "variant": "above_272k_tokens",
+    "input": 10,
+    "output": 45,
+    "cached_input": 1
+  },
+  {
+    "provider": "OpenAI",
+    "model": "gpt-5.6-sol",
+    "variant": "batches",
+    "input": 2.5,
+    "output": 15
+  },
+  {
+    "provider": "OpenAI",
+    "model": "gpt-5.6-sol",
+    "variant": "flex",
+    "input": 2.5,
+    "output": 15,
+    "cached_input": 0.25
+  },
+  {
+    "provider": "OpenAI",
+    "model": "gpt-5.6-sol",
+    "variant": "priority",
+    "input": 10,
+    "output": 60,
+    "cached_input": 1
+  },
+  {
+    "provider": "OpenAI",
+    "model": "gpt-5.6-terra",
+    "variant": "",
+    "input": 2.5,
+    "output": 15,
+    "cached_input": 0.25
+  },
+  {
+    "provider": "OpenAI",
+    "model": "gpt-5.6-terra",
+    "variant": "above_272k_tokens",
+    "input": 5,
+    "output": 22.5,
+    "cached_input": 0.5
+  },
+  {
+    "provider": "OpenAI",
+    "model": "gpt-5.6-terra",
+    "variant": "batches",
+    "input": 1.25,
+    "output": 7.5
+  },
+  {
+    "provider": "OpenAI",
+    "model": "gpt-5.6-terra",
+    "variant": "flex",
+    "input": 1.25,
+    "output": 7.5,
+    "cached_input": 0.125
+  },
+  {
+    "provider": "OpenAI",
+    "model": "gpt-5.6-terra",
+    "variant": "priority",
+    "input": 5,
+    "output": 30,
+    "cached_input": 0.5
+  },
+  {
+    "provider": "OpenAI",
     "model": "gpt-audio",
     "variant": "",
     "input": 2.5,
@@ -6366,6 +7010,22 @@
     "input": 4,
     "output": 16,
     "cached_input": 0.4
+  },
+  {
+    "provider": "OpenAI",
+    "model": "gpt-realtime-2.1",
+    "variant": "",
+    "input": 4,
+    "output": 24,
+    "cached_input": 0.4
+  },
+  {
+    "provider": "OpenAI",
+    "model": "gpt-realtime-2.1-mini",
+    "variant": "",
+    "input": 0.6,
+    "output": 2.4,
+    "cached_input": 0.06
   },
   {
     "provider": "OpenAI",

--- a/chatlas/types/openai/_submit.py
+++ b/chatlas/types/openai/_submit.py
@@ -41,6 +41,9 @@ class SubmitInputArgs(TypedDict, total=False):
     model: Union[
         str,
         Literal[
+            "gpt-5.6-sol",
+            "gpt-5.6-terra",
+            "gpt-5.6-luna",
             "gpt-5.4",
             "gpt-5.4-mini",
             "gpt-5.4-nano",
@@ -153,9 +156,14 @@ class SubmitInputArgs(TypedDict, total=False):
     ]
     presence_penalty: Union[float, None, openai.Omit]
     prompt_cache_key: str | openai.Omit
+    prompt_cache_options: (
+        openai.types.chat.completion_create_params.PromptCacheOptions | openai.Omit
+    )
     prompt_cache_retention: Union[Literal["in_memory", "24h"], None, openai.Omit]
     reasoning_effort: Union[
-        Literal["none", "minimal", "low", "medium", "high", "xhigh"], None, openai.Omit
+        Literal["none", "minimal", "low", "medium", "high", "xhigh", "max"],
+        None,
+        openai.Omit,
     ]
     response_format: Union[
         openai.types.shared_params.response_format_text.ResponseFormatText,

--- a/chatlas/types/openai/_submit_responses.py
+++ b/chatlas/types/openai/_submit_responses.py
@@ -108,6 +108,8 @@ class SubmitInputArgs(TypedDict, total=False):
                 openai.types.responses.response_custom_tool_call_param.ResponseCustomToolCallParam,
                 openai.types.responses.response_input_param.CompactionTrigger,
                 openai.types.responses.response_input_param.ItemReference,
+                openai.types.responses.response_input_param.Program,
+                openai.types.responses.response_input_param.ProgramOutput,
             ]
         ],
         openai.Omit,
@@ -119,6 +121,9 @@ class SubmitInputArgs(TypedDict, total=False):
     model: Union[
         str,
         Literal[
+            "gpt-5.6-sol",
+            "gpt-5.6-terra",
+            "gpt-5.6-luna",
             "gpt-5.4",
             "gpt-5.4-mini",
             "gpt-5.4-nano",
@@ -227,6 +232,9 @@ class SubmitInputArgs(TypedDict, total=False):
         openai.Omit,
     ]
     prompt_cache_key: str | openai.Omit
+    prompt_cache_options: (
+        openai.types.responses.response_create_params.PromptCacheOptions | openai.Omit
+    )
     prompt_cache_retention: Union[Literal["in_memory", "24h"], None, openai.Omit]
     reasoning: Union[openai.types.shared_params.reasoning.Reasoning, None, openai.Omit]
     safety_identifier: str | openai.Omit
@@ -250,6 +258,7 @@ class SubmitInputArgs(TypedDict, total=False):
         openai.types.responses.tool_choice_function_param.ToolChoiceFunctionParam,
         openai.types.responses.tool_choice_mcp_param.ToolChoiceMcpParam,
         openai.types.responses.tool_choice_custom_param.ToolChoiceCustomParam,
+        openai.types.responses.response_create_params.ToolChoiceSpecificProgrammaticToolCallingParam,
         openai.types.responses.tool_choice_apply_patch_param.ToolChoiceApplyPatchParam,
         openai.types.responses.tool_choice_shell_param.ToolChoiceShellParam,
         openai.Omit,
@@ -264,6 +273,7 @@ class SubmitInputArgs(TypedDict, total=False):
                 openai.types.responses.web_search_tool_param.WebSearchToolParam,
                 openai.types.responses.tool_param.Mcp,
                 openai.types.responses.tool_param.CodeInterpreter,
+                openai.types.responses.tool_param.ProgrammaticToolCalling,
                 openai.types.responses.tool_param.ImageGeneration,
                 openai.types.responses.tool_param.LocalShell,
                 openai.types.responses.function_shell_tool_param.FunctionShellToolParam,

--- a/tests/_vcr/test_provider_google/test_data_extraction.yaml
+++ b/tests/_vcr/test_provider_google/test_data_extraction.yaml
@@ -9,44 +9,45 @@ interactions:
       ["title", "author"], "required": ["title", "author"], "title": "ArticleSummary",
       "type": "OBJECT"}}}'
     headers:
-      Accept:
+      accept:
       - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
       - keep-alive
-      Content-Length:
+      content-length:
       - '589'
-      Content-Type:
+      content-type:
       - application/json
-      Host:
+      host:
       - generativelanguage.googleapis.com
       x-goog-api-client:
-      - google-genai-sdk/1.56.0 gl-python/3.11.13
+      - google-genai-sdk/2.10.0 gl-python/3.12.13
     method: POST
-    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent
   response:
     body:
       string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
         [\n          {\n            \"text\": \"{\\\"title\\\": \\\"Apples are tasty\\\",
-        \\\"author\\\": \\\"Hadley Wickham\\\"}\"\n          }\n        ],\n        \"role\":
-        \"model\"\n      },\n      \"finishReason\": \"STOP\",\n      \"index\": 0\n
-        \   }\n  ],\n  \"usageMetadata\": {\n    \"promptTokenCount\": 40,\n    \"candidatesTokenCount\":
-        18,\n    \"totalTokenCount\": 190,\n    \"promptTokensDetails\": [\n      {\n
-        \       \"modality\": \"TEXT\",\n        \"tokenCount\": 40\n      }\n    ],\n
-        \   \"thoughtsTokenCount\": 132\n  },\n  \"modelVersion\": \"gemini-2.5-flash\",\n
-        \ \"responseId\": \"drBVafPsGrq9_uMPkfWTyQg\"\n}\n"
+        \\\"author\\\": \\\"Hadley Wickham\\\"}\",\n            \"thoughtSignature\":
+        \"EucHCuQHARFNMg/nX/gKdi82+fwGg6ChbSuBjIuGYJ5L71o2Dacg4g93reLWDqt2HfZnUzp2OIMCa73vvATfI+DSI6/1b7N+RI1d1PL7WtacnGTz0X2XkdW1hGbkV+MfUg+jjj7HyXMbuKhI+Ra28Yg65Nh/+F8vgxIJs3TdKEGYexrHBONDU6PbTgd/fbStH81Kt6iml0dDH2yN6iQVM3JEpYK2VXxYg9h2N07Sfx/eUxabW304HZeJh9/u9bsAkFbwUnt8cbw+i68NWvpsF3NchpF7fcFElMFAkm0jiw0ZT1x4Y+wTlUouvRG3kJCwZTzPDkb9Wi0mg32GVykqqLD9d2d94dgDy3WsJsWWktaxVcA2vtDd5Tke31GPmc7De78HUY62xUHum0donUU2WmuoC7EvsrD8bpuJ3BpJNtyQYXxFPP8BcTYiPQR/L8wBsJm6qgHbTSABJbAEi4omjBy/iMEDb+LQSZ/0P9LdtYMyf1iKAkwNy6ngjNVsXcOt//Exh2RTA+xG0ZuNaKtCe5rn8jzhf7a9BnIR6bbsIsrh3A4ZCu09yKKyZCNkMvP/7vV+tpydAq5TSbghkN7MFQ6yoiJnskDF+5mstok0qV4002zG90qLceqrBUjTJSeGCnPPKVwoJjMroQuiSX2FbLN+gvghjakf5VEH8LREjzKnfbeRCHiEfpjXQFleC+ZZvoQ1mQypmOSKoPRA2HNhCRXhimCejPVaAKWWAJ8fN0eowaeFQWpmQGmQH4KhfmAWcsQ2JM439WKRO+StNLZzsmS2lIY31TAr70pC6IMAaCQAiCCOc1QWjt1cEkad96N0i27ikUqOojWPXSsElEo2HLPwQv/Q8r56Rfc71MkGtWU4BQyLjJP/DRjK+P7uFV3PQvArfAlTNLVhG9hVaDe8h66VQ1wDLoGyhuSS5XVgbvZ4BpoTZgT6b2Mna14lqb7Fg9UFUdUL9Y8fwXAFQesrg8stEKdOc3eAQ0pSIr+e2TXEZrScoLz6jkjzK1IIs+mKV2mIav4zMU5BJxRHZguFUpUqPmUMWk+w0jozKDKA/Qv3BtN5udaIk6ns+3v21jkO/NRCPzPbXhAbKzUkjTvtVNHgrkiyaTyCkwVPK40Z/zrKzYQ0OIJi7KnE3RI1sIwlf4/9AnWsVsBQDMxh77QtrU13dYZpVrH2ACrV2iw1yD0LFCGxtv3QOpgKMMg+4g5Z5DRF1xVFvqVRIkuMwS13DpNQ+gsevj77NTifoeItkSOisHoZt/OAEzf39yAQp2YcObQyqz+66a8/EOAYWvp9AcBYtFxpI0rV6s1M/wf7nXQ+tIcHiNmTTU51\"\n
+        \         }\n        ],\n        \"role\": \"model\"\n      },\n      \"finishReason\":
+        \"STOP\",\n      \"index\": 0\n    }\n  ],\n  \"usageMetadata\": {\n    \"promptTokenCount\":
+        40,\n    \"candidatesTokenCount\": 18,\n    \"totalTokenCount\": 314,\n    \"promptTokensDetails\":
+        [\n      {\n        \"modality\": \"TEXT\",\n        \"tokenCount\": 40\n
+        \     }\n    ],\n    \"thoughtsTokenCount\": 256,\n    \"serviceTier\": \"standard\"\n
+        \ },\n  \"modelVersion\": \"gemini-3.5-flash\",\n  \"responseId\": \"PoFfaruLA626jrEPj5Sr8Q4\"\n}\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 31 Dec 2025 23:23:34 GMT
+      - Tue, 21 Jul 2026 14:25:03 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1031
+      - gfet4t7; dur=1824
       Transfer-Encoding:
       - chunked
       Vary:
@@ -57,10 +58,12 @@ interactions:
       - nosniff
       X-Frame-Options:
       - SAMEORIGIN
+      X-Gemini-Service-Tier:
+      - standard
       X-XSS-Protection:
       - '0'
       content-length:
-      - '609'
+      - '2012'
     status:
       code: 200
       message: OK
@@ -77,43 +80,44 @@ interactions:
       "Author", "type": "STRING"}}, "property_ordering": ["title", "author"], "required":
       ["title", "author"], "title": "ArticleSummary", "type": "OBJECT"}}}'
     headers:
-      Accept:
+      accept:
       - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
       - keep-alive
-      Content-Length:
+      content-length:
       - '897'
-      Content-Type:
+      content-type:
       - application/json
-      Host:
+      host:
       - generativelanguage.googleapis.com
       x-goog-api-client:
-      - google-genai-sdk/1.56.0 gl-python/3.11.13
+      - google-genai-sdk/2.10.0 gl-python/3.12.13
     method: POST
-    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent
   response:
     body:
       string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
         [\n          {\n            \"text\": \"{\\\"title\\\":\\\"Apples are tasty\\\",\\\"author\\\":\\\"Hadley
-        Wickham\\\"}\"\n          }\n        ],\n        \"role\": \"model\"\n      },\n
-        \     \"finishReason\": \"STOP\",\n      \"index\": 0\n    }\n  ],\n  \"usageMetadata\":
-        {\n    \"promptTokenCount\": 96,\n    \"candidatesTokenCount\": 15,\n    \"totalTokenCount\":
-        175,\n    \"promptTokensDetails\": [\n      {\n        \"modality\": \"TEXT\",\n
-        \       \"tokenCount\": 96\n      }\n    ],\n    \"thoughtsTokenCount\": 64\n
-        \ },\n  \"modelVersion\": \"gemini-2.5-flash\",\n  \"responseId\": \"d7BVaeudGu6p_uMPycCNyAg\"\n}\n"
+        Wickham\\\"}\",\n            \"thoughtSignature\": \"EvIGCu8GARFNMg+ZMHTCCx445wZMjWWVbbLLdOdB7zcjgJKxnGf+xcNISKnr+jSkCgJDlHRZmKi8ImxbjtFRd6vuIgG8ShD21LCGwuPXt1pr0oKoAwjdDGDzrWLEmqZKnC6Qr0wXeZvojmPwbXqcD47Om3Dl6RaYppYMpaZfw8uCHppX8J1vLbtGJ2fDUXczV6jgjclW0yCHS4YXyGjhbJPY2Ls44qasEHMmX2/J4KD4+CZ7P1ihN7463mksHv6pR4YSkf9E61FYN69aAs7IDyOJuPcRTvRe8g9TvUL8zlG84JIcDO55d+nvxHlGq+w6aarVVQnqIsuT4RJJY1U+ZMyKg/lEO2+s+4zSmcPkjkjkaylM1CmgCR9R0Cpqj+c4r31gNbXaojiC84xKEkfMHb/QT/2Zav+4spkmH0s38m5BevUENu01kuNBoCrrij8347v/usbeCAUvzBzxHDEvLuWFZ+otkeAouM0+spdvdNLaR4vjr1sNQZ/j2LFCd4aWM00IWB+ZJ1trnGjCDELQ0zQpBmgUs6+6NnXhfKqJlR97x0qC9CxswhdzEY4uHvmfgd6Tcx3EviEWjg3xKPM1C9RI+3aM1lVkNvGwQaIcmXIge9Ssjm08Jk0kBLOQwkTMfOaR1fSK2pdjNW0X53qTDxC22d4ziNn1zlY2x2qydxYdj1sg+bAzt/sd8UR34wegocsdD/ZENAMd13/ykKOyr+FLAVi3qN+luOYeEJ6BuSwGSWzNjD1CtpzMMCpJDXx4FZD/JSthAXmqZZ/VpaBD8ZnyCRzRK9N0tRXjxKJ/5oPe+smuVd2D7H4IU3fDqZIHOwqFEWeMApGrq38s+wKlVZGVSGFsbgCl4iTM8X6gup13vI2uIsRqTk5yVCtfJz33eN56mnlM1K/V5elst3GgNoqkPa1PW/jq3LMgUQTK8/EtHZGWeu7EEE5poOFZBIRHClzLJdy3fkam+QBkQW4U+hCmXoqwP+AIjX6olLJ+RDxkLY/WBKYX08Buchkddeaxx4dGDK4vSTyborvl2XBkibrrs/YhE8DhXEwyGBZUVpQsCF+ogqAXOgwmUfbMctUE/HpmdIBwy/3rcwNM8nzMdd8ICq5TklOHUtq6+e+/uhf/WlGuU4/PSMS9dEM4tCtomfPXQCPB00DcIEWBmZrwnYQLM0Aq\"\n
+        \         }\n        ],\n        \"role\": \"model\"\n      },\n      \"finishReason\":
+        \"STOP\",\n      \"index\": 0\n    }\n  ],\n  \"usageMetadata\": {\n    \"promptTokenCount\":
+        96,\n    \"candidatesTokenCount\": 15,\n    \"totalTokenCount\": 340,\n    \"promptTokensDetails\":
+        [\n      {\n        \"modality\": \"TEXT\",\n        \"tokenCount\": 96\n
+        \     }\n    ],\n    \"thoughtsTokenCount\": 229,\n    \"serviceTier\": \"standard\"\n
+        \ },\n  \"modelVersion\": \"gemini-3.5-flash\",\n  \"responseId\": \"P4Ffau-rOYersOIPqaaF8Ag\"\n}\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 31 Dec 2025 23:23:35 GMT
+      - Tue, 21 Jul 2026 14:25:08 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=754
+      - gfet4t7; dur=5140
       Transfer-Encoding:
       - chunked
       Vary:
@@ -124,10 +128,12 @@ interactions:
       - nosniff
       X-Frame-Options:
       - SAMEORIGIN
+      X-Gemini-Service-Tier:
+      - standard
       X-XSS-Protection:
       - '0'
       content-length:
-      - '605'
+      - '1853'
     status:
       code: 200
       message: OK
@@ -146,43 +152,44 @@ interactions:
       "INTEGER"}}, "property_ordering": ["name", "age"], "required": ["name", "age"],
       "title": "Person", "type": "OBJECT"}}}'
     headers:
-      Accept:
+      accept:
       - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
       - keep-alive
-      Content-Length:
+      content-length:
       - '1027'
-      Content-Type:
+      content-type:
       - application/json
-      Host:
+      host:
       - generativelanguage.googleapis.com
       x-goog-api-client:
-      - google-genai-sdk/1.56.0 gl-python/3.11.13
+      - google-genai-sdk/2.10.0 gl-python/3.12.13
     method: POST
-    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent
   response:
     body:
       string: "{\n  \"candidates\": [\n    {\n      \"content\": {\n        \"parts\":
-        [\n          {\n            \"text\": \"{\\\"name\\\":\\\"Alice Smith\\\",\\\"age\\\":30}\"\n
+        [\n          {\n            \"text\": \"{\\\"name\\\":\\\"Alice Smith\\\",\\\"age\\\":28}\",\n
+        \           \"thoughtSignature\": \"ErsKCrgKARFNMg8b+TpRKCHxmT/kAZNbL8NN0mivOjHtGukH9TxK0id1gf5298IjmicpmgLtSu+AzCqkVtZAJVi/jDiqWMLg7p5qj4K2KyswrviFsWWav09SEL9wBlkUUTXo+rCSPxVhn/ur4EQW85E1ydWHtrVEKUt/YgJ2tGB25VGBU2g1a2dM/7vpl7BRe1YveRUKWRGmPVRHuAO7JpW0uv08xjdsWVTKa4ggFE6NKqJl+3LvRApmLGsQMtjmmCERLdXsdQHJUrWbJ8yll2nZ6/P9tHbLYxG/7JFqP+CyitqG8ehopEZBugUqSAXCViMg+nfHlSJbbR9imGJXCHMjOeuBxzxndcAc9V7lVMGYZVpGTVd/Q9qU7SNPI23JIG18cFkbjUoylIAFuH5q+6e/pbuvSAWtXmWbpvQ2F3mNO2ZbUTzehEz/7mgbxWtIy5r1OcdfwkV21vSNwdOeVtlihm8seIklu8qrHZ/6T/i3Bs0jxGl44Gpojbbay+9QIUpUyCf4W5vcq4A4Kouy39rD80wBJzFTTZeSxWpVuyo+uqj2gDAJbSz9qnWw2V7e9cb0jp1MnUZ1ch+3aTniXM0Qv7D0pjIcdy3zWzp+qEV+mrpLeWbmvt7sPu6LxAtGjZ9nvVobb+367ZZb87/t5XK7QP6kWDhAu8ub9yJlCr7//ld2fEPB2F94SBc2vhwDBV6stpgGcO/50YHr+E0fcqcAmirUcvFUefBMjvRIJsTSQMvIksqWQrU8QvP4JYBrLcEUtywaI65haMHWQueActAPq7KDRnQBSw3qIJluYCB3afhqx1c0WMje5O7W807N3miJMQ1ldeOeVMUP0OA54HxJ7lwHDtHesJLYQyyFDrQKaiUW6LB6Hx6A28RjK29CzYaREjykE97agGSM9m2n66e+Qg+64Ah5jo9R6TWeCcWpzZSs8n8JMVm1WG7w++QuO28CmuWJ+26aH3dje4KYtQYek1AElFNSoYcDgusUhqZ11uSQVI7lSRGG7U2KzCRmF7hz8oJpfSrQSJEq5ZGBHwl++EllLsDLhmP8HMxmMbnaNLzpFDnITsXJLrBV6mtM0kNY0ElwujD2lMTpVbJDlDhrcsO+jdGql61HYG7avwcsd390+x+rEd4oeJqEZhKYYOWCo8mZ4Vdny5Np5nMVkxXwad0el9b7kACKN/e66Ivqv4Da3VtKiA2kO0KcXl7gBc8p0R44t2fi9Fl7P9YH/23jT10BxSMuip2Kkvf2PZSjpFPJU/NRJtihGuVFolB5Z9QP4x9+Kq69a2lZZR2ixfJ2cLkeTSebUzNfiUfgPnAXnn6EowezSmOBv6JB4YAfq32Kp7NjFMdsEaUDw02YAOPyuI60D6y6ci4IAI+9vB6pBTkAeHjTJHIQNxly/bO/5t4ZqDGL2D2G5uocMW+MifLN0blT8rEVaNDs1BMCFSVUuFoINRJwsH8tuQYIAhAIpTyOOZJPbrxm805SCT8XuurWAsnbe2F7hZwvjskkNAzL60gP/aU3hJxNHcrBNdkTibkTT95Ijs+RmT1as9WlaRnH3UTejWkgw3a3XlfRHsZ9+r8OATSSzXUPJG71bvsofbcCLqIn23ob/yUnP4cmWxEFu2646FSOtebwZTJCYk+E8OOcHA9qGbgGCT7F5YkohoMVCCbIDbUmNMPKGXlWU5wiwl8FXy3mczORkn9huO0cWUm7g7XnSqOQ+MhChM2+21vMTqRqNVJKv+KmmZ0Z3W1mhW20N459aS2T43j7/3hjv2TejJUEUPjUS5GVNw==\"\n
         \         }\n        ],\n        \"role\": \"model\"\n      },\n      \"finishReason\":
         \"STOP\",\n      \"index\": 0\n    }\n  ],\n  \"usageMetadata\": {\n    \"promptTokenCount\":
-        123,\n    \"candidatesTokenCount\": 11,\n    \"totalTokenCount\": 172,\n    \"promptTokensDetails\":
+        123,\n    \"candidatesTokenCount\": 11,\n    \"totalTokenCount\": 509,\n    \"promptTokensDetails\":
         [\n      {\n        \"modality\": \"TEXT\",\n        \"tokenCount\": 123\n
-        \     }\n    ],\n    \"thoughtsTokenCount\": 38\n  },\n  \"modelVersion\":
-        \"gemini-2.5-flash\",\n  \"responseId\": \"eLBVaerkFa6n_uMP8-yp-Ao\"\n}\n"
+        \     }\n    ],\n    \"thoughtsTokenCount\": 375,\n    \"serviceTier\": \"standard\"\n
+        \ },\n  \"modelVersion\": \"gemini-3.5-flash\",\n  \"responseId\": \"RYFfaqXWCODwjrEP-tONkAs\"\n}\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 31 Dec 2025 23:23:36 GMT
+      - Tue, 21 Jul 2026 14:25:42 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=679
+      - gfet4t7; dur=33494
       Transfer-Encoding:
       - chunked
       Vary:
@@ -193,10 +200,12 @@ interactions:
       - nosniff
       X-Frame-Options:
       - SAMEORIGIN
+      X-Gemini-Service-Tier:
+      - standard
       X-XSS-Protection:
       - '0'
       content-length:
-      - '582'
+      - '2442'
     status:
       code: 200
       message: OK
@@ -210,32 +219,38 @@ interactions:
       "role": "user"}, {"parts": [{"text": "{\"title\":\"Apples are tasty\",\"author\":\"Hadley
       Wickham\"}"}], "role": "model"}, {"parts": [{"text": "Generate the name and
       age of a random person."}], "role": "user"}, {"parts": [{"text": "{\"name\":\"Alice
-      Smith\",\"age\":30}"}], "role": "model"}, {"parts": [{"text": "What is the name
+      Smith\",\"age\":28}"}], "role": "model"}, {"parts": [{"text": "What is the name
       of the person?"}], "role": "user"}], "generationConfig": {"temperature": 0}}'
     headers:
-      Accept:
+      accept:
       - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
       - keep-alive
-      Content-Length:
+      content-length:
       - '913'
-      Content-Type:
+      content-type:
       - application/json
-      Host:
+      host:
       - generativelanguage.googleapis.com
       x-goog-api-client:
-      - google-genai-sdk/1.56.0 gl-python/3.11.13
+      - google-genai-sdk/2.10.0 gl-python/3.12.13
     method: POST
-    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:streamGenerateContent?alt=sse
   response:
     body:
-      string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"Alice
-        Smith\"}],\"role\": \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\":
-        {\"promptTokenCount\": 144,\"candidatesTokenCount\": 2,\"totalTokenCount\":
-        146,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 144}]},\"modelVersion\":
-        \"gemini-2.5-flash\",\"responseId\": \"ebBVabjnAtKT_uMP792-mAc\"}\r\n\r\n"
+      string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"{\\\"name\\\":\\\"Alice
+        Smith\\\"}\"}],\"role\": \"model\"},\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
+        144,\"candidatesTokenCount\": 6,\"totalTokenCount\": 516,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 144}],\"thoughtsTokenCount\": 366,\"serviceTier\":
+        \"standard\"},\"modelVersion\": \"gemini-3.5-flash\",\"responseId\": \"ZoFfaq6LLaCjjrEP37Ov6A8\"}\r\n\r\ndata:
+        {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"\",\"thoughtSignature\":
+        \"EpsMCpgMARFNMg9lUaRK10KVbaj37pIXyNhoqgo6YbIvzWdEhB6FIirpv2Ysf4Xkn/Z8eLyNUKHJO23SG/YhOPo5II0yz8ge+mYSeZVSj++0xgAHKlGI4eZg/01cxA64WbooNA0dunfK1ReA2idfobhzUsMjR/eq/QCY14YfpnW3eqZK1zfPO64YZuSe0+VAueGvwLBqCqRuFdJqO85JfHWI7ZfVJOWHpv38WdYoVESQGQD3x9VZFCW5mtX4QEvb1PZBWe27Gqjf/wkPJUYX4KX7BOl3Y6meAEU7eqgajFvRD+8NSh1zNgirujCkOLNAA7PcqNb7zJpsBpojrtgOPl06SyrnctcS264mliE5cdbBoWhPdUYOX8I1UQ1UTmnwUxw02coPQ7o8U/E0H8yLO7wwV44PdZFc2+SJDpj0Eae92ovOTFpghGW4dhdA4kC2BYiXGdKF1ANAoB8aS0RDBaT0Swx+kfdaHDrSGTKMvWwReW9jvG8+TfqUPRdnHhBsOtHcAC+egUSw1grzPi1OBu6U82ttVHEyk6yQYpuBZthXuttW5leeQoc3tlKsyvgou2kzqsl7NHCcnw5M+quMLooF4ORPxXNSjJpZzNMHmy42Kg9TEsGJAB1atJFubhlSawarbkg80GAS3wKmAiqA/jDQzmf+89gJb6+Au07mVLW71fXrmYfu4/91MN5KVYXjG5KWsyD3ds73xQzNiu7Ra95wOrAOyzKvdSGBwU/GBV26oCwxxIlKGcFfskEXTwRBgeyMoV2MRo1pwKEuGOe+gU72bypUrpLuyQocHdtbSSzlDqzer1YBdCjuVB08mSVnZOJY/Jz15cQ4p98vELD/vhTP1ajqBnOIw9i6Y5oCbjwjq8JGkJU4gWuXrBEqhO75WZwNzax2CEQqcyCo/PysEa5zzz0oDM4n8rbsgHbi2CyccHI3lMfZD1QGSNsNLgDaEtlB+w2AFQOZPo677fEo1grBzqE1+WF/lrFGMU1UGDRbMDDlsbjPuqQ5dTiJSad4nJEUtEJ41OKdXiMeltM+oWFImahuK0DMDOHXVxDDB1jrb68F44pdq6aWhVcz9Kv4xs9PxH6cnP3NCZsJOWgZSRvfNCuazy3QwqW13S4dO00XnOu3JEnpm5rbxofODNjDCNygccWzUYtzuujpJC4ZC+SYFVdsnjFKgUK7Bu41Ji1I3C/Y0r9M+xXafT0B3OqamUeIXq1Uh5dMvEzWlOkKdAqrC1aAU+OWxbG2vjc33aM8HU8fmQuezuZbyT184MPObQfWbMfro1SO5VjQVTi4WMeXJPkGAKfXnWi5P/hEBfP04oc7GM6ZlOahUoaMHIOhIPVIGy29dAQzDxeP9F9/T2/jG9MDeko62E3R38ZloUiCgaCdYEdNv82wSPZXXa8uerH5heXVL0AIFhEDdb+yexmoen2vrEE5AH03I9hQCaiDVc4+I4PNqUWUFYVgHHRl2eUgQp9MDDO/Rwivi1+YqB3GcRdNGP1IIKVGSfnW6yUFEQK+Y47m4/9cRmRx+SD3exJBW028uadChpiv1TPAumhhtoQx43UlMw7CoqnJ/tzoBGEnHJgyIclGaBsFDqk2MdXysJFCpe3UzqS/hl6LPX1hkLMTctF7J73GUAupaNDxn3h6kEJouhiAOm0w5nRdTzsoBnVTf5sIqHEFToI85gK+RFoZS0ndphlpO+wHqKM0YK8rn1+6BF3xkFz++BBNEIXKPOfw3PRwzDi+dKSS4FEPrzHW/HMybCRgWv0Hypnnp/ye7fdn1a2VchviwfHvO93tVT3qftZN/rrCerK8xLQDLP3+3G1w7vBGIoKyJAB7osL+1B+0js4Bf7OEsMiA3lE0fIwlK+3keMlG2d5y558rUrBVkcLc3YFCt6+ZHL0kCuPZ6bExjjf7Y4Tw3LFLJqQ8C20PBv9Cd3GNdqfaJeHBrgl820RuabZRh4fmT13BZIBjxV0lXo9+Y2jHR3sQL9cyRICtnJDhnbZIactxWc+/0QF6JRrR1ZTWyLxwfSMBxw9X/Zaf4+D2GlYtIsOs14k9+6s/8rTku6EoB5TmnL+dkXwJu+BQO/Z4Dfcx\"}],\"role\":
+        \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
+        144,\"candidatesTokenCount\": 6,\"totalTokenCount\": 516,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 144}],\"thoughtsTokenCount\": 366,\"serviceTier\":
+        \"standard\"},\"modelVersion\": \"gemini-3.5-flash\",\"responseId\": \"ZoFfaq6LLaCjjrEP37Ov6A8\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -244,11 +259,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Wed, 31 Dec 2025 23:23:37 GMT
+      - Tue, 21 Jul 2026 14:25:44 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=343
+      - gfet4t7; dur=2161
       Transfer-Encoding:
       - chunked
       Vary:

--- a/tests/_vcr/test_provider_google/test_google_pdfs.yaml
+++ b/tests/_vcr/test_provider_google/test_google_pdfs.yaml
@@ -5,30 +5,41 @@ interactions:
       "mimeType": "application/pdf"}}], "role": "user"}], "generationConfig": {"temperature":
       0}}'
     headers:
-      Accept:
+      accept:
       - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
       - keep-alive
-      Content-Length:
+      content-length:
       - '19608'
-      Content-Type:
+      content-type:
       - application/json
-      Host:
+      host:
       - generativelanguage.googleapis.com
       x-goog-api-client:
-      - google-genai-sdk/1.56.0 gl-python/3.11.13
+      - google-genai-sdk/2.10.0 gl-python/3.12.13
     method: POST
-    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:streamGenerateContent?alt=sse
   response:
     body:
-      string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"The
-        title of this document is **Apples are tasty**.\"}],\"role\": \"model\"},\"finishReason\":
-        \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 268,\"candidatesTokenCount\":
-        12,\"totalTokenCount\": 502,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
-        10},{\"modality\": \"DOCUMENT\",\"tokenCount\": 258}],\"thoughtsTokenCount\":
-        222},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\": \"fbBVaaH_LdWA_uMP-MvrmQw\"}\r\n\r\n"
+      string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"The\"}],\"role\":
+        \"model\"},\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 10,\"candidatesTokenCount\":
+        1,\"totalTokenCount\": 160,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
+        10}],\"thoughtsTokenCount\": 149,\"serviceTier\": \"standard\"},\"modelVersion\":
+        \"gemini-3.5-flash\",\"responseId\": \"d4FfasTUJMKR-8YPmKagiAk\"}\r\n\r\ndata:
+        {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \" title of the document
+        is **Apples are tasty**.\"}],\"role\": \"model\"},\"index\": 0}],\"usageMetadata\":
+        {\"promptTokenCount\": 10,\"candidatesTokenCount\": 12,\"totalTokenCount\":
+        171,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 10}],\"thoughtsTokenCount\":
+        149,\"serviceTier\": \"standard\"},\"modelVersion\": \"gemini-3.5-flash\",\"responseId\":
+        \"d4FfasTUJMKR-8YPmKagiAk\"}\r\n\r\ndata: {\"candidates\": [{\"content\":
+        {\"parts\": [{\"text\": \"\",\"thoughtSignature\": \"Er8FCrwFARFNMg+UW6aIBWEvFTngnzPj+tK9c23Vc/ZPCzmDIQYbUF/5YdaZnmtloBu6aQCCciiMJyQ3dPv+8v5Xe3szJ7/OzSWrkmeN/If9QBX02kqTPBSKiGT1XqH1Uo21/prfEmiGSkg+GzU1eDxpG0hprs61pLV42YOWLtEhOO+OBMerJ3QhL8k1AMJLbABbL/kwdlP8EP3+MlwTVdySHjG4MU9GVpB6AQulRXVQIhwvUU8gEpqBjes2XShC/FCWNa036C8tr6prfnNHDY0w/kLs94A+R8G0Z7Ay3CYXe1WaUL76Exnek9uZlkDcGH5px14wAg3KBEw0kU3kqtJfle/sKaGh2PzcFgaqEFTPF9K5jZ/LZz+a9KNz2q2hKLu8sNiorwJ9jXZrBHZ2RFCvRqd0UG1uUb+4GsxWveBC6gHay8p4NGs66yAniWR2wan9HyRQTQHGYA0CgJ27DO5ztBMCusQkSyRsvlhnacu9bNAaHX1PgpG4xbjYhlRLTNk5zrhUJDSU/BslzKiDSRY058VSrLp3NOxLJhWEi8Nr1eE4na3A5KO7RhslHMcE6tFf1cMSbX4T0FX7VR2v1dQ8c9yhqRtlyaffzGmLiZ8xQOrCTrLmKScTuh/E/MnxdWZCeEU7wGAWTNnx3EeS98lH+DC6R9N56zvhRcjfsyClWzYYaew/IJQHHN2q0salGhn0IvC0BVJABMOH9EXXNQCOhPyy0PMY7cxr4kiNp8GE+9dbGG7G/Bk3Jg1+DtX0MBCn5JLd3uAAGCyy51LX0amKA4aj4SwhgrISKgl831GLJcbuhgsSdwC8X6a9TITefcMonVxetak6/oH48cyC7S3/jsGcr4ZNAIXGXitLnocCFbxcq8CAJ6aus5Sc5wRJ8VP4RF3YnGie0frEubXlpHNXTKaalAITOZKW2QlMOpMiKQ==\"}],\"role\":
+        \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
+        530,\"candidatesTokenCount\": 12,\"totalTokenCount\": 691,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 10},{\"modality\": \"IMAGE\",\"tokenCount\":
+        520}],\"thoughtsTokenCount\": 149,\"serviceTier\": \"standard\"},\"modelVersion\":
+        \"gemini-3.5-flash\",\"responseId\": \"d4FfasTUJMKR-8YPmKagiAk\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -37,11 +48,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Wed, 31 Dec 2025 23:23:42 GMT
+      - Tue, 21 Jul 2026 14:26:02 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=2053
+      - gfet4t7; dur=2798
       Transfer-Encoding:
       - chunked
       Vary:
@@ -60,36 +71,42 @@ interactions:
 - request:
     body: '{"contents": [{"parts": [{"text": "What''s the title of this document?"},
       {"inlineData": {"data": "JVBERi0xLjMKJcTl8uXrp_Og0MTGCjMgMCBvYmoKPDwgL0ZpbHRlciAvRmxhdGVEZWNvZGUgL0xlbmd0aCA0MTggPj4Kc3RyZWFtCngBnZLdS8MwFMXf81cc31aQNGnXrIEhuDlQwY9hwAfxoXYZq2v31Qruv_e26zb3oUzJQwK5ueeXc-4cfcwhaCnpoaU9LCyeMYHbzSXiHLJaeUwV5W22qUurk0BavU7ZCEO4j2i34d51b67o2cUFOlfdSkD5XARaa7Q8NMOAhyFUoLhu7ssRCRMguTk1KLFk-URpwf1QEFCGjoFfXoj1ZjK4xpScZojG5WyW2tyBeUfPsD7cp1k0qagu4-IjSo39LNCAs6Y7TUeH3AsJbVeLulQy9MXeXfdEZCkUV95-rxc0ooUDGaJhHbzC3BI-9f0XPtu3SQYel5os-zv_YS8leOAf9CqivFjuGfJ9HDwynJXjsGt4y-cqWOcq68hX24rVq3N9W-I6GqR2ieckHo-izGHkPQXv1wVnu2F81_aPh93UtTajmfpFm7JZTRU2EWFg0yROph85oskAq8-XpxukydiimMJGBYqRzTgcVuV5GmvzOKvfOpm19xnbWYHhdIH1RA22vOcERWRJzmFG5CZ9iVVTh_sHsy3j9RD-DN3_ArZS_GcKZW5kc3RyZWFtCmVuZG9iagoxIDAgb2JqCjw8IC9UeXBlIC9QYWdlIC9QYXJlbnQgMiAwIFIgL1Jlc291cmNlcyA0IDAgUiAvQ29udGVudHMgMyAwIFIgL01lZGlhQm94IFswIDAgNjEyIDc5Ml0KPj4KZW5kb2JqCjQgMCBvYmoKPDwgL1Byb2NTZXQgWyAvUERGIC9UZXh0IF0gL0NvbG9yU3BhY2UgPDwgL0NzMSA1IDAgUiA-PiAvRm9udCA8PCAvVFQxIDYgMCBSCi9UVDIgNyAwIFIgL1RUMyA4IDAgUiA-PiA-PgplbmRvYmoKMTAgMCBvYmoKPDwgL04gMyAvQWx0ZXJuYXRlIC9EZXZpY2VSR0IgL0xlbmd0aCAyNjEyIC9GaWx0ZXIgL0ZsYXRlRGVjb2RlID4-CnN0cmVhbQp4AZ2Wd1RT2RaHz703vdASIiAl9Bp6CSDSO0gVBFGJSYBQAoaEJnZEBUYUESlWZFTAAUeHImNFFAuDgmLXCfIQUMbBUURF5d2MawnvrTXz3pr9x1nf2ee319ln733XugBQ_IIEwnRYAYA0oVgU7uvBXBITy8T3AhgQAQ5YAcDhZmYER_hEAtT8vT2ZmahIxrP27i6AZLvbLL9QJnPW_3-RIjdDJAYACkXVNjx-JhflApRTs8UZMv8EyvSVKTKGMTIWoQmirCLjxK9s9qfmK7vJmJcm5KEaWc4ZvDSejLtQ3pol4aOMBKFcmCXgZ6N8B2W9VEmaAOX3KNPT-JxMADAUmV_M5yahbIkyRRQZ7onyAgAIlMQ5vHIOi_k5aJ4AeKZn5IoEiUliphHXmGnl6Mhm-vGzU_liMSuUw03hiHhMz_S0DI4wF4Cvb5ZFASVZbZloke2tHO3tWdbmaPm_2d8eflP9Pch6-1XxJuzPnkGMnlnfbOysL70WAPYkWpsds76VVQC0bQZA5eGsT-8gAPIFALTenPMehmxeksTiDCcLi-zsbHMBn2suK-g3-5-Cb8q_hjn3mcvu-1Y7phc_gSNJFTNlReWmp6ZLRMzMDA6Xz2T99xD_48A5ac3Jwyycn8AX8YXoVVHolAmEiWi7hTyBWJAuZAqEf9Xhfxg2JwcZfp1rFGh1XwB9hTlQuEkHyG89AEMjAyRuP3oCfetbEDEKyL68aK2Rr3OPMnr-5_ofC1yKbuFMQSJT5vYMj2RyJaIsGaPfhGzBAhKQB3SgCjSBLjACLGANHIAzcAPeIACEgEgQA5YDLkgCaUAEskE-2AAKQTHYAXaDanAA1IF60AROgjZwBlwEV8ANcAsMgEdACobBSzAB3oFpCILwEBWiQaqQFqQPmULWEBtaCHlDQVA4FAPFQ4mQEJJA-dAmqBgqg6qhQ1A99CN0GroIXYP6oAfQIDQG_QF9hBGYAtNhDdgAtoDZsDscCEfCy-BEeBWcBxfA2-FKuBY-DrfCF-Eb8AAshV_CkwhAyAgD0UZYCBvxREKQWCQBESFrkSKkAqlFmpAOpBu5jUiRceQDBoehYZgYFsYZ44dZjOFiVmHWYkow1ZhjmFZMF-Y2ZhAzgfmCpWLVsaZYJ6w_dgk2EZuNLcRWYI9gW7CXsQPYYew7HA7HwBniHHB-uBhcMm41rgS3D9eMu4Drww3hJvF4vCreFO-CD8Fz8GJ8Ib4Kfxx_Ht-PH8a_J5AJWgRrgg8hliAkbCRUEBoI5wj9hBHCNFGBqE90IoYQecRcYimxjthBvEkcJk6TFEmGJBdSJCmZtIFUSWoiXSY9Jr0hk8k6ZEdyGFlAXk-uJJ8gXyUPkj9QlCgmFE9KHEVC2U45SrlAeUB5Q6VSDahu1FiqmLqdWk-9RH1KfS9HkzOX85fjya2Tq5FrleuXeyVPlNeXd5dfLp8nXyF_Sv6m_LgCUcFAwVOBo7BWoUbhtMI9hUlFmqKVYohimmKJYoPiNcVRJbySgZK3Ek-pQOmw0iWlIRpC06V50ri0TbQ62mXaMB1HN6T705PpxfQf6L30CWUlZVvlKOUc5Rrls8pSBsIwYPgzUhmljJOMu4yP8zTmuc_jz9s2r2le_7wplfkqbip8lSKVZpUBlY-qTFVv1RTVnaptqk_UMGomamFq2Wr71S6rjc-nz3eez51fNP_k_IfqsLqJerj6avXD6j3qkxqaGr4aGRpVGpc0xjUZmm6ayZrlmuc0x7RoWgu1BFrlWue1XjCVme7MVGYls4s5oa2u7act0T6k3as9rWOos1hno06zzhNdki5bN0G3XLdTd0JPSy9YL1-vUe-hPlGfrZ-kv0e_W3_KwNAg2mCLQZvBqKGKob9hnmGj4WMjqpGr0SqjWqM7xjhjtnGK8T7jWyawiZ1JkkmNyU1T2NTeVGC6z7TPDGvmaCY0qzW7x6Kw3FlZrEbWoDnDPMh8o3mb-SsLPYtYi50W3RZfLO0sUy3rLB9ZKVkFWG206rD6w9rEmmtdY33HhmrjY7POpt3mta2pLd92v-19O5pdsN0Wu067z_YO9iL7JvsxBz2HeIe9DvfYdHYou4R91RHr6OG4zvGM4wcneyex00mn351ZzinODc6jCwwX8BfULRhy0XHhuBxykS5kLoxfeHCh1FXbleNa6_rMTdeN53bEbcTd2D3Z_bj7Kw9LD5FHi8eUp5PnGs8LXoiXr1eRV6-3kvdi72rvpz46Pok-jT4Tvna-q30v-GH9Av12-t3z1_Dn-tf7TwQ4BKwJ6AqkBEYEVgc-CzIJEgV1BMPBAcG7gh8v0l8kXNQWAkL8Q3aFPAk1DF0V-nMYLiw0rCbsebhVeH54dwQtYkVEQ8S7SI_I0shHi40WSxZ3RslHxUXVR01Fe0WXRUuXWCxZs-RGjFqMIKY9Fh8bFXskdnKp99LdS4fj7OIK4-4uM1yWs-zacrXlqcvPrpBfwVlxKh4bHx3fEP-JE8Kp5Uyu9F-5d-UE15O7h_uS58Yr543xXfhl_JEEl4SyhNFEl8RdiWNJrkkVSeMCT0G14HWyX_KB5KmUkJSjKTOp0anNaYS0-LTTQiVhirArXTM9J70vwzSjMEO6ymnV7lUTokDRkUwoc1lmu5iO_kz1SIwkmyWDWQuzarLeZ0dln8pRzBHm9OSa5G7LHcnzyft-NWY1d3Vnvnb-hvzBNe5rDq2F1q5c27lOd13BuuH1vuuPbSBtSNnwy0bLjWUb326K3tRRoFGwvmBos-_mxkK5QlHhvS3OWw5sxWwVbO3dZrOtatuXIl7R9WLL4oriTyXckuvfWX1X-d3M9oTtvaX2pft34HYId9zd6brzWJliWV7Z0K7gXa3lzPKi8re7V-y-VmFbcWAPaY9kj7QyqLK9Sq9qR9Wn6qTqgRqPmua96nu37Z3ax9vXv99tf9MBjQPFBz4eFBy8f8j3UGutQW3FYdzhrMPP66Lqur9nf19_RO1I8ZHPR4VHpcfCj3XVO9TXN6g3lDbCjZLGseNxx2_94PVDexOr6VAzo7n4BDghOfHix_gf754MPNl5in2q6Sf9n_a20FqKWqHW3NaJtqQ2aXtMe9_pgNOdHc4dLT-b_3z0jPaZmrPKZ0vPkc4VnJs5n3d-8kLGhfGLiReHOld0Prq05NKdrrCu3suBl69e8blyqdu9-_xVl6tnrjldO32dfb3thv2N1h67npZf7H5p6bXvbb3pcLP9luOtjr4Ffef6Xfsv3va6feWO_50bA4sG-u4uvnv_Xtw96X3e_dEHqQ9eP8x6OP1o_WPs46InCk8qnqo_rf3V-Ndmqb307KDXYM-ziGePhrhDL_-V-a9PwwXPqc8rRrRG6ketR8-M-YzderH0xfDLjJfT44W_Kf6295XRq59-d_u9Z2LJxPBr0euZP0reqL45-tb2bedk6OTTd2nvpqeK3qu-P_aB_aH7Y_THkensT_hPlZ-NP3d8CfzyeCZtZubf94Tz-wplbmRzdHJlYW0KZW5kb2JqCjUgMCBvYmoKWyAvSUNDQmFzZWQgMTAgMCBSIF0KZW5kb2JqCjEyIDAgb2JqCjw8IC9UeXBlIC9TdHJ1Y3RUcmVlUm9vdCAvSyAxMSAwIFIgL1BhcmVudFRyZWUgMTMgMCBSIC9JRFRyZWUgMTQgMCBSPj4KZW5kb2JqCjExIDAgb2JqCjw8IC9UeXBlIC9TdHJ1Y3RFbGVtIC9TIC9Eb2N1bWVudCAvUCAxMiAwIFIgL0sgWyAxNSAwIFIgMTYgMCBSIDE3IDAgUiAxOCAwIFIKXSAgPj4KZW5kb2JqCjE1IDAgb2JqCjw8IC9UeXBlIC9TdHJ1Y3RFbGVtIC9TIC9IIC9QIDExIDAgUiAvUGcgMSAwIFIgL0sgMSAgPj4KZW5kb2JqCjE2IDAgb2JqCjw8IC9UeXBlIC9TdHJ1Y3RFbGVtIC9TIC9QIC9QIDExIDAgUiAvUGcgMSAwIFIgL0sgMiAgPj4KZW5kb2JqCjE3IDAgb2JqCjw8IC9UeXBlIC9TdHJ1Y3RFbGVtIC9TIC9QIC9QIDExIDAgUiAvUGcgMSAwIFIgL0sgMyAgPj4KZW5kb2JqCjE4IDAgb2JqCjw8IC9UeXBlIC9TdHJ1Y3RFbGVtIC9TIC9QIC9QIDExIDAgUiAvUGcgMSAwIFIgL0sgNCAgPj4KZW5kb2JqCjIgMCBvYmoKPDwgL1R5cGUgL1BhZ2VzIC9NZWRpYUJveCBbMCAwIDYxMiA3OTJdIC9Db3VudCAxIC9LaWRzIFsgMSAwIFIgXSA-PgplbmRvYmoKMTkgMCBvYmoKPDwgL1R5cGUgL0NhdGFsb2cgL1BhZ2VzIDIgMCBSIC9NYXJrSW5mbyA8PCAvTWFya2VkIHRydWUgPj4gL1N0cnVjdFRyZWVSb290CjEyIDAgUiA-PgplbmRvYmoKOSAwIG9iagpbIDEgMCBSICAvWFlaIDAgNzkyIDAgXQplbmRvYmoKNiAwIG9iago8PCAvVHlwZSAvRm9udCAvU3VidHlwZSAvVHJ1ZVR5cGUgL0Jhc2VGb250IC9BQUFBQUIrSGVsdmV0aWNhTmV1ZS1Cb2xkIC9Gb250RGVzY3JpcHRvcgoyMCAwIFIgL0VuY29kaW5nIC9NYWNSb21hbkVuY29kaW5nIC9GaXJzdENoYXIgMzIgL0xhc3RDaGFyIDEyMSAvV2lkdGhzIFsgMjc4CjAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCA2ODUgMCAwIDAKMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCA1NzQgMCAwIDAgNTc0IDAgMAowIDAgMCAwIDI1OCAwIDAgMCA2MTEgMCAzODkgNTM3IDM1MiAwIDAgMCAwIDUxOSBdID4-CmVuZG9iagoyMCAwIG9iago8PCAvVHlwZSAvRm9udERlc2NyaXB0b3IgL0ZvbnROYW1lIC9BQUFBQUIrSGVsdmV0aWNhTmV1ZS1Cb2xkIC9GbGFncyAzMiAvRm9udEJCb3gKWy0xMDE4IC00ODEgMTQzNyAxMTQxXSAvSXRhbGljQW5nbGUgMCAvQXNjZW50IDk3NSAvRGVzY2VudCAtMjE3IC9DYXBIZWlnaHQKNzE0IC9TdGVtViAxNTcgL0xlYWRpbmcgMjkgL1hIZWlnaHQgNTE3IC9TdGVtSCAxMzIgL0F2Z1dpZHRoIDQ3OCAvTWF4V2lkdGgKMTUwMCAvRm9udEZpbGUyIDIxIDAgUiA-PgplbmRvYmoKMjEgMCBvYmoKPDwgL0xlbmd0aDEgMzY1MiAvTGVuZ3RoIDIxMjQgL0ZpbHRlciAvRmxhdGVEZWNvZGUgPj4Kc3RyZWFtCngBrVdtbJtXFT73vv5IHMf2G38m_sj7-o3txHZiJ46d5mOpkzlRu1Ysa9dibwtt2rhroGnLSMYmMVGJVR0RRBP7MaGtGxL82BBIRirFy4-2PxCCCmkVvyoUUMUfxn4yKkHb2Dz3tRs1o0xVtdc6955z7r3nnvPccz-88tJqmax0jiTKH19eOEv6Z7qF6o_HX15RdJH4s6h3nTj74nJT_gGRoffFU6-eaMjm3xKZAifLC4sNme6hzp2EoiGzYdQ9J5dXXmnIpkuok6fOHG-2m38B2be88EpzftqErJxeWC43-tt8ov_ZM99aacjtt1DvOvtSudmfFSHfbbQ9UDLwbTRFXNc1yhBBNPTqGtEO-pPr0odH7BO3Waf0idBffvLf-0X911v98j1Trdt40bCKfq1NO_oY6eN6jILGTbR_23hRWNnxtVXJlWAbZCAHeRLsKskUo27qog6ATRRIXAWXpMgOjZN6dvShq2SjNDop5N0eZqdhSuzQOCi-wxBtkAsT-xNValdmXlvyFapkSUDLEIBVeCU1mCtgemGqE760UUfiCkb1UBCTyWSBTFcwJAPrKlQ2vQOHFCY_OeEPOmyQEWNkzET3Z4JzLlqm8_RDeheROmhf3UZGbqPrXCY0rdA36HVap-_SRTTL9aeonRvJxq-TDCvJfVVqnSv-irH1UpXVz1cLFPwIyEtHvtZfJZZUlJmlQoUdhcCTUMRVcFJSma1IkdkDRa2krClrexfXlFnl5MJixRDRazSU10oppUIHi0sony2qlXzJv82WS6Ux2DEIOxiC7mslWPh60wJqXZXaQidjcp9SkaJzxWeKlXMFfyVfKPlVVZmpXJsrVq4V_GqphF6mbU_hsViChs9m-GyKo72lYeUgbMBEaW1N2ITEo2rl2tqafw2R6BpNrTJqKhCp6CNFZqosP1cUTXlN9QuFpmoq_CgVYLs1ue9gcQaeqMITy_9ASoUHIG3bdhR9rXCvTYe0_UuC1PYokNofCVLHtqc7IJXhs0NA2vFwSLUvAHQb4fxDED7XQPjcQxB27kDY9cUIu7f9hpMeeOvWEfZ-SQj7HgXhzkdCuGvb0x0I--Fzl0A4sI1w3l-h7aQFwuc-l7L0f3P4cSEPPgA5-xfJzINz_Jf1O3ySFFCQcRrjxynHzlOOd0I-SiZuros7geEnPiuZcKLhpKLnmhpd_ZhF4zZ5zMEYJjWHGnaYMDYlE2ozteDku_9ZdMZDHpqly8zKetnvOOdv8JuSDae5TBL7GxcnuxkBq7LqlFWZXah9wnzP11L8SI3481t7-W8AWv0Oiks4byUc-hHCsZfCqQZqTW3os0riOHdswCoOd7ljND3oZxmnxDIjqjfD_jPPn_t57Z_v7WJtuZ_WbjMXM9XusMtbufffh01xuSr1z7iPO3ER5AmmXIn04JSEe6yF2DyYEdLuM3kwBFWOxsE5J6XMUIi7ZZfHqw2wmI1p4QGeHZ40xYYHuBY2mb02yWyT3K4QzwxN8mxaShYOJWJz0_EWy5sGIwu_kI7k0_7uwd35yXSA2TtVZzxt2Gj1d4dlR7fXZvMpcnzAY2QnhqZ75TZlNFX7TMs7rJ3tWqAjOtabHA3LFpPV6_H67cae-FJLq8kgSRa5y-XsspsCsV5xdXMKIr4exNeCm3D3BpbIRQKyVgfuoxu4EsWFKhQKMLQj5wRvBy9eEIJn6NgJCm6mB5kmgvaY1ZyI0MYbseVGNBF8lP3o76zN3x8ezvyFrRoCu49Njy_MRiOFY08UvxN6zTyZmMizMXs07N315sTpw5n43sWxicU9sbl5X2JSpAujMZS_19faL5IDaQcHJExu3MTKM6w6pdKDTjkjj63z61s5fQkRY66-jxcQoxP3_dUqJZEaXnLro71i9I1GyiTBK5sIb3PKSH9GtJ-C-PyUH6HaAYOd-kCjoL2gEmgJ9Cro-6Afgz4EfQT6A6h9vkrCei-s92LGPszoRQI2tHFo4yl47UZTBA8UEUoEuBLeI4IXOesDTxgiBlsoomdvpJFFyBkkl8vGmZzJZkJMT6FmYmlZNh5OB9utwZQWToVEXbu5zrueSY8eGg0ExopPpOe6-Hygf6JbmRgIBlMT3d0T_QH2wdbs7Wgs-dTR4ZHy_oFofFpgnkPxPWDnpsENFA3M3YiLIwIuImCIwIb8EV7b4LULvE33FSuBhIerHm82KhLCrGVz6zY1F2sPWGSbfygZtnBu3Lr7D22iv0virxsdwT7fUUzCRF6ye5h3lJYFKAzmNyiE95yYJoT5g6C2zQ28-XAg6rj2IgHcWD_RkoZ3acii5_gm8jjbzN0sPNTwUBVmNDSaQIRBghc5PKKFkMPYjwAzNiDd9z8zIN3PaG-ICeDFdv7ZBZ548nB_8tB0X2BgvDs01h9weAPW6C7pgqFv8ul4fC4fEw37D3X4Vbs7FnJ-MDwT75DjM5meQdVlNlvtPqfDaZGCfendUYc9kh8Kp7qdZoeiODvtZotb1UM31e-yA_wnSMGDYuNx3Xmx8bgI4EZjE3puNNdCvGZFdE5EasCpJ3gDOhI6WlHbUdsBjRG89wb2S1Zza-6MrB9EuZGsvlmzWLpP1w8f7uofV93JDovH2uM7yY3vvHOk9nEs3dXKpdOc-3oYHSFWv4v9Jd69biwP3i-w7QSJ_WhEbhiw75ieD0anJuHn9LhdJrMpGnOLvM2x7M23vslX3_61yR9wx12ehGfvgTyfqb3HjtX8dtkblZiBr3IJmYjQ9a_-Lg01uM-VbZAlPPsLtIeepoN0iA7TV-kFaBn-FiBR8JmAI02Jbzqxp3zq5fLK0vGFr5RXy_3TZ04t0n8BcHfSQQplbmRzdHJlYW0KZW5kb2JqCjcgMCBvYmoKPDwgL1R5cGUgL0ZvbnQgL1N1YnR5cGUgL1RydWVUeXBlIC9CYXNlRm9udCAvQUFBQUFDK0hlbHZldGljYU5ldWUgL0ZvbnREZXNjcmlwdG9yCjIyIDAgUiAvRW5jb2RpbmcgL01hY1JvbWFuRW5jb2RpbmcgL0ZpcnN0Q2hhciAzMiAvTGFzdENoYXIgMTIxIC9XaWR0aHMgWyAyNzgKMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDI3OCAwIDI3OCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCAwIDAgMCA2NDggMAowIDAgNjExIDAgMCA3MjIgMjU5IDAgMCAwIDAgNzIyIDc2MCAwIDAgMCAwIDU3NCAwIDAgOTI2IDAgMCAwIDAgMCAwIDAgMCAwCjUzNyA1OTMgNTM3IDU5MyA1MzcgMjk2IDAgNTU2IDIyMiAwIDUxOSAyMjIgODUzIDU1NiA1NzQgNTkzIDAgMzMzIDUwMCAzMTUKNTU2IDAgMCA1MTggNTAwIF0gPj4KZW5kb2JqCjIyIDAgb2JqCjw8IC9UeXBlIC9Gb250RGVzY3JpcHRvciAvRm9udE5hbWUgL0FBQUFBQytIZWx2ZXRpY2FOZXVlIC9GbGFncyAzMiAvRm9udEJCb3gKWy05NTEgLTQ4MSAxOTg3IDEwNzddIC9JdGFsaWNBbmdsZSAwIC9Bc2NlbnQgOTUyIC9EZXNjZW50IC0yMTMgL0NhcEhlaWdodAo3MTQgL1N0ZW1WIDk1IC9MZWFkaW5nIDI4IC9YSGVpZ2h0IDUxNyAvU3RlbUggODAgL0F2Z1dpZHRoIDQ0NyAvTWF4V2lkdGggMjIyNQovRm9udEZpbGUyIDIzIDAgUiA-PgplbmRvYmoKMjMgMCBvYmoKPDwgL0xlbmd0aDEgNzYwOCAvTGVuZ3RoIDQxNjYgL0ZpbHRlciAvRmxhdGVEZWNvZGUgPj4Kc3RyZWFtCngB5Vl9bFvXdb_38vtDlCh-i5RE6omkRFKkKJof-qYsUZasSlFsM6bsyIotK5aLuDYSN026LfDQxUmFrXULtFvSoCsSbO3QtVC2NZHZbTGabW3TBjA6LAEyoRg2bNiKIAiCtBvSitrvvPdIS1oWBEX-GLBHnXfPve_ec889X_fcq6sPfnKNWdk1pmHF1UtnrzD50a-j-PHqw1eDSp1_A6X3_isXLqn1W4xpey488Oj9St3wCGOuv1hfO3teqbNfocyto0Gp80Mou9cvXUU_enT_jte1By6vqt8N9P3wpbOPqPOzbdSDnzh7aQ0lnvYbePVcufzQVbnK2hMoz195cE3tzyuozyvf9rw58CCbZEJuU94dDFVtj9xC3wHvPObVrjSP_JzbNcQXe2HyPirYT_-pz_6r2Vqn4WVtFlWTSkceo9najbOA8Xl8v2Z4majse4JbzBnnVYwQzB3nL0G8YyzP4qyTOdAxEGcv4cvR_U1VpsXPH99iPFj6rYveqS1mRgWjGHPS3xw7BdS-O8QsQses4hVmx-fE3BYzLVae5_xzS1t89_GtKdZ-E9xqVs70gVQiGCxdnNrk96EiEmiIhYBpEsHpTU14-lhFWgpuBDdmz28Ep4PrZ89vasNyiQ9rG0up4CY7XrmI94lKaLO45G-ga0tLQ6CjJToYgu4bS6DwcZUCSrkptYNOusRccFMTWazcXdm8NuXfLE4t-UOhYGnz1mJl89aUP7S0hF76BqfgmJav8GwAz_oYvhsVKsdBAySWNjaIJmoiEtq8tbHh38BK5BYptMWZ2oCVUh9NuLTFi4sV-lSUQn5qkEJSCHwsTYG2KTF3vFICJyHixPw_RMqm9ojU0mAUfa1gzyKLtOkjEqntw4i0-UOJtKXB6T6R2sFzC4m09f1FKn2AQBsSLr6PhK8pEr72PhJ27JOw84Ml7GrwDSbd4NYlS9jzEUnY-2Ek7PtQEm5rcLpPwn7w3EYSDjQkXPRvsobRQsLXDpgs-19t-NcVefsekfN3WYa7Ebrc7DiBeHL3PbHKFsRP2ALXsGMo58V_sYgYY0LzVcQWH-sWd7NJteymkvegPcGK7KesJAysRKWmzIrUhnFyfz7PRjFXJx9mJrldz0yoGxG3uBolrUzP_hr1IKLZwbiJZvmhWK1R8Q8utOpnnVzqmaHR3YgYWH_MMmKpV_eUVtbEbKyZtTA7Wlvl8OxkLuZmHuZlPrS1MT8LsHZ5TAcCOD0z-D3MbrBb7B2e5DP8SdEjFsSTmi9qY9pndEO6Z3Vv6Yv6j-uf0b9gWDT8gbFgvG2smZ41vWueMl8xvwEKgmUY5z8WP8A6DWyN9guEuBTiOcDYgph3G5C6iY6ad9HachN7A2GmbYYgXqog9qb81GgeW1IbdNSgY1pq0GIAZsEAHTDsQ-_2p3nIHnLYQ3b-VO1VnsnULoind74kntoZFN-HJo7vfoJ9j11GNtBXxQsKAEdWcMIABnBjSFVlRVrtrYPgQWG2P513Zdw2YXCN8VF-fJjrbB770KHLl60Bv0c_YD82uEa0QY5oa5i_KiuWaGtaWBXtXJ6ItciUsscv4yHOd9_D6wb2OA2zsDDm00IwOoAJbDDIjEiwFtpjsWSw1J_284xDwzP5kCfDf_io-NQ3az87u8iTCxdr_8GjfL725_y5ndzrr4MmzboA-mPALSxTlU2FCJqwVu1t8KWV-aKZsJOqMxkxE-FG8Ao5Zuu_Bf527TJ_qPZ7_HPilZ3c4n8u_ssiBqpz_I48x5EqJlJkagHTepWUHvNZAALy1aE03sZKyQQMAC6vuMrMkAHNa5bnzUCDGbuE98IKf2RlpfYkTcqP1G6KV0ivNO8xTPW8LDvPPnkrNFmK-M_Yj63QSFkcGIP8SVyXeZ3bO6YKURvl6Q3EH8AMXs0pskKZvzq_iswYNEEcw7NlndA8GU78Snz-lOCfXD8lFI7F6M7LmP-vxCTJSrDI7tviJ-If4YFR9qMt1gPivYAezOjEjE7gbHvCD9ExeCdjEUAOMA24B3A_4GHAdcCXAX8MeAHwd4Cm5Qkd-wcg_woQy6AMqh3bWMc2PrwBfn8GEMsgbwLiA_QCBgGzgCXARcCjgM8CngL8CeAm4IeApmVYTDOGkZaaoV5JVa9EGjs0JjIDHcLltAmpKymizg7Ux0T2UBJ1m3g8MHJmYuLMSKBersTvuVYuX7snXi_5Wu7iiUzmxMVcvZx9Yn10dP2JWZRjY-tPYFEcEmRiFPozsOhe_cl6IoNTPIYMjhSpua3YQCYbcr298tbO34pP71wXn14kw-Xk_povglYzy-7Rs4lUALDAAynuclnXcmyXMZva1p8OOSSN-nNk8BN__9LKF8RXL3xN_O7ZF1f_SDwHxX9bHJMhJyo73wD33bs_F2ZhZ_3sML-X4uF3WQGG38S8wGLAEJAhXg-Y192mUDBhx6oKsIUCbKEAWyjAFgqwhQJsoQBbKDAj6f1xIF8CkN4LCIZBxNGbCOQUTT2o96vYFkuDbhoLjGGOqUacDVNYDTNjI84KasApotFgpAYjNVSheMHCEMcWC4N2AIEXLHwWyFNUWQbTRiBeQA-gAJgBVADrgEcARvAZBgedsE8BGkmiYYf-khBBEt6RxLkhyY4ATgIuAD4FkNd6HciXAWK5inUpnFRZusHTKNQe1ktdkayNkzFmYZz5MY1ii3qDNKaRTdXudGcG8lGbzlU3VmF2R0NRaTknjSf9HenxkDTeH3CFep25GU1ZdI_MJ6RSocvgtDRvtBwaHEq22_3dzthIpFU0hWOxcEtXPpooSK16g6HJ5w10tep7B_sP97aaOwt9tV90BHTft1oMJmc46GpvNXqk3laYEpiehE30wQ69LMG-tcWSMDwvPpCbeSEhippUalHS9pAEboPUqM2NNjfabMB9ipf74OW-upf7gPrg5T54uQ9e7oOX--DlPni5DwrzQWE-eLkPXu6Dl_vg5QplCZQlin8M7HSo-0MHvN4BlRJrDiVOZzMdkGbd0SFcO1dDAEmd5DxZFrbeZMoxvDTc3jG8NJI75RJ8uKV7OJEYi7baIyPx3tGog4J0ydPZaozNnsvnz80lonFuqY1GZgpdodyRSPd0viuYK5HvkQ_x9-BDEnu0CkuyyOwEWuSoGYCnBOApAXhKAJ4SgKcE4CkBeEoAUTMAwwkgagYQNQOImoF61AwgapLpIsZ5kCfRCj3yFhaScYooDEJvQencRpaRSWoorimmk8tLdywtM-Dmf1jRRYbnE6P3jnZ0jp4eXn3IdtJ4ZLxnqNveEh5L5op8JTmZcMXn1oaGzk5H1u8bORzMTnVHZwtdOcUmKE7YYBMO2MR3t1gflEDpGrHlAgt9gK7bAOj-o9sv3KCq7HuwKuBezODFDITHgMfARZx1MZfs-dSaoJ3cheZmeCwxR_tCu7ovtMNC8gf2BR3tkftFl3E91tI9Et9rDPyGbDNJ516bqR2whTeQCfzC0-kwxmWLOZqIxKdlfyLZaWAfZtjB6SquFBAFwZoTrLlUvyIZOgEcq6LMz4rSmpL3t-7GOtoQeWlgGwZykCGco3M3DSAbCCmBxKMqPx_KKZudi1wix79ee124I9lQMBv1nDhhKeViYz2tnH9GuPKnS9mliW7ROXZ6rHKVH-rI9ng80dy3MwOB1GhXar0y2DNzbnj4_ExPRdmneC_OLh521949T8meifsmGCaVTtIGhzZo7cSt_cCSqZPmtmJCusbeKGUP5WC0nmwS0VLfziXXavn8-a5OS5vF2mmdnj3Jq7VpXp2b6fJqtEe12onx-TnywyJeb8JG29jdVbyUiEXCsqk-SVGpDUARjErFnuSYQnySyCmeKImXAwN9oHono5JNx-1CbqUmEQguxbIjMhhNF8r22FTGk-7rNguKHLxbGk54C_21Z_mJWGkgYHaFvNyO2EoR42nwSOcPTEYJRF2NAhxRTCWV6klyOrmDsgxO0S0rtXPM_nS5LM6try_v_BIXUiABmsIAmnJOfSffpXXK8idKUAioGdX1HMgVs3lHRpOXDPZSefH5B7ZffRBS3Mn9zdHaO3z2L_-Zf12ZQ-X7g3LbUpkGghU8sj40Lth9jL24306atic0bAVJBl8G8vk6EqwjmzKC4Ea7CvX9PDYgue9KHQnWkU0Z2WL-bUoAm1iLHAs0kGEPZNmDRfeSJcitfrQm5AwD8rABfPgcUfUdwUdKtB0YRnhQtcd6wCC1wyyRUtYNQG8gAzVI2WK5OZQNt4fdpvLMeGfUbSz7-sajmXJby0L_pSEhdDu_5Ieb-2Id9s6Yr_YtfnhkprUz5gX2Gz2D3fZkrL-n8rGGzGDDdvhWaa_M9tswrc4FNinQudXVqZreb8FKtnnAbmWG91jtQ1mFwwMmewbHGSU_bAM__9_OB4_5EsOh0HDCVy9PBYtnRseWi8FgcXls9EwxyEVqdqCtbWA2lZpNt7WlZ1OD52Z7e2fPDQ6uzsZis6tQDOVSw8il7DDS_4u5FMXmO_nT3rxKPaccyKWyul8vl9IhIpr3J1PTB7dPxf5HETjmhQMhWz5PKdcUZO9NsPcm5fxLFwdKjDZRVLRn5MwuG0Gylx0tOxMzmdKpTtmm_21gPhc4JUbG8S8UzjqRp70GXQyxb9IVA9Gu4lyi7MZBhPs08KAcKdIp-YSaRu6KNF45oaaxHaQRTdLIXdPIXdPIXdPIXdPIXdPIXdPIXdPIXdPIXdPIXdNy7mpR98IYSheA7h1GtrGz59TdPIeJw9iuaBugA0g9s1MOI8hYpDtKiCZxaFCyWM-dhE9bP-RepTPBQjx613i0PTUa7Bjp73QGow5Xb5dblDVdg0cTXaW8NDBXmRvwhhPOtnTU-1z_ZG9rc2QsFR4IOXFMcLS7nb5mvckZ8qXGw812qRAdKHTaXV0hb2eL3uyJQmy44ePt4muIUchmDu5geuiJ9EV3V7SjebBm0h3tao18oBlnXVovZWdaNTvTogNDRx1KF8XerOSSXBk7zkLDPCsfm6DpF8qViq09FZqIOn023QWh-8pX5movdie8pjmNubWZTyATINUWoes3sT16KReg60aazorpDvKrnFgoyRby0VrhupEZ1LMCI_yESNAtVAg5o-wHkSxhdLGQy2dc_M29ucDgCT9MsLat5AH8TO1PkQf4-_rpkkiV4Q74syBPVe6dzNiPaDYtfFKDHgYYIlm6gkEemkzeI2_TUelH37tw48alH_zZ_b_9m5d4S-3t117jnre-8x30Ne6m5XW72XXIO067At1a2umsjENw4_DsogbXngb1GlNPp2kTVGLH9DchOfUUbIWArODVilOwFadgK07BVpyCrTgFW-unYCsOMxiBU7BTpdCf1tlwLolEsx0cUhrnGrqYyHBLc7sUDzR32Czt5jbJJL163--LL5wqRQ6FmrW6BZ3B5zkpRG0JqQfUIj-7z7ABBTvwDqKuQb5vZ904CcYRZ9PomYeXTyEzmgavM3DWOfYx3D3exRbZ3binO87KOIedxAXAaXavTI_jFhq5Hh49mGcT9EzGZ9YeeHjt6sXVswtr-I8t-29Q7uggCmVuZHN0cmVhbQplbmRvYmoKOCAwIG9iago8PCAvVHlwZSAvRm9udCAvU3VidHlwZSAvVHJ1ZVR5cGUgL0Jhc2VGb250IC9BQUFBQUQrSGVsdmV0aWNhTmV1ZSAvRm9udERlc2NyaXB0b3IKMjQgMCBSIC9Ub1VuaWNvZGUgMjUgMCBSIC9GaXJzdENoYXIgMzMgL0xhc3RDaGFyIDMzIC9XaWR0aHMgWyAyNzggXSA-PgplbmRvYmoKMjUgMCBvYmoKPDwgL0xlbmd0aCAyMjIgL0ZpbHRlciAvRmxhdGVEZWNvZGUgPj4Kc3RyZWFtCngBXZC9bsQgEIR7nmLLS3ECX42QootOcpEfxckDYFhbSPGC1rjw2weIc5FSbMHMfDCsvPZPPYUM8o2jGzDDFMgzrnFjhzDiHEh0F_DB5ePUNLfYJGSBh33NuPQ0RdBaAMj3gqyZdzg9-jjiQ9Ve2SMHmuH0eR2aMmwpfeGClEEJY8DjVK57tunFLgiyoefeFz_k_Vyov8THnhBKo0J0P5Vc9Lgm65AtzSi0UkbfbkYg-X_WAYzTkbx0RtdRStmW_3UqWr94r-Q25tKm7aEVrQUC4X1VKab6YJtvfCZwQQplbmRzdHJlYW0KZW5kb2JqCjI0IDAgb2JqCjw8IC9UeXBlIC9Gb250RGVzY3JpcHRvciAvRm9udE5hbWUgL0FBQUFBRCtIZWx2ZXRpY2FOZXVlIC9GbGFncyA0IC9Gb250QkJveApbLTk1MSAtNDgxIDE5ODcgMTA3N10gL0l0YWxpY0FuZ2xlIDAgL0FzY2VudCA5NTIgL0Rlc2NlbnQgLTIxMyAvQ2FwSGVpZ2h0CjcxNCAvU3RlbVYgOTUgL0xlYWRpbmcgMjggL1hIZWlnaHQgNTE3IC9TdGVtSCA4MCAvQXZnV2lkdGggNDQ3IC9NYXhXaWR0aCAyMjI1Ci9Gb250RmlsZTIgMjYgMCBSID4-CmVuZG9iagoyNiAwIG9iago8PCAvTGVuZ3RoMSAxNzg4IC9MZW5ndGggODQ1IC9GaWx0ZXIgL0ZsYXRlRGVjb2RlID4-CnN0cmVhbQp4Aa1VTUzTUBz_v7b7AKYyvkSK2mZCiBvZFD-iMWbEjqBEM8VD60FYoMIMA4LD6EGzi5cejBcPGo8ePNaLKVxY4kFjNPHg0RiPHo3BmzB_r20apkiI4XXv_T_fv7_3y-t_5YVFk2JUIZGyE6XCPLkj9B2ia-J2WfFs9gKy88b8VMm3q0RS39TM3RueHW6DfDRtFiY9m35BnpiGw7PZMchD06XyHc8OfYOMzsxN-PFwDHa4VLjjv58-w1ZmCyXTyw9_guybn7tV9u3nkJn5BdPPZzrsi15sw8qgCxTF5MNbD3BF6nM9PI75436nNLbnzE8WFzkuenVunAv68rU__uv8-sHIa-k4zAa_grtHdGpJ6o6-RLwSec2r1A3BobYkW8YOgTqSbAX0nqWTlKSD1IrE7iStIHKh3rVMEh456RBTcveKnZpDjTCwi6iN_0boGtR47TQ1CSGKCe8ojnBqxKGGvP6SsYeGw2oPHI32LwGtOHa9H6VSipIrajYbhyGk4DisQhNTypAt9gxd0ROGYinW-UlLGVKmC5O21ONKBEzLSCs2jepFrFd11c4acqCahnEadSReB1uQbhmocNOvAOm60mtICqVGFFvszeuXdbuiyXZWM2RVVXJ2Na_bVU1WDQNZ4QApEPPje5gjwBw-jHjUqzKKGihhWBavCUvoVe2qZckWTuJ6EqrDyHfgpDxH7Mk5LJvXeSibUGXuSKgJFTgMDbUbUiOjeg5IVI6k8S9KSdtAaVMAFLkxwGtyKd21Q5Tu3g6le7ZFaXOAtI7SODA3c0pbNqc0sQWhAcPZTRiueAxXNmG4tY7htq0Zbg9wA2QH0La7DO_dIYY7t8Pwvm0x3BUgrWNYBuYuznB3wHBWtim4tGC48seVpX_e4f-lfP8GytkqDbAOdA_evbxuFaMwOj-RGniIhvHwBjlAjL0X3qJtRcjkvQyfXxq9BjPajO_xI2Z6CYniKrzNS-hbXGv4TGgwOR19IS1zZ-NZw3eEuCNEEndI2IC3YEMIGnrkauYIU-Nqa1yNsyfrH9jAwPqU8HTtsfBk7ZTwBhnuqD2jo572x4o4EyKLs8VMJjPoxhi1-KcM89Y5yIeWHDZnbpvl4kThkol_PfoN6L-nmgplbmRzdHJlYW0KZW5kb2JqCjI3IDAgb2JqCjw8IC9UaXRsZSAoYXBwbGVzKSAvUHJvZHVjZXIgKG1hY09TIFZlcnNpb24gMTUuMiBcKEJ1aWxkIDI0QzEwMVwpIFF1YXJ0eiBQREZDb250ZXh0KQovQ3JlYXRvciAoUGFnZXMpIC9DcmVhdGlvbkRhdGUgKEQ6MjAyNTAyMDYxNjAzNDFaMDAnMDAnKSAvTW9kRGF0ZSAoRDoyMDI1MDIwNjE2MDM0MVowMCcwMCcpCj4-CmVuZG9iagp4cmVmCjAgMjgKMDAwMDAwMDAwMCA2NTUzNSBmIAowMDAwMDAwNTEyIDAwMDAwIG4gCjAwMDAwMDM5NTggMDAwMDAgbiAKMDAwMDAwMDAyMiAwMDAwMCBuIAowMDAwMDAwNjE2IDAwMDAwIG4gCjAwMDAwMDM0NDggMDAwMDAgbiAKMDAwMDAwNDE4MiAwMDAwMCBuIAowMDAwMDA3MDQ4IDAwMDAwIG4gCjAwMDAwMTE5ODUgMDAwMDAgbiAKMDAwMDAwNDE0MyAwMDAwMCBuIAowMDAwMDAwNzM1IDAwMDAwIG4gCjAwMDAwMDM1NzEgMDAwMDAgbiAKMDAwMDAwMzQ4NCAwMDAwMCBuIAowMDAwMDAwMDAwIDAwMDAwIG4gCjAwMDAwMDAwMDAgMDAwMDAgbiAKMDAwMDAwMzY3MCAwMDAwMCBuIAowMDAwMDAzNzQyIDAwMDAwIG4gCjAwMDAwMDM4MTQgMDAwMDAgbiAKMDAwMDAwMzg4NiAwMDAwMCBuIAowMDAwMDA0MDQxIDAwMDAwIG4gCjAwMDAwMDQ1NjIgMDAwMDAgbiAKMDAwMDAwNDgzNiAwMDAwMCBuIAowMDAwMDA3NDY1IDAwMDAwIG4gCjAwMDAwMDc3MzEgMDAwMDAgbiAKMDAwMDAxMjQ0OCAwMDAwMCBuIAowMDAwMDEyMTUzIDAwMDAwIG4gCjAwMDAwMTI3MTMgMDAwMDAgbiAKMDAwMDAxMzY0NSAwMDAwMCBuIAp0cmFpbGVyCjw8IC9TaXplIDI4IC9Sb290IDE5IDAgUiAvSW5mbyAyNyAwIFIgL0lEIFsgPGI2ZTBhMjA4YmMwOWEwNDQ0NjU3MmU0NGQ1ODViNDQwPgo8YjZlMGEyMDhiYzA5YTA0NDQ2NTcyZTQ0ZDU4NWI0NDA-IF0gPj4Kc3RhcnR4cmVmCjEzODQxCiUlRU9GCg==",
-      "mimeType": "application/pdf"}}], "role": "user"}, {"parts": [{"text": "The
-      title of this document is **Apples are tasty**."}], "role": "model"}, {"parts":
-      [{"text": "What apple is not tasty according to the document?"}, {"text": "Two
-      word answer only."}], "role": "user"}], "generationConfig": {"temperature":
+      "mimeType": "application/pdf"}}], "role": "user"}, {"parts": [{"text": "The"},
+      {"text": " title of the document is **Apples are tasty**."}], "role": "model"},
+      {"parts": [{"text": "What apple is not tasty according to the document?"}, {"text":
+      "Two word answer only."}], "role": "user"}], "generationConfig": {"temperature":
       0}}'
     headers:
-      Accept:
+      accept:
       - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
       - keep-alive
-      Content-Length:
-      - '19831'
-      Content-Type:
+      content-length:
+      - '19844'
+      content-type:
       - application/json
-      Host:
+      host:
       - generativelanguage.googleapis.com
       x-goog-api-client:
-      - google-genai-sdk/1.56.0 gl-python/3.11.13
+      - google-genai-sdk/2.10.0 gl-python/3.12.13
     method: POST
-    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:streamGenerateContent?alt=sse
   response:
     body:
-      string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"red
-        delicious\"}],\"role\": \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\":
-        {\"promptTokenCount\": 297,\"candidatesTokenCount\": 2,\"totalTokenCount\":
-        387,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 39},{\"modality\":
-        \"DOCUMENT\",\"tokenCount\": 258}],\"thoughtsTokenCount\": 88},\"modelVersion\":
-        \"gemini-2.5-flash\",\"responseId\": \"f7BVaYilMuOi_uMPvcOsqQs\"}\r\n\r\n"
+      string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"Red
+        delicious\"}],\"role\": \"model\"},\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
+        39,\"candidatesTokenCount\": 2,\"totalTokenCount\": 235,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 39}],\"thoughtsTokenCount\": 194,\"serviceTier\":
+        \"standard\"},\"modelVersion\": \"gemini-3.5-flash\",\"responseId\": \"eoFfauWZG_yY-8YPg7mH-Q4\"}\r\n\r\ndata:
+        {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"\",\"thoughtSignature\":
+        \"ErYHCrMHARFNMg/kZdkmSt+hrzxUUOvpCYUVoc0tLvA8YB0mP+BQ6LyAo4S29Cxuv0nljq6sbNG8V9WCVr6pCxIBRuwlnqGDcWhOAN2GuIdJcvza8tm7FCvd2s0Bmh2YUswbkIVy09Ee3L/R5gI5Hdvdo7T7mLFM/+f63hqvzbZYOeiCchjER+FMMyS3K9Wyz7wVambENGYd/zRgWhQ2UtPKTl41TP2mCZbf9UQkao+YP/TNLBojEOAYHITUGYwkpZwLMWmYp2oRIPIb91eUMn3Xp816Hn55zM6ZTUvQrt3VlTvZ1EvOXXTLCHnmXSxnmtYGkbEBwtC4zTNuIMN9EvaOwAz/3fMJoK0pFpPuuavvByR85uQbCMOqM7ZHXEUIaXftXynTSE7MB+bADGocRGwNmfR0Cz9UTJQaZS7x2crXe6YY2Yb/yD2LrF6Q9AmT/kVaIcR8fayZqPz9R4vDU9mQXehF1rPqUR3BKmnQGPFsi7qB/AMYCqka38FNuUghPtIqNFbEYm/pKC0yqQfPBooNzkgP98XUcDdKBdUw6HVK6lgBLpwN8e3K7jZt8PMxHz5DmgDmaIC0KJ/XtV9FxDaMOXbFSEW56kH656NNhDmKW/qRGshD8qMmlRN/v+RPH/a+DhOPm5Rxmqo+n5dwqNE9R+PUHE4tge67l54ZhMY9LiJKUT5vJDeXvM4zd1DP0FqModkLrWTDibhx4JkErjLVIttYTc8rR5GMJc9iw1frBUzqMYCnbEkC+X7iPD/uYflK2S+7Bj3MZoUxclvfWSx0OoTLpnQsUk6HmttHOVLkkULLBXSaltg4R7RMui7u5RF7DkpEZKpj7au2uEbj+Q9KJrnRHbAOqthrXUok9j6bfn5Vzl2S7rMJGo5HHqgPiybkYRap7q/MaAf9eJX2hgc4eKu4JtJM2EGHLrKDUg1TPxS7HRqIF2YO1P3BctiR3jwpHNltIYCQ0c0vdic0/LnNTXR82nhew2163n5b6p2XFkNs8XKqAN59hzCQTSN1tQC5+KXzZCWrr0bn6pykSXe9Pfeznxx1t1rUUmkXLMxlP3ZZZ8Fi4t67v5oeizNopsMr1760zBAH8GU3pSBgx7/llz9oj16kRhI8AeOwyFfxppVY1Bw+s1BzY/0H7k1cfSXYrJPq+3+9dd/ha76UYFUQ6MYZ8SpUQlwyM1DOERPy1G5p7EVVJ9Uc3yRkRKqpsRfWFQtb9mhyT+EvkLpuOslVhhjgqURejAangI1Ms4P2RN3oCncEC9g=\"}],\"role\":
+        \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
+        559,\"candidatesTokenCount\": 2,\"totalTokenCount\": 755,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 39},{\"modality\": \"IMAGE\",\"tokenCount\":
+        520}],\"thoughtsTokenCount\": 194,\"serviceTier\": \"standard\"},\"modelVersion\":
+        \"gemini-3.5-flash\",\"responseId\": \"eoFfauWZG_yY-8YPg7mH-Q4\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -98,11 +115,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Wed, 31 Dec 2025 23:23:44 GMT
+      - Tue, 21 Jul 2026 14:26:04 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1287
+      - gfet4t7; dur=1772
       Transfer-Encoding:
       - chunked
       Vary:

--- a/tests/_vcr/test_provider_google/test_google_respects_turns_interface.yaml
+++ b/tests/_vcr/test_provider_google/test_google_respects_turns_interface.yaml
@@ -5,29 +5,35 @@ interactions:
       "Return very minimal output, AND ONLY USE UPPERCASE."}], "role": "user"}, "generationConfig":
       {"temperature": 0}}'
     headers:
-      Accept:
+      accept:
       - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
       - keep-alive
-      Content-Length:
+      content-length:
       - '263'
-      Content-Type:
+      content-type:
       - application/json
-      Host:
+      host:
       - generativelanguage.googleapis.com
       x-goog-api-client:
-      - google-genai-sdk/1.56.0 gl-python/3.11.13
+      - google-genai-sdk/2.10.0 gl-python/3.12.13
     method: POST
-    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:streamGenerateContent?alt=sse
   response:
     body:
       string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"CHRISTOPHER
-        ROBIN\"}],\"role\": \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\":
-        {\"promptTokenCount\": 27,\"candidatesTokenCount\": 5,\"totalTokenCount\":
-        67,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 27}],\"thoughtsTokenCount\":
-        35},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\": \"w7FVaf77JODQjMcP3NDmyQw\"}\r\n\r\n"
+        ROBIN\"}],\"role\": \"model\"},\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
+        27,\"candidatesTokenCount\": 5,\"totalTokenCount\": 102,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 27}],\"thoughtsTokenCount\": 70,\"serviceTier\":
+        \"standard\"},\"modelVersion\": \"gemini-3.5-flash\",\"responseId\": \"KoFfauCaDcCkjrEP-Kv52Ac\"}\r\n\r\ndata:
+        {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"\",\"thoughtSignature\":
+        \"EuoCCucCARFNMg9wY0fCCrgA92fNppAToQ+Dyihgugl2tOBfN2OFuejyuMH3097sn5PrVNo1g2PwSiu/jt3uxYKLzPpwScHsGRGPvRLL8w2Wz/JuD3FwEU2EJDW7gtU//L1pQyzVw8n2gCI8+59GkoSWoDL/zqLchQ3Vr0Ih6KEf73PmnmH+G8aMWd+YYvR+IfGV9xKD8vVqnObP25hRSU7rmzWBIbQwAy+uCnKBtV1z88kUNEfhK59Ore8Yempxc/ZW56l1CHINnIuykCJBqbAd3AIvrVqQIzyIIs4HuuTOsTTdGtJwqfZZCzHIsMzpG2ECijJN/iFfylLfo9tnjwGFT8pnF8gSKUi1xu7NQg76fi8Cq14AJT0OXRAS1CuqsQ8T7AdhcGeDnqVFudjkiRH7VnS+Ch6Lm06moXEvJk3qDGC0q1t6tsdIH40HHKOMgj8jqIuGWKtAyvsEvghc+2zSrzd3w7cEMyYGikA=\"}],\"role\":
+        \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
+        27,\"candidatesTokenCount\": 5,\"totalTokenCount\": 102,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 27}],\"thoughtsTokenCount\": 70,\"serviceTier\":
+        \"standard\"},\"modelVersion\": \"gemini-3.5-flash\",\"responseId\": \"KoFfauCaDcCkjrEP-Kv52Ac\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -36,11 +42,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Wed, 31 Dec 2025 23:29:07 GMT
+      - Tue, 21 Jul 2026 14:24:43 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=564
+      - gfet4t7; dur=1045
       Transfer-Encoding:
       - chunked
       Vary:
@@ -62,29 +68,35 @@ interactions:
       "Return very minimal output, AND ONLY USE UPPERCASE."}], "role": "user"}, "generationConfig":
       {"temperature": 0}}'
     headers:
-      Accept:
+      accept:
       - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
       - keep-alive
-      Content-Length:
+      content-length:
       - '263'
-      Content-Type:
+      content-type:
       - application/json
-      Host:
+      host:
       - generativelanguage.googleapis.com
       x-goog-api-client:
-      - google-genai-sdk/1.56.0 gl-python/3.11.13
+      - google-genai-sdk/2.10.0 gl-python/3.12.13
     method: POST
-    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:streamGenerateContent?alt=sse
   response:
     body:
       string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"CHRISTOPHER
-        ROBIN\"}],\"role\": \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\":
-        {\"promptTokenCount\": 27,\"candidatesTokenCount\": 5,\"totalTokenCount\":
-        67,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 27}],\"thoughtsTokenCount\":
-        35},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\": \"YbpVaaStDqbP_uMP1PvVgQU\"}\r\n\r\n"
+        ROBIN\"}],\"role\": \"model\"},\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
+        27,\"candidatesTokenCount\": 5,\"totalTokenCount\": 102,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 27}],\"thoughtsTokenCount\": 70,\"serviceTier\":
+        \"standard\"},\"modelVersion\": \"gemini-3.5-flash\",\"responseId\": \"K4FfauWvJfuQ_uMPuNm3WQ\"}\r\n\r\ndata:
+        {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"\",\"thoughtSignature\":
+        \"EuoCCucCARFNMg+ntRjz8PGDUiHZByD4l7eqI+Xvat3beplDLy+BDbD5NiIonohMuvz1KTD/+DEJ3jqXnedbttH72MOIndvi/ooafY1xHiNtmri/DMqOctVJ/z78nuYyaaMV7Ul514RNkBDjXBHKHX+P+E5l96dK+qz5OSEzA3+zqrLQB2hWSG+rdwGb1SrUbgENP07k4Ox+Cj6gYHv+U+nAfQau96XoaTOjgveCtt9RQP36DZhs3Wx1q/VgZMZQZ3xz/w9tHL9DNr0AotrC+263Xe+brllruyYgyK1uQHmhxIlDqgL/mmvbjyFhQUrGwu+CBinEzmzz4oLZAorz+yPpQtP8lSKzUrau4PSexVWguL1D5igApUbxPHHg84gSJr21sRvJFGw0l4NNcOaoi/Dp2WT477+q1p3l8r83vRoSeId0SXupX/MeBMXVyX4KiK6EAvIeQ+mYnrtcod2sFCCLsA9Tp9SKT0oJ7hI=\"}],\"role\":
+        \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
+        27,\"candidatesTokenCount\": 5,\"totalTokenCount\": 102,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 27}],\"thoughtsTokenCount\": 70,\"serviceTier\":
+        \"standard\"},\"modelVersion\": \"gemini-3.5-flash\",\"responseId\": \"K4FfauWvJfuQ_uMPuNm3WQ\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -93,68 +105,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Thu, 01 Jan 2026 00:05:53 GMT
+      - Tue, 21 Jul 2026 14:24:44 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=571
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Origin
-      - X-Origin
-      - Referer
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-XSS-Protection:
-      - '0'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"contents": [{"parts": [{"text": "What is the name of Winnie the Pooh''s
-      human friend?"}], "role": "user"}], "systemInstruction": {"parts": [{"text":
-      "Return very minimal output, AND ONLY USE UPPERCASE."}], "role": "user"}, "generationConfig":
-      {"temperature": 0}}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '263'
-      Content-Type:
-      - application/json
-      Host:
-      - generativelanguage.googleapis.com
-      x-goog-api-client:
-      - google-genai-sdk/1.56.0 gl-python/3.11.13
-    method: POST
-    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse
-  response:
-    body:
-      string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"CHRISTOPHER
-        ROBIN\"}],\"role\": \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\":
-        {\"promptTokenCount\": 27,\"candidatesTokenCount\": 5,\"totalTokenCount\":
-        67,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 27}],\"thoughtsTokenCount\":
-        35},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\": \"YrpVafm5Au7pjMcPwozHqAo\"}\r\n\r\n"
-    headers:
-      Alt-Svc:
-      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
-      Content-Disposition:
-      - attachment
-      Content-Type:
-      - text/event-stream
-      Date:
-      - Thu, 01 Jan 2026 00:05:54 GMT
-      Server:
-      - scaffolding on HTTPServer2
-      Server-Timing:
-      - gfet4t7; dur=614
+      - gfet4t7; dur=1057
       Transfer-Encoding:
       - chunked
       Vary:
@@ -176,30 +131,40 @@ interactions:
       {"parts": [{"text": "What is my name?"}], "role": "user"}], "generationConfig":
       {"temperature": 0}}'
     headers:
-      Accept:
+      accept:
       - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
       - keep-alive
-      Content-Length:
+      content-length:
       - '254'
-      Content-Type:
+      content-type:
       - application/json
-      Host:
+      host:
       - generativelanguage.googleapis.com
       x-goog-api-client:
-      - google-genai-sdk/1.56.0 gl-python/3.11.13
+      - google-genai-sdk/2.10.0 gl-python/3.12.13
     method: POST
-    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:streamGenerateContent?alt=sse
   response:
     body:
       string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"Your
-        name is Steve.\"}],\"role\": \"model\"},\"finishReason\": \"STOP\",\"index\":
-        0}],\"usageMetadata\": {\"promptTokenCount\": 22,\"candidatesTokenCount\":
-        5,\"totalTokenCount\": 50,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
-        22}],\"thoughtsTokenCount\": 23},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\":
-        \"YrpVadufNebc_uMPmcHq6Q8\"}\r\n\r\n"
+        name is Steve\"}],\"role\": \"model\"},\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
+        22,\"candidatesTokenCount\": 4,\"totalTokenCount\": 120,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 22}],\"thoughtsTokenCount\": 94,\"serviceTier\":
+        \"standard\"},\"modelVersion\": \"gemini-3.5-flash\",\"responseId\": \"LIFfao-rL6-E_uMPu4a5gAg\"}\r\n\r\ndata:
+        {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \". How can I help
+        you today?\"}],\"role\": \"model\"},\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
+        22,\"candidatesTokenCount\": 12,\"totalTokenCount\": 128,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 22}],\"thoughtsTokenCount\": 94,\"serviceTier\":
+        \"standard\"},\"modelVersion\": \"gemini-3.5-flash\",\"responseId\": \"LIFfao-rL6-E_uMPu4a5gAg\"}\r\n\r\ndata:
+        {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"\",\"thoughtSignature\":
+        \"EugDCuUDARFNMg9MLdfY09jVPsWd+StdDCU1fmcNlY2UmxsZJnMrsinqJbiXGpLElnisJxzJWq8IzwFMY0nQG+9q+Cai2JnOX8QSWDgDgYyJcjM7FP2KUyaA7cAuNOIyZKJV6bM5d9+pCbdNYsmVj4JWVvsB2NIVO8Cbb/4DCDl2XlxR+u3tWS0IoFX2ncfOtzSzQDPiVg/Fhr6wc2gqX9ay18KeVIA72tSwlStND/E89o2wTF84oW9G+0bDy7bebLV44WiMCDTF2x6buSwOdRVytMx/rQz2lt0JGHSnfGqFcEClVgYHbx6DdXpcbOv8iYuCGBCmi06YzKwxptr6A7Lu32w+B42CyNQWN7acGobtJGm0lLEGXcPHEEedE0NdLiRcZ9RbpH3KUBr04QOyZEGoGU0NZkCZ+s2Xv3LTu5/lasvhXaeGa00VshyBNu1qzi4dZUVEBM5ZNHypCTntaXfGM4vnlEboaFSfJEtbi+kGvuqzJRkz+vt2V3MVRAavebawo3CTB94NTw4iJer/HdUX2LCCaupEMoWUPTMvEwS6t6550GMaROEmCBPbtT9AtxFskZhjepQApFqNMxNGkJX3YPYinqVM9YurNLWyhhBxId3HRTA5Do0db+dDNNz0D5gS5cEdO21hKb8=\"}],\"role\":
+        \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
+        22,\"candidatesTokenCount\": 12,\"totalTokenCount\": 128,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 22}],\"thoughtsTokenCount\": 94,\"serviceTier\":
+        \"standard\"},\"modelVersion\": \"gemini-3.5-flash\",\"responseId\": \"LIFfao-rL6-E_uMPu4a5gAg\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -208,11 +173,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Thu, 01 Jan 2026 00:05:55 GMT
+      - Tue, 21 Jul 2026 14:24:45 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=518
+      - gfet4t7; dur=974
       Transfer-Encoding:
       - chunked
       Vary:

--- a/tests/_vcr/test_provider_google/test_google_simple_request.yaml
+++ b/tests/_vcr/test_provider_google/test_google_simple_request.yaml
@@ -4,29 +4,35 @@ interactions:
       "systemInstruction": {"parts": [{"text": "Be as terse as possible; no punctuation"}],
       "role": "user"}, "generationConfig": {"temperature": 0}}'
     headers:
-      Accept:
+      accept:
       - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
       - keep-alive
-      Content-Length:
+      content-length:
       - '214'
-      Content-Type:
+      content-type:
       - application/json
-      Host:
+      host:
       - generativelanguage.googleapis.com
       x-goog-api-client:
-      - google-genai-sdk/1.56.0 gl-python/3.11.13
+      - google-genai-sdk/2.10.0 gl-python/3.12.13
     method: POST
-    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:streamGenerateContent?alt=sse
   response:
     body:
       string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"2\"}],\"role\":
+        \"model\"},\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 18,\"candidatesTokenCount\":
+        1,\"totalTokenCount\": 135,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
+        18}],\"thoughtsTokenCount\": 116,\"serviceTier\": \"standard\"},\"modelVersion\":
+        \"gemini-3.5-flash\",\"responseId\": \"KIFfapaQMca7jrEPwr7E0AM\"}\r\n\r\ndata:
+        {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"\",\"thoughtSignature\":
+        \"EpcECpQEARFNMg87XCWlnQ6gqRdW9sWM4lt8JnU0a2g/YTOMoAT951jWO75cc2wpj77NfTDr4ekNOV3YD4+rqQTOFj4hbF84XHdF0SP7/+IDOBDs03GvuCJx9DC5VOqvrTFGf9eaUiWJ3RMTd7bpKxUz8KyzdexJ0cqz6zgXmqUKM4RybLIz/H14N473T41I5Cr/oVFTf+0Y+GuZa2Uw1zKggfZWawGJboScAAXQkmRbTIw1+VPNY5aIWSbuqizjo3v6hBX687hm00bCmLsO9wtIi5V5QU4GKPJemv5DsiESrWZv1BrYWvOkQ/vA7esPBFjKlHDAYTukElUcpshv+nOkJbtsU3hHawcBOI+om5ZUgOv0gF7zpAL/JlS17OmQR8jA1MBnxfnSQ4bU5+4PW62psBwCgwKnaoh8h1DYmQGYvxGmSMaBGZg5y2JRDsmnt7pjanM3EwHliswZHefVQMxtkDl54QKizXyMReImYYdLsXrIc4Bs/6OXh+xoniLmL0H4QVas6pd2xVZv56zzpJTi5F6+yzbok3oFErtV5Z6WDPU/HzrjHoo70WgmafYvaMn1iWXP6TISJGCpGAVI2wYFc984ut5EEzNE1smWpveWKEZ1z0F2HRQPEiXxAwo0RYs6pOUbcPPKRJ2eE6tsZ/2EZv5lUjogtFynTPxRkww78U/8nRzN5fxd/pQy/LtwngLzoAb1QFxSvw==\"}],\"role\":
         \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
-        18,\"candidatesTokenCount\": 1,\"totalTokenCount\": 47,\"promptTokensDetails\":
-        [{\"modality\": \"TEXT\",\"tokenCount\": 18}],\"thoughtsTokenCount\": 28},\"modelVersion\":
-        \"gemini-2.5-flash\",\"responseId\": \"wbFVabfhLdql_uMPt9e6qAw\"}\r\n\r\n"
+        18,\"candidatesTokenCount\": 1,\"totalTokenCount\": 135,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 18}],\"thoughtsTokenCount\": 116,\"serviceTier\":
+        \"standard\"},\"modelVersion\": \"gemini-3.5-flash\",\"responseId\": \"KIFfapaQMca7jrEPwr7E0AM\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -35,11 +41,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Wed, 31 Dec 2025 23:29:05 GMT
+      - Tue, 21 Jul 2026 14:24:41 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=510
+      - gfet4t7; dur=1322
       Transfer-Encoding:
       - chunked
       Vary:

--- a/tests/_vcr/test_provider_google/test_google_web_fetch.yaml
+++ b/tests/_vcr/test_provider_google/test_google_web_fetch.yaml
@@ -4,51 +4,49 @@ interactions:
       "role": "user"}], "tools": [{"urlContext": {}}], "generationConfig": {"temperature":
       0}}'
     headers:
-      Accept:
+      accept:
       - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
       - keep-alive
-      Content-Length:
+      content-length:
       - '212'
-      Content-Type:
+      content-type:
       - application/json
-      Host:
+      host:
       - generativelanguage.googleapis.com
       x-goog-api-client:
-      - google-genai-sdk/1.56.0 gl-python/3.12.11
+      - google-genai-sdk/2.10.0 gl-python/3.12.13
     method: POST
-    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:streamGenerateContent?alt=sse
   response:
     body:
       string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"The
-        first movie listed\"}],\"role\": \"model\"},\"index\": 0,\"groundingMetadata\":
-        {},\"urlContextMetadata\": {\"urlMetadata\": [{\"retrievedUrl\": \"https://rvest.tidyverse.org/articles/starwars.html\",\"urlRetrievalStatus\":
-        \"URL_RETRIEVAL_STATUS_SUCCESS\"}]}}],\"usageMetadata\": {\"promptTokenCount\":
-        25,\"candidatesTokenCount\": 26,\"totalTokenCount\": 1219,\"promptTokensDetails\":
-        [{\"modality\": \"TEXT\",\"tokenCount\": 25}],\"toolUsePromptTokenCount\":
-        1130,\"toolUsePromptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
-        1130}],\"thoughtsTokenCount\": 38},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\":
-        \"VDVYaY2XOYqM_uMPi8-j8AY\"}\r\n\r\ndata: {\"candidates\": [{\"content\":
-        {\"parts\": [{\"text\": \" on https://rvest.tidyverse.org/articles/starwars.html
-        is \\\"\"}],\"role\": \"model\"},\"index\": 0,\"groundingMetadata\": {}}],\"usageMetadata\":
-        {\"promptTokenCount\": 25,\"candidatesTokenCount\": 44,\"totalTokenCount\":
-        1237,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 25}],\"toolUsePromptTokenCount\":
-        1130,\"toolUsePromptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
-        1130}],\"thoughtsTokenCount\": 38},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\":
-        \"VDVYaY2XOYqM_uMPi8-j8AY\"}\r\n\r\ndata: {\"candidates\": [{\"content\":
-        {\"parts\": [{\"text\": \"The Phantom Menace\\\".\"}],\"role\": \"model\"},\"finishReason\":
-        \"STOP\",\"index\": 0,\"groundingMetadata\": {\"groundingChunks\": [{\"web\":
-        {\"uri\": \"https://rvest.tidyverse.org/articles/starwars.html\",\"title\":
+        first movie listed on that\"}],\"role\": \"model\"},\"index\": 0}],\"usageMetadata\":
+        {\"promptTokenCount\": 25,\"candidatesTokenCount\": 6,\"totalTokenCount\":
+        94,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 25}],\"thoughtsTokenCount\":
+        63,\"serviceTier\": \"standard\"},\"modelVersion\": \"gemini-3.5-flash\",\"responseId\":
+        \"aYFfavXOBYDQjrEP1JudsA4\"}\r\n\r\ndata: {\"candidates\": [{\"content\":
+        {\"parts\": [{\"text\": \" page is ***The Phantom Menace***.\"}],\"role\":
+        \"model\"},\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 25,\"candidatesTokenCount\":
+        6,\"totalTokenCount\": 94,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
+        25}],\"thoughtsTokenCount\": 63,\"serviceTier\": \"standard\"},\"modelVersion\":
+        \"gemini-3.5-flash\",\"responseId\": \"aYFfavXOBYDQjrEP1JudsA4\"}\r\n\r\ndata:
+        {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"\",\"thoughtSignature\":
+        \"ErcCCrQCARFNMg+1ZorWCI0r1CNh7X04kqq/pWLdmIR42TkMHS+XAIM4O6t0DjdUEq2m23dML1ik7hkLC/vYPJgJKbSWPuQIWc8S0qVaFVa1yufdRiaqAavsKmK6aJVOkRWnSZzeuNr9E3sZOkRkUiQUTsF7TMMl8FwBs+JCWRgyGliMt4kMEyDeVoWA4dAtd+TMGSCH7Ls9G2tNcZ/nch58QpSJ48idVxy/r5Zqgdkn6RYnWiXjsQ9lQ0mReQZtmPhjK0LjWYi9yKqqhTXkFbfplMQowV1DBvxQoqfPpblrbQUiIgjMFo2CgFckIOnmF9uQfeU6proDbXAuf+d/YDpDKtLKNe8R6Msv6dXMWN5RmeoD0+E0yv7zdDO9nLim7Bkn4y195BkRXWr8gm+hQ04lLLp7vnmG1Q4=\"}],\"role\":
+        \"model\"},\"finishReason\": \"STOP\",\"index\": 0,\"groundingMetadata\":
+        {\"groundingChunks\": [{\"web\": {\"uri\": \"https://rvest.tidyverse.org/articles/starwars.html\",\"title\":
         \"Star Wars films (static HTML) \u2022 rvest\"}}],\"groundingSupports\": [{\"segment\":
-        {\"endIndex\": 100,\"text\": \"The first movie listed on https://rvest.tidyverse.org/articles/starwars.html
-        is \\\"The Phantom Menace\\\"\"},\"groundingChunkIndices\": [0]}]}}],\"usageMetadata\":
-        {\"promptTokenCount\": 25,\"candidatesTokenCount\": 49,\"totalTokenCount\":
-        1242,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 25}],\"toolUsePromptTokenCount\":
-        1130,\"toolUsePromptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
-        1130}],\"thoughtsTokenCount\": 38},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\":
-        \"VDVYaY2XOYqM_uMPi8-j8AY\"}\r\n\r\n"
+        {\"endIndex\": 63,\"text\": \"The first movie listed on that page is ***The
+        Phantom Menace***\"},\"groundingChunkIndices\": [0]}]},\"urlContextMetadata\":
+        {\"urlMetadata\": [{\"retrievedUrl\": \"https://rvest.tidyverse.org/articles/starwars.html\",\"urlRetrievalStatus\":
+        \"URL_RETRIEVAL_STATUS_SUCCESS\"}]}}],\"usageMetadata\": {\"promptTokenCount\":
+        132,\"candidatesTokenCount\": 45,\"totalTokenCount\": 1702,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 132}],\"toolUsePromptTokenCount\":
+        1355,\"toolUsePromptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
+        1355}],\"thoughtsTokenCount\": 170,\"serviceTier\": \"standard\"},\"modelVersion\":
+        \"gemini-3.5-flash\",\"responseId\": \"aYFfavXOBYDQjrEP1JudsA4\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -57,11 +55,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Fri, 02 Jan 2026 21:15:00 GMT
+      - Tue, 21 Jul 2026 14:25:46 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1102
+      - gfet4t7; dur=1940
       Transfer-Encoding:
       - chunked
       Vary:
@@ -79,44 +77,54 @@ interactions:
       message: OK
 - request:
     body: '{"contents": [{"parts": [{"text": "What''s the first movie listed on https://rvest.tidyverse.org/articles/starwars.html?"}],
-      "role": "user"}, {"parts": [{"text": "The first movie listed"}, {"text": " on
-      https://rvest.tidyverse.org/articles/starwars.html is \""}, {"text": "The Phantom
-      Menace\"."}], "role": "model"}, {"parts": [{"text": "Who directed it?"}], "role":
-      "user"}], "tools": [{"urlContext": {}}], "generationConfig": {"temperature":
-      0}}'
+      "role": "user"}, {"parts": [{"text": "The first movie listed on that"}, {"text":
+      " page is ***The Phantom Menace***."}], "role": "model"}, {"parts": [{"text":
+      "Who directed it?"}], "role": "user"}], "tools": [{"urlContext": {}}], "generationConfig":
+      {"temperature": 0}}'
     headers:
-      Accept:
+      accept:
       - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
       - keep-alive
-      Content-Length:
-      - '446'
-      Content-Type:
+      content-length:
+      - '393'
+      content-type:
       - application/json
-      Host:
+      host:
       - generativelanguage.googleapis.com
       x-goog-api-client:
-      - google-genai-sdk/1.56.0 gl-python/3.12.11
+      - google-genai-sdk/2.10.0 gl-python/3.12.13
     method: POST
-    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:streamGenerateContent?alt=sse
   response:
     body:
-      string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"George
-        Lucas directed \\\"The Phantom Menace\\\".\"}],\"role\": \"model\"},\"finishReason\":
-        \"STOP\",\"index\": 0,\"groundingMetadata\": {\"groundingChunks\": [{\"web\":
-        {\"uri\": \"https://rvest.tidyverse.org/articles/starwars.html\",\"title\":
+      string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"According
+        to the page, it was directed by **George Lucas**\"}],\"role\": \"model\"},\"index\":
+        0}],\"usageMetadata\": {\"promptTokenCount\": 46,\"candidatesTokenCount\":
+        13,\"totalTokenCount\": 97,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
+        46}],\"thoughtsTokenCount\": 38,\"serviceTier\": \"standard\"},\"modelVersion\":
+        \"gemini-3.5-flash\",\"responseId\": \"a4FfaoS0DsW8sOIPxon_iAc\"}\r\n\r\ndata:
+        {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \".\"}],\"role\":
+        \"model\"},\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 46,\"candidatesTokenCount\":
+        13,\"totalTokenCount\": 97,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
+        46}],\"thoughtsTokenCount\": 38,\"serviceTier\": \"standard\"},\"modelVersion\":
+        \"gemini-3.5-flash\",\"responseId\": \"a4FfaoS0DsW8sOIPxon_iAc\"}\r\n\r\ndata:
+        {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"\",\"thoughtSignature\":
+        \"EskBCsYBARFNMg9CqXxES6t/5HXqbXNoKVWIh/Xx7q09oIcU6VBkFCmaKzi3CL9PqXGEXwnxQYbibNUhh4WeTFdNnlJW/qGLU9Z2u6F6H8V/t4Hs19O4wz2U6Eyh16niKYzV9PbMlsBdl4O71Tv5LAU9flgRCp8W9elPbim3VGoaPhnFCB1qVfyT5I8iGyhOsQ39JkA/ZyJWzgzOHaNQSVhljA6CELF5scPNlFCMYFAR4Krk0Y9rqw51EdeWusVSHRrBXf6jONP08u5G\"}],\"role\":
+        \"model\"},\"finishReason\": \"STOP\",\"index\": 0,\"groundingMetadata\":
+        {\"groundingChunks\": [{\"web\": {\"uri\": \"https://rvest.tidyverse.org/articles/starwars.html\",\"title\":
         \"Star Wars films (static HTML) \u2022 rvest\"}}],\"groundingSupports\": [{\"segment\":
-        {\"startIndex\": 1,\"endIndex\": 43,\"text\": \"George Lucas directed \\\"The
-        Phantom Menace\\\"\"},\"groundingChunkIndices\": [0]}]},\"urlContextMetadata\":
-        {\"urlMetadata\": [{\"retrievedUrl\": \"https://rvest.tidyverse.org/articles/starwars.html\",\"urlRetrievalStatus\":
+        {\"endIndex\": 58,\"text\": \"According to the page, it was directed by **George
+        Lucas**\"},\"groundingChunkIndices\": [0]}]},\"urlContextMetadata\": {\"urlMetadata\":
+        [{\"retrievedUrl\": \"https://rvest.tidyverse.org/articles/starwars.html\",\"urlRetrievalStatus\":
         \"URL_RETRIEVAL_STATUS_SUCCESS\"}]}}],\"usageMetadata\": {\"promptTokenCount\":
-        58,\"candidatesTokenCount\": 31,\"totalTokenCount\": 1282,\"promptTokensDetails\":
-        [{\"modality\": \"TEXT\",\"tokenCount\": 58}],\"toolUsePromptTokenCount\":
-        1159,\"toolUsePromptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
-        1159}],\"thoughtsTokenCount\": 34},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\":
-        \"VjVYaYPpEbTQ_uMP_vPbaQ\"}\r\n\r\n"
+        258,\"candidatesTokenCount\": 44,\"totalTokenCount\": 2031,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 258}],\"toolUsePromptTokenCount\":
+        1479,\"toolUsePromptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
+        1479}],\"thoughtsTokenCount\": 250,\"serviceTier\": \"standard\"},\"modelVersion\":
+        \"gemini-3.5-flash\",\"responseId\": \"a4FfaoS0DsW8sOIPxon_iAc\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -125,11 +133,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Fri, 02 Jan 2026 21:15:02 GMT
+      - Tue, 21 Jul 2026 14:25:49 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1074
+      - gfet4t7; dur=2817
       Transfer-Encoding:
       - chunked
       Vary:

--- a/tests/_vcr/test_provider_google/test_google_web_search.yaml
+++ b/tests/_vcr/test_provider_google/test_google_web_search.yaml
@@ -4,101 +4,39 @@ interactions:
       Answer in YYYY-MM-DD format."}], "role": "user"}], "tools": [{"googleSearch":
       {}}], "generationConfig": {"temperature": 0}}'
     headers:
-      Accept:
+      accept:
       - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
       - keep-alive
-      Content-Length:
+      content-length:
       - '199'
-      Content-Type:
+      content-type:
       - application/json
-      Host:
+      host:
       - generativelanguage.googleapis.com
       x-goog-api-client:
-      - google-genai-sdk/1.56.0 gl-python/3.12.11
+      - google-genai-sdk/2.10.0 gl-python/3.12.13
     method: POST
-    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:streamGenerateContent?alt=sse
   response:
     body:
-      string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"ggplot2
-        version 1.0.0 was released to CRAN on 2014-05-21.\"}],\"role\": \"model\"},\"finishReason\":
-        \"STOP\",\"index\": 0,\"groundingMetadata\": {\"searchEntryPoint\": {\"renderedContent\":
-        \"\\u003cstyle\\u003e\\n.container {\\n  align-items: center;\\n  border-radius:
-        8px;\\n  display: flex;\\n  font-family: Google Sans, Roboto, sans-serif;\\n
-        \ font-size: 14px;\\n  line-height: 20px;\\n  padding: 8px 12px;\\n}\\n.chip
-        {\\n  display: inline-block;\\n  border: solid 1px;\\n  border-radius: 16px;\\n
-        \ min-width: 14px;\\n  padding: 5px 16px;\\n  text-align: center;\\n  user-select:
-        none;\\n  margin: 0 8px;\\n  -webkit-tap-highlight-color: transparent;\\n}\\n.carousel
-        {\\n  overflow: auto;\\n  scrollbar-width: none;\\n  white-space: nowrap;\\n
-        \ margin-right: -12px;\\n}\\n.headline {\\n  display: flex;\\n  margin-right:
-        4px;\\n}\\n.gradient-container {\\n  position: relative;\\n}\\n.gradient {\\n
-        \ position: absolute;\\n  transform: translate(3px, -9px);\\n  height: 36px;\\n
-        \ width: 9px;\\n}\\n@media (prefers-color-scheme: light) {\\n  .container
-        {\\n    background-color: #fafafa;\\n    box-shadow: 0 0 0 1px #0000000f;\\n
-        \ }\\n  .headline-label {\\n    color: #1f1f1f;\\n  }\\n  .chip {\\n    background-color:
-        #ffffff;\\n    border-color: #d2d2d2;\\n    color: #5e5e5e;\\n    text-decoration:
-        none;\\n  }\\n  .chip:hover {\\n    background-color: #f2f2f2;\\n  }\\n  .chip:focus
-        {\\n    background-color: #f2f2f2;\\n  }\\n  .chip:active {\\n    background-color:
-        #d8d8d8;\\n    border-color: #b6b6b6;\\n  }\\n  .logo-dark {\\n    display:
-        none;\\n  }\\n  .gradient {\\n    background: linear-gradient(90deg, #fafafa
-        15%, #fafafa00 100%);\\n  }\\n}\\n@media (prefers-color-scheme: dark) {\\n
-        \ .container {\\n    background-color: #1f1f1f;\\n    box-shadow: 0 0 0 1px
-        #ffffff26;\\n  }\\n  .headline-label {\\n    color: #fff;\\n  }\\n  .chip
-        {\\n    background-color: #2c2c2c;\\n    border-color: #3c4043;\\n    color:
-        #fff;\\n    text-decoration: none;\\n  }\\n  .chip:hover {\\n    background-color:
-        #353536;\\n  }\\n  .chip:focus {\\n    background-color: #353536;\\n  }\\n
-        \ .chip:active {\\n    background-color: #464849;\\n    border-color: #53575b;\\n
-        \ }\\n  .logo-light {\\n    display: none;\\n  }\\n  .gradient {\\n    background:
-        linear-gradient(90deg, #1f1f1f 15%, #1f1f1f00 100%);\\n  }\\n}\\n\\u003c/style\\u003e\\n\\u003cdiv
-        class=\\\"container\\\"\\u003e\\n  \\u003cdiv class=\\\"headline\\\"\\u003e\\n
-        \   \\u003csvg class=\\\"logo-light\\\" width=\\\"18\\\" height=\\\"18\\\"
-        viewBox=\\\"9 9 35 35\\\" fill=\\\"none\\\" xmlns=\\\"http://www.w3.org/2000/svg\\\"\\u003e\\n
-        \     \\u003cpath fill-rule=\\\"evenodd\\\" clip-rule=\\\"evenodd\\\" d=\\\"M42.8622
-        27.0064C42.8622 25.7839 42.7525 24.6084 42.5487 23.4799H26.3109V30.1568H35.5897C35.1821
-        32.3041 33.9596 34.1222 32.1258 35.3448V39.6864H37.7213C40.9814 36.677 42.8622
-        32.2571 42.8622 27.0064V27.0064Z\\\" fill=\\\"#4285F4\\\"/\\u003e\\n      \\u003cpath
-        fill-rule=\\\"evenodd\\\" clip-rule=\\\"evenodd\\\" d=\\\"M26.3109 43.8555C30.9659
-        43.8555 34.8687 42.3195 37.7213 39.6863L32.1258 35.3447C30.5898 36.3792 28.6306
-        37.0061 26.3109 37.0061C21.8282 37.0061 18.0195 33.9811 16.6559 29.906H10.9194V34.3573C13.7563
-        39.9841 19.5712 43.8555 26.3109 43.8555V43.8555Z\\\" fill=\\\"#34A853\\\"/\\u003e\\n
-        \     \\u003cpath fill-rule=\\\"evenodd\\\" clip-rule=\\\"evenodd\\\" d=\\\"M16.6559
-        29.8904C16.3111 28.8559 16.1074 27.7588 16.1074 26.6146C16.1074 25.4704 16.3111
-        24.3733 16.6559 23.3388V18.8875H10.9194C9.74388 21.2072 9.06992 23.8247 9.06992
-        26.6146C9.06992 29.4045 9.74388 32.022 10.9194 34.3417L15.3864 30.8621L16.6559
-        29.8904V29.8904Z\\\" fill=\\\"#FBBC05\\\"/\\u003e\\n      \\u003cpath fill-rule=\\\"evenodd\\\"
-        clip-rule=\\\"evenodd\\\" d=\\\"M26.3109 16.2386C28.85 16.2386 31.107 17.1164
-        32.9095 18.8091L37.8466 13.8719C34.853 11.082 30.9659 9.3736 26.3109 9.3736C19.5712
-        9.3736 13.7563 13.245 10.9194 18.8875L16.6559 23.3388C18.0195 19.2636 21.8282
-        16.2386 26.3109 16.2386V16.2386Z\\\" fill=\\\"#EA4335\\\"/\\u003e\\n    \\u003c/svg\\u003e\\n
-        \   \\u003csvg class=\\\"logo-dark\\\" width=\\\"18\\\" height=\\\"18\\\"
-        viewBox=\\\"0 0 48 48\\\" xmlns=\\\"http://www.w3.org/2000/svg\\\"\\u003e\\n
-        \     \\u003ccircle cx=\\\"24\\\" cy=\\\"23\\\" fill=\\\"#FFF\\\" r=\\\"22\\\"/\\u003e\\n
-        \     \\u003cpath d=\\\"M33.76 34.26c2.75-2.56 4.49-6.37 4.49-11.26 0-.89-.08-1.84-.29-3H24.01v5.99h8.03c-.4
-        2.02-1.5 3.56-3.07 4.56v.75l3.91 2.97h.88z\\\" fill=\\\"#4285F4\\\"/\\u003e\\n
-        \     \\u003cpath d=\\\"M15.58 25.77A8.845 8.845 0 0 0 24 31.86c1.92 0 3.62-.46
-        4.97-1.31l4.79 3.71C31.14 36.7 27.65 38 24 38c-5.93 0-11.01-3.4-13.45-8.36l.17-1.01
-        4.06-2.85h.8z\\\" fill=\\\"#34A853\\\"/\\u003e\\n      \\u003cpath d=\\\"M15.59
-        20.21a8.864 8.864 0 0 0 0 5.58l-5.03 3.86c-.98-2-1.53-4.25-1.53-6.64 0-2.39.55-4.64
-        1.53-6.64l1-.22 3.81 2.98.22 1.08z\\\" fill=\\\"#FBBC05\\\"/\\u003e\\n      \\u003cpath
-        d=\\\"M24 14.14c2.11 0 4.02.75 5.52 1.98l4.36-4.36C31.22 9.43 27.81 8 24 8c-5.93
-        0-11.01 3.4-13.45 8.36l5.03 3.85A8.86 8.86 0 0 1 24 14.14z\\\" fill=\\\"#EA4335\\\"/\\u003e\\n
-        \   \\u003c/svg\\u003e\\n    \\u003cdiv class=\\\"gradient-container\\\"\\u003e\\u003cdiv
-        class=\\\"gradient\\\"\\u003e\\u003c/div\\u003e\\u003c/div\\u003e\\n  \\u003c/div\\u003e\\n
-        \ \\u003cdiv class=\\\"carousel\\\"\\u003e\\n    \\u003ca class=\\\"chip\\\"
-        href=\\\"https://vertexaisearch.cloud.google.com/grounding-api-redirect/AUZIYQE75eSdvY972f3gk17-ltnPSn_fT3oGdUZUzeh5BmbuubDdtmayE5D_qhVVfxt0xzDYGEWwSYqTUknHYkxh4KqoXcugsloF1T3brrdsP9Ot6GiEs-lvoavkWlfNmog9vQVe7F9Q33-kDFmnguX11lct2m3s4XASwT-Co5rNXGBMIWCPi60uSyD2zAKBmZA0iLZxlvvY2pSM9UOt\\\"\\u003eggplot2
-        release history\\u003c/a\\u003e\\n    \\u003ca class=\\\"chip\\\" href=\\\"https://vertexaisearch.cloud.google.com/grounding-api-redirect/AUZIYQGSGekQqCaK1aOSrYxAiVrFEu-RzLE0TgQfMsxRhU5kmaBa2UloBVNjXVXFwXOraVNfHhVl0XfJL6W00kqSQAXzMGtMqtKPhEGTwJfe4HYk79nedjYFyL5g55qHO7IIscjDuRm4JYscp4U5QUSRDV0w-ZF8ioTngPjC5_x9fmPCKQOEe_b1504bnqgpLPmuDNboAowG7VGDRC6kazYQxEcNc-A=\\\"\\u003eggplot2
-        1.0.0 CRAN release date\\u003c/a\\u003e\\n  \\u003c/div\\u003e\\n\\u003c/div\\u003e\\n\"},\"groundingChunks\":
-        [{\"web\": {\"uri\": \"https://vertexaisearch.cloud.google.com/grounding-api-redirect/AUZIYQEjSNbji19KjF_gw6UFj3ZOC3mMjsKRoEV3fUpDEbRUR2lotH6MDj_eipDOvtSDLH_zzb7PzQbAGHzF32W-MKmU9mVYIDBh_qRW37-SyVsMycfRtcqVI0HwZ5qm\",\"title\":
-        \"rpkg.net\"}}],\"groundingSupports\": [{\"segment\": {\"startIndex\": 20,\"endIndex\":
-        57,\"text\": \"0 was released to CRAN on 2014-05-21.\"},\"groundingChunkIndices\":
-        [0]}],\"webSearchQueries\": [\"ggplot2 1.0.0 CRAN release date\",\"ggplot2
-        release history\"]}}],\"usageMetadata\": {\"promptTokenCount\": 27,\"candidatesTokenCount\":
-        56,\"totalTokenCount\": 374,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
-        27}],\"toolUsePromptTokenCount\": 118,\"toolUsePromptTokensDetails\": [{\"modality\":
-        \"TEXT\",\"tokenCount\": 118}],\"thoughtsTokenCount\": 173},\"modelVersion\":
-        \"gemini-2.5-flash\",\"responseId\": \"UjVYabbAJpvUjMcPirW1qA0\"}\r\n\r\n"
+      string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"2014\"}],\"role\":
+        \"model\"},\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 27,\"totalTokenCount\":
+        330,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 27}],\"thoughtsTokenCount\":
+        303,\"serviceTier\": \"standard\"},\"modelVersion\": \"gemini-3.5-flash\",\"responseId\":
+        \"boFfaoT1Eoj8jrEP-9unqA4\"}\r\n\r\ndata: {\"candidates\": [{\"content\":
+        {\"parts\": [{\"text\": \"-05-21\"}],\"role\": \"model\"},\"index\": 0}],\"usageMetadata\":
+        {\"promptTokenCount\": 27,\"totalTokenCount\": 330,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 27}],\"thoughtsTokenCount\": 303,\"serviceTier\":
+        \"standard\"},\"modelVersion\": \"gemini-3.5-flash\",\"responseId\": \"boFfaoT1Eoj8jrEP-9unqA4\"}\r\n\r\ndata:
+        {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"\",\"thoughtSignature\":
+        \"EugCCuUCARFNMg/qmUQbOx8cFUVk/i+BzrNnxOQRQ0f5rcRqJvpoclpQfOQ6BsHU0sIk/TbVm3CfBqY48C/YNSofjxQR+Go+EVfwUsgdGZJC1qXJggrO8CzcD4UN6edHEwS0GgdOxfgWGUqQH+4/AyH7teNwSxOeG1iPTHBPaMjfknBNst9OvFDOHwbICuW1HjwqCvMIlMwS/AWEt280Wb4wq+XSTNXL8J3aP2l/G6jjJjd6AO+wpxLb0LJru+/W59iXkSkcFUKXsQu8hXdcJreA3qvvni8qgEiAUVCsOPyig1kQyFcd9CmYUJu66P3uFdWq9LyPBObzl2d9K/mlwXQBG4vXoeusZ9zRmBv9zs3DZzWSvtClPZUwuxdzKdCFxg5B4Q1QTfzXYF1712omTOJAapjZjaAQsa7EyhSJcye45M0nPxEONgkAyUrqyYYPPJ0Fg+DWqs412R1f5QHez5Cg/NKa4Bcwxu3a\"}],\"role\":
+        \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
+        330,\"candidatesTokenCount\": 10,\"totalTokenCount\": 771,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 330}],\"thoughtsTokenCount\": 431,\"serviceTier\":
+        \"standard\"},\"modelVersion\": \"gemini-3.5-flash\",\"responseId\": \"boFfaoT1Eoj8jrEP-9unqA4\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -107,11 +45,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Fri, 02 Jan 2026 21:14:58 GMT
+      - Tue, 21 Jul 2026 14:25:55 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=2418
+      - gfet4t7; dur=5201
       Transfer-Encoding:
       - chunked
       Vary:
@@ -129,35 +67,40 @@ interactions:
       message: OK
 - request:
     body: '{"contents": [{"parts": [{"text": "When was ggplot2 1.0.0 released to CRAN?
-      Answer in YYYY-MM-DD format."}], "role": "user"}, {"parts": [{"text": "ggplot2
-      version 1.0.0 was released to CRAN on 2014-05-21."}], "role": "model"}, {"parts":
-      [{"text": "What month was that?"}], "role": "user"}], "tools": [{"googleSearch":
-      {}}], "generationConfig": {"temperature": 0}}'
+      Answer in YYYY-MM-DD format."}], "role": "user"}, {"parts": [{"text": "2014"},
+      {"text": "-05-21"}], "role": "model"}, {"parts": [{"text": "What month was that?"}],
+      "role": "user"}], "tools": [{"googleSearch": {}}], "generationConfig": {"temperature":
+      0}}'
     headers:
-      Accept:
+      accept:
       - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
       - keep-alive
-      Content-Length:
-      - '363'
-      Content-Type:
+      content-length:
+      - '330'
+      content-type:
       - application/json
-      Host:
+      host:
       - generativelanguage.googleapis.com
       x-goog-api-client:
-      - google-genai-sdk/1.56.0 gl-python/3.12.11
+      - google-genai-sdk/2.10.0 gl-python/3.12.13
     method: POST
-    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:streamGenerateContent?alt=sse
   response:
     body:
       string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"That
-        was May.\"}],\"role\": \"model\"},\"finishReason\": \"STOP\",\"index\": 0,\"groundingMetadata\":
-        {}}],\"usageMetadata\": {\"promptTokenCount\": 61,\"candidatesTokenCount\":
-        4,\"totalTokenCount\": 113,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
-        61}],\"thoughtsTokenCount\": 48},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\":
-        \"UzVYaey0I767_uMPlY_W6Q4\"}\r\n\r\n"
+        was **May**.\"}],\"role\": \"model\"},\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
+        44,\"candidatesTokenCount\": 5,\"totalTokenCount\": 157,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 44}],\"thoughtsTokenCount\": 108,\"serviceTier\":
+        \"standard\"},\"modelVersion\": \"gemini-3.5-flash\",\"responseId\": \"c4FfavzbJr6QjrEPxOCsuQk\"}\r\n\r\ndata:
+        {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"\",\"thoughtSignature\":
+        \"EuYDCuMDARFNMg8D8Gw134elLmPId3S5tfjnrDHuDrd6HiWdWYVGH39870cgk7SkP6QyOtJHhhW8Vr/Eu4OWikO6Ppp2MyNQ2aAFYmqbv2qryYGVZGWJNygOgziAr5K/NyAShIWQOpYqFj2/9DqEZsByLlHsJAlWTqrcRdp/b8Uy9R08GYovT9CGvt0Ad+dDXp8GiLUOrwjohfS2Cb42VINN5FXdiINSBZvmqe5H2OSDc0HpSOcczJD3lbeR2Ol5VSww02kyNBEIPumKTJZPedo4t7ZkS41RUdfhOoCc3GsAC1pPIUixhtz6IJMyWGAQWb8dKfShPxuQHMA71A5mwr+TYaLduQ3jLcCp+xPZV/5IT5ZcfsZS1knsnWzpaQxvjpv1GXCPfl0aYEFl3fvuPphVbZDujm6nRos6tw/zwv4SgWIzqHqHbSdgklEcRLTOtx/9xm72fGke6ZsoRr+VWTHuBqzT2xo8vQstK26gHJjo6ed1mYV4Xhg96HtHYxwGsmd8A5Nc8yPH1WdcHVhaSE1VOcVhKsUdknoaR20jo02ZqA1vV6Q2HiecXoaD1uxY8eISSbW45ZbUMyJwyOcX5ocektUA1dt0uWNVC3NVDBQp9qFYHshaB4cp7j1TMHAdjBnLswP/o1IN\"}],\"role\":
+        \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
+        44,\"candidatesTokenCount\": 5,\"totalTokenCount\": 157,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 44}],\"thoughtsTokenCount\": 108,\"serviceTier\":
+        \"standard\"},\"modelVersion\": \"gemini-3.5-flash\",\"responseId\": \"c4FfavzbJr6QjrEPxOCsuQk\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -166,11 +109,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Fri, 02 Jan 2026 21:14:59 GMT
+      - Tue, 21 Jul 2026 14:25:56 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=704
+      - gfet4t7; dur=1164
       Transfer-Encoding:
       - chunked
       Vary:

--- a/tests/_vcr/test_provider_google/test_images_inline.yaml
+++ b/tests/_vcr/test_provider_google/test_images_inline.yaml
@@ -5,32 +5,36 @@ interactions:
       "mimeType": "image/png"}}], "role": "user"}], "generationConfig": {"temperature":
       0}}'
     headers:
-      Accept:
+      accept:
       - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
       - keep-alive
-      Content-Length:
+      content-length:
       - '7505'
-      Content-Type:
+      content-type:
       - application/json
-      Host:
+      host:
       - generativelanguage.googleapis.com
       x-goog-api-client:
-      - google-genai-sdk/1.56.0 gl-python/3.11.13
+      - google-genai-sdk/2.10.0 gl-python/3.12.13
     method: POST
-    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:streamGenerateContent?alt=sse
   response:
     body:
-      string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"The
-        image is a solid, uniform field of **red**.\\n\\nThere are no discernible
-        objects, patterns, textures, or variations in color within the image; it is
-        simply a flat, vibrant red.\"}],\"role\": \"model\"},\"finishReason\": \"STOP\",\"index\":
-        0}],\"usageMetadata\": {\"promptTokenCount\": 266,\"candidatesTokenCount\":
-        40,\"totalTokenCount\": 795,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
-        8},{\"modality\": \"IMAGE\",\"tokenCount\": 258}],\"thoughtsTokenCount\":
-        489},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\": \"ebBVab_6Opmn_uMP-r6TOA\"}\r\n\r\n"
+      string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"This
+        image is a solid, bright red color.\"}],\"role\": \"model\"},\"index\": 0}],\"usageMetadata\":
+        {\"promptTokenCount\": 8,\"candidatesTokenCount\": 10,\"totalTokenCount\":
+        169,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 8}],\"thoughtsTokenCount\":
+        151,\"serviceTier\": \"standard\"},\"modelVersion\": \"gemini-3.5-flash\",\"responseId\":
+        \"dYFfarTnA4vj_uMPu-m5gQE\"}\r\n\r\ndata: {\"candidates\": [{\"content\":
+        {\"parts\": [{\"text\": \"\",\"thoughtSignature\": \"Er8FCrwFARFNMg8RKwAH5MFW5dYi2Db2cbunajr/4zLoyHrR5WdaME715m4xgWUbRYBMTJs6q4uyNd3weRzsHsYgN5fhFgdWOhVzda4yuq51k0hMi7nWyRndIHIkGglEWaqlSH0T+jsDDWPtSv0rDdflkK/yGWfrbjqGWRVcGsUvzipIoGUOk6pED7T8znXsAb/iJTB3G3KU8s2izKa+OXYDz7vEGxKJ/kFY6RjG64s/hFSI930UUZyNEOwQW5+lS9mc+cAI5Yg2Q+UgzxaBrUe6oPGaoWR3L9kYbYq24BeSuk1p5/AaJ/UdsduI+iX1OjGYeu+znvAcFf+Pzhb29JIoSCxUi4Oos9F6MobsI5piGLKcnVWInjvmpCx8ttn5OC+q0wdaiwdjRA8QuBsGqhjgFOjoj8tWgI2tMsbvpX+j9jiKa7HWmfgezVmXtihimuffud2HokAUgmcTc9Hnta2xA+zmLJnrm70CIPm2rXUfFkbWPtkuLvNJ4p3kpEo7LcX9vgwEw4kpPoJQtG+baOccFgyfU655zlDjAju40TDE/sgRP+eGEmBb6//bjtpen0F7UnIv8ELBOFZ0qjxxH0xfr2Z3aIhTGlOUXCBsiNz0aN7+q+h6L22N9jZ/tMnv17FUDNqC+XfOZ57xIvwf7lEbuUKPb7kzbyO3+5PZP6DU06qfIbf5fY1VF2UEXRwMx0s9LrrCDEaAKeV9eTLkmU2jjrDg4HVHTdnu2H+AbR5q4Yol+yZf2JVrKXzYjaFptw0LeQ11rDGRZPzKkxFP/+geqfHAOmRNDXV1rIb08WgrcZGkYDlqU61epkKOTs4KSL3nB92WD4RmjTf+1pJVulAF1Dvz/e5OwsQakq0zbW6iqgcA3LpPL9knwIB1udyLvyruUa7rU12b7oEjy/4JlNoZOT2DpF62akMG5jBSVsjSxA==\"}],\"role\":
+        \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
+        1089,\"candidatesTokenCount\": 10,\"totalTokenCount\": 1250,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 8},{\"modality\": \"IMAGE\",\"tokenCount\":
+        1081}],\"thoughtsTokenCount\": 151,\"serviceTier\": \"standard\"},\"modelVersion\":
+        \"gemini-3.5-flash\",\"responseId\": \"dYFfarTnA4vj_uMPu-m5gQE\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -39,11 +43,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Wed, 31 Dec 2025 23:23:40 GMT
+      - Tue, 21 Jul 2026 14:25:59 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=2870
+      - gfet4t7; dur=2161
       Transfer-Encoding:
       - chunked
       Vary:

--- a/tests/_vcr/test_provider_google/test_tools_parallel.yaml
+++ b/tests/_vcr/test_provider_google/test_tools_parallel.yaml
@@ -8,33 +8,42 @@ interactions:
       {"properties": {"_person": {"type": "STRING"}}, "required": ["_person"], "type":
       "OBJECT"}}]}], "generationConfig": {"temperature": 0}}'
     headers:
-      Accept:
+      accept:
       - '*/*'
-      Accept-Encoding:
+      accept-encoding:
       - gzip, deflate, zstd
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
+      content-length:
       - '536'
-      Content-Type:
+      content-type:
       - application/json
-      Host:
+      host:
       - generativelanguage.googleapis.com
       x-goog-api-client:
-      - google-genai-sdk/1.64.0 gl-python/3.12.11
+      - google-genai-sdk/2.10.0 gl-python/3.12.13
     method: POST
-    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:streamGenerateContent?alt=sse
   response:
     body:
       string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"functionCall\":
-        {\"name\": \"favorite_color\",\"args\": {\"_person\": \"Joe\"}},\"thoughtSignature\":
-        \"CiQBvj72+8qmWM1fJrd6ra7ZgLl6S50DseOu29VO/2xz+TmRE4YKdQG+Pvb7rA36hxdWBUl6jFSEashnpxFkSHmvclNFvAHC6eFM0b0emagP+ouMXbxvk7CIJA47V/Zw+W/bpb2A/AfpVCkIslG0OBrZ29VtvIWFZdV7h1zrkSeRM+8ez+UXP3g94exlMim+6gMeRu9Hoa+8XukkdwrYAQG+Pvb7H/sYkbdpb6+knFARJuxcQxNvMGEyxatkqXruoy236+5fjAdfnzCMAAHb1wua3yLN8xwmQH+4v3xokH3cGSp1cipT9UoLiYs6LNziJOcPrMvij7W0c/kTkdGfbwwvToBpugFOAbmDm3ou6VPEiNrTiaXipYLRAl3oIvyXEoCZ3dFulaOLbSAG46UAs93FVgCj0va+tNyBxXMhAc4R94fk1tDsifiQPD6HnqMroqQiXnLO7m4Y8pKbaMcAUPLNGS6Bpq9aqf4t972m8j9tFSz1/DPdEg==\"},{\"functionCall\":
-        {\"name\": \"favorite_color\",\"args\": {\"_person\": \"Hadley\"}}}],\"role\":
-        \"model\"},\"finishReason\": \"STOP\",\"index\": 0,\"finishMessage\": \"Model
-        generated function call(s).\"}],\"usageMetadata\": {\"promptTokenCount\":
-        80,\"candidatesTokenCount\": 31,\"totalTokenCount\": 172,\"promptTokensDetails\":
-        [{\"modality\": \"TEXT\",\"tokenCount\": 80}],\"thoughtsTokenCount\": 61},\"modelVersion\":
-        \"gemini-2.5-flash\",\"responseId\": \"sa3NadKnNOnSjMcPsZyr4Qw\"}\r\n\r\n"
+        {\"name\": \"favorite_color\",\"args\": {\"_person\": \"Joe\"},\"id\": \"0b3pdf3o\"},\"thoughtSignature\":
+        \"EqQFCqEFARFNMg/n1ZU9kj5ykZOXQwk1pXyQ5oBBXotOfGYhGEj1y41sfBXZLyM3+6YN5xmpBDXk811DJAzSiqmFj6+fTwz7IRSOZ7ah5fPwxoInNyBBtuFjaQk/ECB0rVp/NxEIeHcu2cCgebeR2X8SZQ8vnjaPEAKBxrCqbsipjgjYCL1MibUEcsJJIDN7EkmEyPepUAIv4hLIGostKn3+Z7sU6r4J9TDEdqBrstKjBA672LZuc/7uwe0Jf6CvDRc00EukCFhj8la6uYExH1XwSIjRHBbHr5g/VS/jJypICrEwuV6ldzcM85SBOJANLaEwT/2zstA7Ig5e7Uc7Q2xdrdhKDmIsOpPDs/VRpVPShWIQ43+MKcW5jM5r7fKC50rbcMPkOAIYn0SLJ+xOahrcHoI6oe3qAdt2kBWMvVI7O9g5U5gBkpzNZNX+OpBm0F+9hcmCWpJoRET1jpSC2fz88ZNim8Y99H0S6OfQ1uFetUD8n8vvRx6nkusuPls3afZN7+s5qKsH5tOAH5BnsorwoORAxZAUppd35Fn9tHIPnbaX4JYPUnGoEJU8OpX+e76R4p/UgFS+0D7tJ6Tyow4n7VFTERfEfXsNdhUBDePT+jnHEoP7lK4BRCBQhjiRfZKhx5wp6IR7nI4pEUO8HGy3W8XD6VvkUH9emm2A3YyK7RZuW4ZirAevsxCcrmQ1Uvk2SVEMgZ/EmJVF5LwllvW8025AnZi78mD2YNtO1fxhBe5bz9CNWl8e32rCVKn4z3r5QQ++sUYZSVkKuxM4IkzIAtpObGx52yLAttJAaeKzv4L64ww9C0vEm/FA9GWTAr4aVLY1ZDkoGNvxZ9RS4W1F2kfCajbAYYqJT/PRyHu4KUsc/WXhpJamFHJLuSiepIUlxekI1Q==\"}],\"role\":
+        \"model\"},\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 85,\"candidatesTokenCount\":
+        17,\"totalTokenCount\": 229,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
+        85}],\"thoughtsTokenCount\": 127,\"serviceTier\": \"standard\"},\"modelVersion\":
+        \"gemini-3.5-flash\",\"responseId\": \"NoFfas7rAsidjrEP3fymkA4\"}\r\n\r\ndata:
+        {\"candidates\": [{\"content\": {\"parts\": [{\"functionCall\": {\"name\":
+        \"favorite_color\",\"args\": {\"_person\": \"Hadley\"},\"id\": \"brynwdxm\"}}],\"role\":
+        \"model\"},\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 85,\"candidatesTokenCount\":
+        35,\"totalTokenCount\": 247,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
+        85}],\"thoughtsTokenCount\": 127,\"serviceTier\": \"standard\"},\"modelVersion\":
+        \"gemini-3.5-flash\",\"responseId\": \"NoFfas7rAsidjrEP3fymkA4\"}\r\n\r\ndata:
+        {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"\"}],\"role\": \"model\"},\"finishReason\":
+        \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 85,\"candidatesTokenCount\":
+        35,\"totalTokenCount\": 247,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
+        85}],\"thoughtsTokenCount\": 127,\"serviceTier\": \"standard\"},\"modelVersion\":
+        \"gemini-3.5-flash\",\"responseId\": \"NoFfas7rAsidjrEP3fymkA4\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -43,11 +52,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Wed, 01 Apr 2026 23:43:46 GMT
+      - Tue, 21 Jul 2026 14:24:55 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=755
+      - gfet4t7; dur=1482
       Transfer-Encoding:
       - chunked
       Vary:
@@ -66,45 +75,47 @@ interactions:
 - request:
     body: '{"contents": [{"parts": [{"text": "\n        What are Joe and Hadley''s
       favourite colours?\n        Answer like name1: colour1, name2: colour2\n    "}],
-      "role": "user"}, {"parts": [{"functionCall": {"args": {"_person": "Joe"}, "name":
-      "favorite_color"}, "thoughtSignature": "CiQBvj72-8qmWM1fJrd6ra7ZgLl6S50DseOu29VO_2xz-TmRE4YKdQG-Pvb7rA36hxdWBUl6jFSEashnpxFkSHmvclNFvAHC6eFM0b0emagP-ouMXbxvk7CIJA47V_Zw-W_bpb2A_AfpVCkIslG0OBrZ29VtvIWFZdV7h1zrkSeRM-8ez-UXP3g94exlMim-6gMeRu9Hoa-8XukkdwrYAQG-Pvb7H_sYkbdpb6-knFARJuxcQxNvMGEyxatkqXruoy236-5fjAdfnzCMAAHb1wua3yLN8xwmQH-4v3xokH3cGSp1cipT9UoLiYs6LNziJOcPrMvij7W0c_kTkdGfbwwvToBpugFOAbmDm3ou6VPEiNrTiaXipYLRAl3oIvyXEoCZ3dFulaOLbSAG46UAs93FVgCj0va-tNyBxXMhAc4R94fk1tDsifiQPD6HnqMroqQiXnLO7m4Y8pKbaMcAUPLNGS6Bpq9aqf4t972m8j9tFSz1_DPdEg=="},
-      {"functionCall": {"args": {"_person": "Hadley"}, "name": "favorite_color"}}],
-      "role": "model"}, {"parts": [{"functionResponse": {"name": "favorite_color",
-      "response": {"result": "sage green"}}}, {"functionResponse": {"name": "favorite_color",
-      "response": {"result": "red"}}}], "role": "user"}], "systemInstruction": {"parts":
-      [{"text": "Be very terse, not even punctuation."}], "role": "user"}, "tools":
-      [{"functionDeclarations": [{"description": "Returns a person''s favourite colour",
-      "name": "favorite_color", "parameters": {"properties": {"_person": {"type":
-      "STRING"}}, "required": ["_person"], "type": "OBJECT"}}]}], "generationConfig":
-      {"temperature": 0}}'
+      "role": "user"}, {"parts": [{"functionCall": {"id": "0b3pdf3o", "args": {"_person":
+      "Joe"}, "name": "favorite_color"}, "thoughtSignature": "EqQFCqEFARFNMg_n1ZU9kj5ykZOXQwk1pXyQ5oBBXotOfGYhGEj1y41sfBXZLyM3-6YN5xmpBDXk811DJAzSiqmFj6-fTwz7IRSOZ7ah5fPwxoInNyBBtuFjaQk_ECB0rVp_NxEIeHcu2cCgebeR2X8SZQ8vnjaPEAKBxrCqbsipjgjYCL1MibUEcsJJIDN7EkmEyPepUAIv4hLIGostKn3-Z7sU6r4J9TDEdqBrstKjBA672LZuc_7uwe0Jf6CvDRc00EukCFhj8la6uYExH1XwSIjRHBbHr5g_VS_jJypICrEwuV6ldzcM85SBOJANLaEwT_2zstA7Ig5e7Uc7Q2xdrdhKDmIsOpPDs_VRpVPShWIQ43-MKcW5jM5r7fKC50rbcMPkOAIYn0SLJ-xOahrcHoI6oe3qAdt2kBWMvVI7O9g5U5gBkpzNZNX-OpBm0F-9hcmCWpJoRET1jpSC2fz88ZNim8Y99H0S6OfQ1uFetUD8n8vvRx6nkusuPls3afZN7-s5qKsH5tOAH5BnsorwoORAxZAUppd35Fn9tHIPnbaX4JYPUnGoEJU8OpX-e76R4p_UgFS-0D7tJ6Tyow4n7VFTERfEfXsNdhUBDePT-jnHEoP7lK4BRCBQhjiRfZKhx5wp6IR7nI4pEUO8HGy3W8XD6VvkUH9emm2A3YyK7RZuW4ZirAevsxCcrmQ1Uvk2SVEMgZ_EmJVF5LwllvW8025AnZi78mD2YNtO1fxhBe5bz9CNWl8e32rCVKn4z3r5QQ--sUYZSVkKuxM4IkzIAtpObGx52yLAttJAaeKzv4L64ww9C0vEm_FA9GWTAr4aVLY1ZDkoGNvxZ9RS4W1F2kfCajbAYYqJT_PRyHu4KUsc_WXhpJamFHJLuSiepIUlxekI1Q=="},
+      {"functionCall": {"id": "brynwdxm", "args": {"_person": "Hadley"}, "name": "favorite_color"}}],
+      "role": "model"}, {"parts": [{"functionResponse": {"id": "0b3pdf3o", "name":
+      "favorite_color", "response": {"result": "sage green"}}}, {"functionResponse":
+      {"id": "brynwdxm", "name": "favorite_color", "response": {"result": "red"}}}],
+      "role": "user"}], "systemInstruction": {"parts": [{"text": "Be very terse, not
+      even punctuation."}], "role": "user"}, "tools": [{"functionDeclarations": [{"description":
+      "Returns a person''s favourite colour", "name": "favorite_color", "parameters":
+      {"properties": {"_person": {"type": "STRING"}}, "required": ["_person"], "type":
+      "OBJECT"}}]}], "generationConfig": {"temperature": 0}}'
     headers:
-      Accept:
+      accept:
       - '*/*'
-      Accept-Encoding:
+      accept-encoding:
       - gzip, deflate, zstd
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '1443'
-      Content-Type:
+      content-length:
+      - '1919'
+      content-type:
       - application/json
-      Host:
+      host:
       - generativelanguage.googleapis.com
       x-goog-api-client:
-      - google-genai-sdk/1.64.0 gl-python/3.12.11
+      - google-genai-sdk/2.10.0 gl-python/3.12.13
     method: POST
-    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:streamGenerateContent?alt=sse
   response:
     body:
-      string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"Joe:
-        sage green\"}],\"role\": \"model\"},\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
-        201,\"candidatesTokenCount\": 4,\"totalTokenCount\": 205,\"promptTokensDetails\":
-        [{\"modality\": \"TEXT\",\"tokenCount\": 201}]},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\":
-        \"sq3NaYj9L47RjMcP4tTv-Ag\"}\r\n\r\ndata: {\"candidates\": [{\"content\":
-        {\"parts\": [{\"text\": \", Hadley: red\"}],\"role\": \"model\"},\"finishReason\":
-        \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 201,\"candidatesTokenCount\":
-        8,\"totalTokenCount\": 209,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
-        201}]},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\": \"sq3NaYj9L47RjMcP4tTv-Ag\"}\r\n\r\n"
+      string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"Joe
+        sage green Hadley red\"}],\"role\": \"model\"},\"index\": 0}],\"usageMetadata\":
+        {\"promptTokenCount\": 147,\"candidatesTokenCount\": 5,\"totalTokenCount\":
+        512,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 147}],\"thoughtsTokenCount\":
+        360,\"serviceTier\": \"standard\"},\"modelVersion\": \"gemini-3.5-flash\",\"responseId\":
+        \"N4FfaraYJYDQjrEP1JudsA4\"}\r\n\r\ndata: {\"candidates\": [{\"content\":
+        {\"parts\": [{\"text\": \"\",\"thoughtSignature\": \"Ep0NCpoNARFNMg8i/3DY+G9jAf7kMr7ahSINuMD7R+BxE3GKvwK1XyGh+MuQpICwGp9P/AJl8O2FG878e9pwZUm2uEF/WFJqNYzdX5zm+xKGzPew4tvhSjCMiQjxmrFD0jTx4JOvhjPVY62l7S7LIikSZ+oC1DtqDBux/S5pnJZg9bNhyGVEUEuWuxEL5T5oHKLAhDxtfm0YHrt81kwS2Kyg4dfymMM70j0wW1x0WT7udJ2TA3SaYUm/GfAETVmRXeei5VHK6q4kSu5COEbK7NTkWyY2mkMiALEJ1hwIUDxIl387wjYJG+5YkF2mh3OQ4e1unzs0hXbjWhLo/nYRecMQZuSk0A6iWwvkdDbZjkS7PlLQ4nDTOt2R+UMhfxDIrvKXSr9rUPC+EoLLWwKGUyp4cpgUAbEBLsGy5p2Ricz/6s5YslpWpouRIAtFZaRlfI38qM4xh4zualXiCSbqKRu9fNsHW2C6ck7pafmE5MGDsQNTgyHYVcr0GNcEaQuiArsksxm+TIJSnpJm35qiESylkEyg5yGS7WS1TdZ8ZBtnbd1wk+FV85yB8Wnbt9etXgeNY0Q4JpWOS7Jike8tMGVYizcmpF7Sgq+Fl3cUUVPyG7/i1Mk80wsFOitieuWhkbL4SYkDe1OYnTqDxGNziA94DmNwjFoQZYMVSWrazWG/R9erICiR53xKMOqERJnayiyZKQQ8n4tVHfKgmxGZSNTfVdPbvT4NMoiv4B+xiXUkRC80UIAJb8ovMqAADciAxJyUiA03p+yY24QEar9n6LCeYjorW1uRk8thoql0U9ge4KXEiyrB76BoXUK65oZddWJgoTIcTBfbihvZzo5Qxtbfr3+Cs9nLDf/NzZUzjgLqx5tX/UPSn5nn4xbosbOx+Ne7lNx7ZPsWic+ilzdgxAdAzznm/qzb+68/11TZp927wTQG4mRxRzD70knae4GzFp1Qds6qHoW/BXR2Sui4U2MNaA4Nob9dOc2+A1ViNYcHHv/PpVbU4Z3moTG1HmtRqYfBLB0cU3IlJgYDK8Jyw4NvNBkeJkCFzuKk70uO3AwJ96uwOjaa+n4rJCk92bYae8Fo5pdxmVHT09Ldpf6HeoeuGq2vOeEVAQR3+fGanq7azuxxxr1OL3srvxQPKpkBm5g832x8foHvK//D8WHgKkcQcEDcSbDnRa9pRo5tEeq2w42Sl0JpgWmqe1p10WyePfUks+0Sr/+jpv1wLKE0lllxcyNJc6Vmghw8T+BHS0X6a0llsWPOIdw4O2F8kF58Z7lg9AZR+378yXDcoqmNcjqTaUaJO5cOqDZsZkUFw9nSxYpu20rLT/7r6NYHEYfEIdvWNFM31hEz10U3q+b4oXR4K8L6J3aNK78fTtDFUICBy8wTHHWQgvxoW/u5ZmE4q/Ui453g0O4xGsx3Tz0mSch1Mql5DhA2MIqRxmTwjfkgz+vhVfWierYAS48WHThOt2ZWAIKI+XfJ7aTWXy5SMPRb0b0oG4ydMllw5/HANWJka+hcHH6j7Dqfzjdgo5BU8kIN3S7n9wMhzxHHCndRp/8CQqiuh/9ngrAj89ILjmbSNHb7xXTU5lxEBgRoBSj81AM5bhH2wssluxT7dOtktqfkIAx8bfXSwyNmRalzfNWnDiKnLPbYL/U+ARRyoLQO9Kr/+sjWF29yE4UgohMfZywy1/XWIvRdXD01nxbdoEGVPNNxcqZ0GUpePymKkQO2mhTaKinJmZPwsBbCz2GiWgjK679m+wLy37OBAoVtWmWWdd0VJFx1BiHRLre61lZPDPL72+8LOsZvsi1cC355mVEQODlSh6PwkC/d5PY1CGiF8o9ItYsxoVOAoF5V38EsdPfljSOgNuabaaOEE+SP4c6O4klIjCLNMskPMq7pPCl/a3eRG0NwNvXFLL6Ko4Hfu/2RLyvRT9cQ43ut1Rg1+FbVXKXgeZ1jleX8brKkWeo/ckMm0R+wgZAC3VR1ZYXmY4AEcfyrtlEcMCJnLG92fxaWNnqNwfOCD1bMbRKSZCdgEKfSIXUXOqkF0mg/YuQ1NsUjjqQS7xNDyKeOUfVVeJFv6KT0N4iFtgujlCfcSb4ToqHEZCJmBbptsuaHIcmJSObZ9muJSPrBz8JxIxPPbgFJr6GpRwAyqG63lSOK1BL2xLLwboeVLrYygxSMze2ycToizOrbuLnOIM6TUgJeThkp4Ok0s/o+ApHBtfFnyvHjUKQypmE8ISiO7OuPdPywujFmrx9Csxx/jljblY9buA==\"}],\"role\":
+        \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
+        274,\"candidatesTokenCount\": 5,\"totalTokenCount\": 639,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 274}],\"thoughtsTokenCount\": 360,\"serviceTier\":
+        \"standard\"},\"modelVersion\": \"gemini-3.5-flash\",\"responseId\": \"N4FfaraYJYDQjrEP1JudsA4\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -113,11 +124,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Wed, 01 Apr 2026 23:43:47 GMT
+      - Tue, 21 Jul 2026 14:24:58 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=425
+      - gfet4t7; dur=2546
       Transfer-Encoding:
       - chunked
       Vary:

--- a/tests/_vcr/test_provider_google/test_tools_sequential.yaml
+++ b/tests/_vcr/test_provider_google/test_tools_sequential.yaml
@@ -12,32 +12,36 @@ interactions:
       "STRING"}}, "required": ["weather"], "type": "OBJECT"}}]}], "generationConfig":
       {"temperature": 0}}'
     headers:
-      Accept:
+      accept:
       - '*/*'
-      Accept-Encoding:
+      accept-encoding:
       - gzip, deflate, zstd
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
+      content-length:
       - '832'
-      Content-Type:
+      content-type:
       - application/json
-      Host:
+      host:
       - generativelanguage.googleapis.com
       x-goog-api-client:
-      - google-genai-sdk/1.64.0 gl-python/3.12.11
+      - google-genai-sdk/2.10.0 gl-python/3.12.13
     method: POST
-    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:streamGenerateContent?alt=sse
   response:
     body:
       string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"functionCall\":
-        {\"name\": \"weather_forecast\",\"args\": {\"city\": \"New York\"}},\"thoughtSignature\":
-        \"CiQBvj72+xxMEex6SHIQZulbUX7wtWNnRGXXxKbhSaW9tkOp5zcKeQG+Pvb7m1c68mQ/MVJ/DT/Y0kSd4gESZdh7Wgn3+TsDk713oVFMXFBt2Y6Al8g600gGl1YYFEyHjf2DG3HyTKjXvW+cNzjAka4dzqyZSh1tXdhfZfrVN+6qlz2N+omWiuvA2TCd/ZLX43RzusaFeay3oEM2EXswTn4KjAIBvj72+z1xp+zi3e9hnBl0c4wjVDKT9AluzMLQKKkQPGeckj7uvW8IaujdcwqWdWuTCQqcEGSDk42yRzggZ6ZJSb+mhIn1GO2q8Wpx5IKCm/vvh1uuC4lfCGOhqjj3XgcZlmkJEdu90aWk4858EszU8OTwUcc0PBxRZHzvFW4QPvyIwZEZmV+R15nuOHnPHIkmVnigntFQjdMEQrdN7bjuXGAxjFiQDOYjco6+eR0szvVwOhSHzlUUZZbJcZwKO+0okGkEiNzsEHC5c0VJHfbgGthSOy75n6rIUmqLMOjf5XzDuYjLdz+SPFfZHWO6/Le6ynLvEOSPe/leyg60y1ewK0jz/l2tmF70A/BQCl0Bvj72+0E4RcowLNheQ7kFGBUvXsa5ub+8oFruOcPiRjmfUEGq8TFEJPYrBWz+BP5nVZRsRzBsc6abneT689SpeXf2KEhd2zSpT05jKpDNXoEisHgjAiAQEvjhpM8=\"}],\"role\":
-        \"model\"},\"finishReason\": \"STOP\",\"index\": 0,\"finishMessage\": \"Model
-        generated function call(s).\"}],\"usageMetadata\": {\"promptTokenCount\":
-        133,\"candidatesTokenCount\": 16,\"totalTokenCount\": 231,\"promptTokensDetails\":
-        [{\"modality\": \"TEXT\",\"tokenCount\": 133}],\"thoughtsTokenCount\": 82},\"modelVersion\":
-        \"gemini-2.5-flash\",\"responseId\": \"s63NaYSvHeCTjMcP5Yi98Ac\"}\r\n\r\n"
+        {\"name\": \"weather_forecast\",\"args\": {\"city\": \"New York\"},\"id\":
+        \"2oaiqhji\"},\"thoughtSignature\": \"EvEFCu4FARFNMg++nSaOgFhDiFIZosrGyEJjH3hMgMF6sp7yXaONeDjoNJfa6WvrKdw1cCEkrui9JlqIrAwy7IJIM94RlYT2aGRW3sz8smNPXkrWgmRT5b+65GJU/e0jBO9ul0d6YBXs6+J5+PRHHwkfIjKV8gP0snpj7Dn/XCUtgFfFK4kwvowFpV2I7Tn3HytMUYTxaOQN6qh8+q2qtZmHYzbziHvZDbIXqcqiAsv9fMAUD4If19l5Mmm0pSWxwBUbhBu46ly2jSd1F6Mlu0FDmSWS0UktrvvE+WY6Qh5qlkYd2bPCY5olsC68Fphm0rT6vnx998zUU8JbTEi2Zr75EH7mPwAxn3LXL10oueD+33bJO+RhD6fXHpI78rvP2CNRYuzSBBhdcumWPArHwEcMD6o9XaptEx5aHPNYSOOlJFm6iwjao3hJjf4Q28trNTchDCQBRD+Lw+nmXZVG7R+WhNpSztTnBXgSJ3U1P/VXO29Jj/gbQj8V/Z6O4GLTXqY3ZGWHNEFnCUDpRH59LKdK0xNPozJroSASy9UmL7ZXl8dEB9+wIs0TxDYbJLnRbTBaDAi6PuAmZYgydMfcvQHLAXE/HU5VYgMWRa1k6ZDk92Veo/0izYwcY+7T8z8M3PjbbuUfIzngU7JJ2GqO80sTsmAIvLDjfYjWD3AtKCsoNlbDUboWOg0cVRA8pOWg7wZZoj2T41fqfTwz+4cYNFtk1H95W2B/xjyVWSkIQiwYaiBiTfHseUPhBToFioFEHJhq/09zadLgNseG5ICSSKb3gz5hsrPUMLCFD6zc+RDBGJZYIi0mLWSavbdxSaOIaDcBU/+X7rju1KUgG4hl5+yVtCpZqJYfIgN+pFlRdcOHpy6696SeIsi05AEkjzhzHx2RNTDIP636M8KwdP6TNGw8o7MCpSlmDj9RxsqxQOoYuWaBCgrjvC8tBXK5cts8gfm7RVk8PRPA1cUcKWzRWFYxGm5PSVPVYmiO2OrNatLu7nkT\"}],\"role\":
+        \"model\"},\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 143,\"candidatesTokenCount\":
+        17,\"totalTokenCount\": 314,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
+        143}],\"thoughtsTokenCount\": 154,\"serviceTier\": \"standard\"},\"modelVersion\":
+        \"gemini-3.5-flash\",\"responseId\": \"OoFfatmhFsidjrEP3fymkA4\"}\r\n\r\ndata:
+        {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"\"}],\"role\": \"model\"},\"finishReason\":
+        \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 143,\"candidatesTokenCount\":
+        17,\"totalTokenCount\": 314,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
+        143}],\"thoughtsTokenCount\": 154,\"serviceTier\": \"standard\"},\"modelVersion\":
+        \"gemini-3.5-flash\",\"responseId\": \"OoFfatmhFsidjrEP3fymkA4\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -46,11 +50,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Wed, 01 Apr 2026 23:43:48 GMT
+      - Tue, 21 Jul 2026 14:24:59 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=869
+      - gfet4t7; dur=1375
       Transfer-Encoding:
       - chunked
       Vary:
@@ -68,46 +72,51 @@ interactions:
       message: OK
 - request:
     body: '{"contents": [{"parts": [{"text": "What should I pack for New York this
-      weekend?"}], "role": "user"}, {"parts": [{"functionCall": {"args": {"city":
-      "New York"}, "name": "weather_forecast"}, "thoughtSignature": "CiQBvj72-xxMEex6SHIQZulbUX7wtWNnRGXXxKbhSaW9tkOp5zcKeQG-Pvb7m1c68mQ_MVJ_DT_Y0kSd4gESZdh7Wgn3-TsDk713oVFMXFBt2Y6Al8g600gGl1YYFEyHjf2DG3HyTKjXvW-cNzjAka4dzqyZSh1tXdhfZfrVN-6qlz2N-omWiuvA2TCd_ZLX43RzusaFeay3oEM2EXswTn4KjAIBvj72-z1xp-zi3e9hnBl0c4wjVDKT9AluzMLQKKkQPGeckj7uvW8IaujdcwqWdWuTCQqcEGSDk42yRzggZ6ZJSb-mhIn1GO2q8Wpx5IKCm_vvh1uuC4lfCGOhqjj3XgcZlmkJEdu90aWk4858EszU8OTwUcc0PBxRZHzvFW4QPvyIwZEZmV-R15nuOHnPHIkmVnigntFQjdMEQrdN7bjuXGAxjFiQDOYjco6-eR0szvVwOhSHzlUUZZbJcZwKO-0okGkEiNzsEHC5c0VJHfbgGthSOy75n6rIUmqLMOjf5XzDuYjLdz-SPFfZHWO6_Le6ynLvEOSPe_leyg60y1ewK0jz_l2tmF70A_BQCl0Bvj72-0E4RcowLNheQ7kFGBUvXsa5ub-8oFruOcPiRjmfUEGq8TFEJPYrBWz-BP5nVZRsRzBsc6abneT689SpeXf2KEhd2zSpT05jKpDNXoEisHgjAiAQEvjhpM8="}],
-      "role": "model"}, {"parts": [{"functionResponse": {"name": "weather_forecast",
-      "response": {"result": "rainy"}}}], "role": "user"}], "systemInstruction": {"parts":
-      [{"text": "\n        Be very terse, not even punctuation. If asked for equipment
-      to pack,\n        first use the weather_forecast tool provided to you. Then,
-      use the\n        equipment tool provided to you.\n        "}], "role": "user"},
-      "tools": [{"functionDeclarations": [{"description": "Gets the weather forecast
-      for a city", "name": "weather_forecast", "parameters": {"properties": {"city":
-      {"type": "STRING"}}, "required": ["city"], "type": "OBJECT"}}, {"description":
+      weekend?"}], "role": "user"}, {"parts": [{"functionCall": {"id": "2oaiqhji",
+      "args": {"city": "New York"}, "name": "weather_forecast"}, "thoughtSignature":
+      "EvEFCu4FARFNMg--nSaOgFhDiFIZosrGyEJjH3hMgMF6sp7yXaONeDjoNJfa6WvrKdw1cCEkrui9JlqIrAwy7IJIM94RlYT2aGRW3sz8smNPXkrWgmRT5b-65GJU_e0jBO9ul0d6YBXs6-J5-PRHHwkfIjKV8gP0snpj7Dn_XCUtgFfFK4kwvowFpV2I7Tn3HytMUYTxaOQN6qh8-q2qtZmHYzbziHvZDbIXqcqiAsv9fMAUD4If19l5Mmm0pSWxwBUbhBu46ly2jSd1F6Mlu0FDmSWS0UktrvvE-WY6Qh5qlkYd2bPCY5olsC68Fphm0rT6vnx998zUU8JbTEi2Zr75EH7mPwAxn3LXL10oueD-33bJO-RhD6fXHpI78rvP2CNRYuzSBBhdcumWPArHwEcMD6o9XaptEx5aHPNYSOOlJFm6iwjao3hJjf4Q28trNTchDCQBRD-Lw-nmXZVG7R-WhNpSztTnBXgSJ3U1P_VXO29Jj_gbQj8V_Z6O4GLTXqY3ZGWHNEFnCUDpRH59LKdK0xNPozJroSASy9UmL7ZXl8dEB9-wIs0TxDYbJLnRbTBaDAi6PuAmZYgydMfcvQHLAXE_HU5VYgMWRa1k6ZDk92Veo_0izYwcY-7T8z8M3PjbbuUfIzngU7JJ2GqO80sTsmAIvLDjfYjWD3AtKCsoNlbDUboWOg0cVRA8pOWg7wZZoj2T41fqfTwz-4cYNFtk1H95W2B_xjyVWSkIQiwYaiBiTfHseUPhBToFioFEHJhq_09zadLgNseG5ICSSKb3gz5hsrPUMLCFD6zc-RDBGJZYIi0mLWSavbdxSaOIaDcBU_-X7rju1KUgG4hl5-yVtCpZqJYfIgN-pFlRdcOHpy6696SeIsi05AEkjzhzHx2RNTDIP636M8KwdP6TNGw8o7MCpSlmDj9RxsqxQOoYuWaBCgrjvC8tBXK5cts8gfm7RVk8PRPA1cUcKWzRWFYxGm5PSVPVYmiO2OrNatLu7nkT"}],
+      "role": "model"}, {"parts": [{"functionResponse": {"id": "2oaiqhji", "name":
+      "weather_forecast", "response": {"result": "rainy"}}}], "role": "user"}], "systemInstruction":
+      {"parts": [{"text": "\n        Be very terse, not even punctuation. If asked
+      for equipment to pack,\n        first use the weather_forecast tool provided
+      to you. Then, use the\n        equipment tool provided to you.\n        "}],
+      "role": "user"}, "tools": [{"functionDeclarations": [{"description": "Gets the
+      weather forecast for a city", "name": "weather_forecast", "parameters": {"properties":
+      {"city": {"type": "STRING"}}, "required": ["city"], "type": "OBJECT"}}, {"description":
       "Gets the equipment needed for a weather condition", "name": "equipment", "parameters":
       {"properties": {"weather": {"type": "STRING"}}, "required": ["weather"], "type":
       "OBJECT"}}]}], "generationConfig": {"temperature": 0}}'
     headers:
-      Accept:
+      accept:
       - '*/*'
-      Accept-Encoding:
+      accept-encoding:
       - gzip, deflate, zstd
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '1782'
-      Content-Type:
+      content-length:
+      - '2122'
+      content-type:
       - application/json
-      Host:
+      host:
       - generativelanguage.googleapis.com
       x-goog-api-client:
-      - google-genai-sdk/1.64.0 gl-python/3.12.11
+      - google-genai-sdk/2.10.0 gl-python/3.12.13
     method: POST
-    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:streamGenerateContent?alt=sse
   response:
     body:
       string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"functionCall\":
-        {\"name\": \"equipment\",\"args\": {\"weather\": \"rainy\"}},\"thoughtSignature\":
-        \"CiQBvj72+2PIPZW2BEXWn2H6BpCDUD41n62tzhc3O54ZQ3WZJQMKagG+Pvb7dCWuKwT3wOQH5hm98sa4C6P8v5kQIc9jURAqgyslANBijYPs1P3GfMAbqHi4CZjzTIHjYtLtTE9Njw7DNl8P1jGbq6dBmBu3kPviFTLivL8t6r5+U6OEcXvc6LedzKpf9quleBYKwQEBvj72+xxnMwQIMBq3X/h0pQNMPfCsaS3y2GmpUwtxfwmoVl5DlpD9nskb/Mu/R6D6h41TYCURQsKw62b1vULNyyEIBUuv45vnNXgnTjo9RZSzN30bL4YuUmJii2sqinpa2HAUoFtE1T0sEEfSmoYUdZqMIqzO9ZAiRyk+XMhj5Zh8l5W+LRmJVCyE/o1NgVO4feZLxa7QeHwdbC2BoAJxr9gzgnN43AmpNpMgZnxs/guiwrpYmjss08Ud6Zr328cE\"}],\"role\":
-        \"model\"},\"finishReason\": \"STOP\",\"index\": 0,\"finishMessage\": \"Model
-        generated function call(s).\"}],\"usageMetadata\": {\"promptTokenCount\":
-        247,\"candidatesTokenCount\": 14,\"totalTokenCount\": 318,\"promptTokensDetails\":
-        [{\"modality\": \"TEXT\",\"tokenCount\": 247}],\"thoughtsTokenCount\": 57},\"modelVersion\":
-        \"gemini-2.5-flash\",\"responseId\": \"tK3NaZuwIu_RjMcPjoP02As\"}\r\n\r\n"
+        {\"name\": \"equipment\",\"args\": {\"weather\": \"rainy\"},\"id\": \"xdds9n0p\"},\"thoughtSignature\":
+        \"ErYCCrMCARFNMg/+eVwwz4mqF7rRCoSYalSlVfYUoL5QN0ejC1hvLxzzAbMjHlh9ng4Unv63kqPyD6koswDXTJbs4/NJXVM9c89T1QtlDLD6Q0S8R3aNzSmxpr/cjS9O2wVV2i5DG8eSWXW+5rT5Dr3agsojleRL2xizh5IJovsieaRwwf8WlE7xW3CHCzlxkgE+g/FU/Ft1Ms33k9NKAwRZIzwtkThrJPizoarLRfZU4pb0Q6iWY0QaCj5YiVdjnWo7/4ZL9+3/cj7Ks4bE2NQlPb0VWPrngv6dGMEs/2kfbAJWW+o3CvJlozVFqfcC8U/L/vtTblTBKqHToDlfXxE8HMt0bwTY2dlJrLlYaXbBln8w3IOphbz6w49gzv3FW66zIbGzPbvd4+Gcd+2q3fr3YM+VPiHwXg==\"}],\"role\":
+        \"model\"},\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 175,\"candidatesTokenCount\":
+        15,\"totalTokenCount\": 243,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
+        175}],\"thoughtsTokenCount\": 53,\"serviceTier\": \"standard\"},\"modelVersion\":
+        \"gemini-3.5-flash\",\"responseId\": \"O4FfarPzMtKkjrEP4bHf8A0\"}\r\n\r\ndata:
+        {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"\"}],\"role\": \"model\"},\"finishReason\":
+        \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 329,\"candidatesTokenCount\":
+        15,\"totalTokenCount\": 397,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
+        329}],\"thoughtsTokenCount\": 53,\"serviceTier\": \"standard\"},\"modelVersion\":
+        \"gemini-3.5-flash\",\"responseId\": \"O4FfarPzMtKkjrEP4bHf8A0\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -116,11 +125,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Wed, 01 Apr 2026 23:43:49 GMT
+      - Tue, 21 Jul 2026 14:25:00 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=749
+      - gfet4t7; dur=990
       Transfer-Encoding:
       - chunked
       Vary:
@@ -138,47 +147,54 @@ interactions:
       message: OK
 - request:
     body: '{"contents": [{"parts": [{"text": "What should I pack for New York this
-      weekend?"}], "role": "user"}, {"parts": [{"functionCall": {"args": {"city":
-      "New York"}, "name": "weather_forecast"}, "thoughtSignature": "CiQBvj72-xxMEex6SHIQZulbUX7wtWNnRGXXxKbhSaW9tkOp5zcKeQG-Pvb7m1c68mQ_MVJ_DT_Y0kSd4gESZdh7Wgn3-TsDk713oVFMXFBt2Y6Al8g600gGl1YYFEyHjf2DG3HyTKjXvW-cNzjAka4dzqyZSh1tXdhfZfrVN-6qlz2N-omWiuvA2TCd_ZLX43RzusaFeay3oEM2EXswTn4KjAIBvj72-z1xp-zi3e9hnBl0c4wjVDKT9AluzMLQKKkQPGeckj7uvW8IaujdcwqWdWuTCQqcEGSDk42yRzggZ6ZJSb-mhIn1GO2q8Wpx5IKCm_vvh1uuC4lfCGOhqjj3XgcZlmkJEdu90aWk4858EszU8OTwUcc0PBxRZHzvFW4QPvyIwZEZmV-R15nuOHnPHIkmVnigntFQjdMEQrdN7bjuXGAxjFiQDOYjco6-eR0szvVwOhSHzlUUZZbJcZwKO-0okGkEiNzsEHC5c0VJHfbgGthSOy75n6rIUmqLMOjf5XzDuYjLdz-SPFfZHWO6_Le6ynLvEOSPe_leyg60y1ewK0jz_l2tmF70A_BQCl0Bvj72-0E4RcowLNheQ7kFGBUvXsa5ub-8oFruOcPiRjmfUEGq8TFEJPYrBWz-BP5nVZRsRzBsc6abneT689SpeXf2KEhd2zSpT05jKpDNXoEisHgjAiAQEvjhpM8="}],
-      "role": "model"}, {"parts": [{"functionResponse": {"name": "weather_forecast",
-      "response": {"result": "rainy"}}}], "role": "user"}, {"parts": [{"functionCall":
-      {"args": {"weather": "rainy"}, "name": "equipment"}, "thoughtSignature": "CiQBvj72-2PIPZW2BEXWn2H6BpCDUD41n62tzhc3O54ZQ3WZJQMKagG-Pvb7dCWuKwT3wOQH5hm98sa4C6P8v5kQIc9jURAqgyslANBijYPs1P3GfMAbqHi4CZjzTIHjYtLtTE9Njw7DNl8P1jGbq6dBmBu3kPviFTLivL8t6r5-U6OEcXvc6LedzKpf9quleBYKwQEBvj72-xxnMwQIMBq3X_h0pQNMPfCsaS3y2GmpUwtxfwmoVl5DlpD9nskb_Mu_R6D6h41TYCURQsKw62b1vULNyyEIBUuv45vnNXgnTjo9RZSzN30bL4YuUmJii2sqinpa2HAUoFtE1T0sEEfSmoYUdZqMIqzO9ZAiRyk-XMhj5Zh8l5W-LRmJVCyE_o1NgVO4feZLxa7QeHwdbC2BoAJxr9gzgnN43AmpNpMgZnxs_guiwrpYmjss08Ud6Zr328cE"}],
-      "role": "model"}, {"parts": [{"functionResponse": {"name": "equipment", "response":
-      {"result": "umbrella"}}}], "role": "user"}], "systemInstruction": {"parts":
-      [{"text": "\n        Be very terse, not even punctuation. If asked for equipment
-      to pack,\n        first use the weather_forecast tool provided to you. Then,
-      use the\n        equipment tool provided to you.\n        "}], "role": "user"},
-      "tools": [{"functionDeclarations": [{"description": "Gets the weather forecast
-      for a city", "name": "weather_forecast", "parameters": {"properties": {"city":
-      {"type": "STRING"}}, "required": ["city"], "type": "OBJECT"}}, {"description":
+      weekend?"}], "role": "user"}, {"parts": [{"functionCall": {"id": "2oaiqhji",
+      "args": {"city": "New York"}, "name": "weather_forecast"}, "thoughtSignature":
+      "EvEFCu4FARFNMg--nSaOgFhDiFIZosrGyEJjH3hMgMF6sp7yXaONeDjoNJfa6WvrKdw1cCEkrui9JlqIrAwy7IJIM94RlYT2aGRW3sz8smNPXkrWgmRT5b-65GJU_e0jBO9ul0d6YBXs6-J5-PRHHwkfIjKV8gP0snpj7Dn_XCUtgFfFK4kwvowFpV2I7Tn3HytMUYTxaOQN6qh8-q2qtZmHYzbziHvZDbIXqcqiAsv9fMAUD4If19l5Mmm0pSWxwBUbhBu46ly2jSd1F6Mlu0FDmSWS0UktrvvE-WY6Qh5qlkYd2bPCY5olsC68Fphm0rT6vnx998zUU8JbTEi2Zr75EH7mPwAxn3LXL10oueD-33bJO-RhD6fXHpI78rvP2CNRYuzSBBhdcumWPArHwEcMD6o9XaptEx5aHPNYSOOlJFm6iwjao3hJjf4Q28trNTchDCQBRD-Lw-nmXZVG7R-WhNpSztTnBXgSJ3U1P_VXO29Jj_gbQj8V_Z6O4GLTXqY3ZGWHNEFnCUDpRH59LKdK0xNPozJroSASy9UmL7ZXl8dEB9-wIs0TxDYbJLnRbTBaDAi6PuAmZYgydMfcvQHLAXE_HU5VYgMWRa1k6ZDk92Veo_0izYwcY-7T8z8M3PjbbuUfIzngU7JJ2GqO80sTsmAIvLDjfYjWD3AtKCsoNlbDUboWOg0cVRA8pOWg7wZZoj2T41fqfTwz-4cYNFtk1H95W2B_xjyVWSkIQiwYaiBiTfHseUPhBToFioFEHJhq_09zadLgNseG5ICSSKb3gz5hsrPUMLCFD6zc-RDBGJZYIi0mLWSavbdxSaOIaDcBU_-X7rju1KUgG4hl5-yVtCpZqJYfIgN-pFlRdcOHpy6696SeIsi05AEkjzhzHx2RNTDIP636M8KwdP6TNGw8o7MCpSlmDj9RxsqxQOoYuWaBCgrjvC8tBXK5cts8gfm7RVk8PRPA1cUcKWzRWFYxGm5PSVPVYmiO2OrNatLu7nkT"}],
+      "role": "model"}, {"parts": [{"functionResponse": {"id": "2oaiqhji", "name":
+      "weather_forecast", "response": {"result": "rainy"}}}], "role": "user"}, {"parts":
+      [{"functionCall": {"id": "xdds9n0p", "args": {"weather": "rainy"}, "name": "equipment"},
+      "thoughtSignature": "ErYCCrMCARFNMg_-eVwwz4mqF7rRCoSYalSlVfYUoL5QN0ejC1hvLxzzAbMjHlh9ng4Unv63kqPyD6koswDXTJbs4_NJXVM9c89T1QtlDLD6Q0S8R3aNzSmxpr_cjS9O2wVV2i5DG8eSWXW-5rT5Dr3agsojleRL2xizh5IJovsieaRwwf8WlE7xW3CHCzlxkgE-g_FU_Ft1Ms33k9NKAwRZIzwtkThrJPizoarLRfZU4pb0Q6iWY0QaCj5YiVdjnWo7_4ZL9-3_cj7Ks4bE2NQlPb0VWPrngv6dGMEs_2kfbAJWW-o3CvJlozVFqfcC8U_L_vtTblTBKqHToDlfXxE8HMt0bwTY2dlJrLlYaXbBln8w3IOphbz6w49gzv3FW66zIbGzPbvd4-Gcd-2q3fr3YM-VPiHwXg=="}],
+      "role": "model"}, {"parts": [{"functionResponse": {"id": "xdds9n0p", "name":
+      "equipment", "response": {"result": "umbrella"}}}], "role": "user"}], "systemInstruction":
+      {"parts": [{"text": "\n        Be very terse, not even punctuation. If asked
+      for equipment to pack,\n        first use the weather_forecast tool provided
+      to you. Then, use the\n        equipment tool provided to you.\n        "}],
+      "role": "user"}, "tools": [{"functionDeclarations": [{"description": "Gets the
+      weather forecast for a city", "name": "weather_forecast", "parameters": {"properties":
+      {"city": {"type": "STRING"}}, "required": ["city"], "type": "OBJECT"}}, {"description":
       "Gets the equipment needed for a weather condition", "name": "equipment", "parameters":
       {"properties": {"weather": {"type": "STRING"}}, "required": ["weather"], "type":
       "OBJECT"}}]}], "generationConfig": {"temperature": 0}}'
     headers:
-      Accept:
+      accept:
       - '*/*'
-      Accept-Encoding:
+      accept-encoding:
       - gzip, deflate, zstd
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '2473'
-      Content-Type:
+      content-length:
+      - '2813'
+      content-type:
       - application/json
-      Host:
+      host:
       - generativelanguage.googleapis.com
       x-goog-api-client:
-      - google-genai-sdk/1.64.0 gl-python/3.12.11
+      - google-genai-sdk/2.10.0 gl-python/3.12.13
     method: POST
-    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:streamGenerateContent?alt=sse
   response:
     body:
-      string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"umbrella\",\"thoughtSignature\":
-        \"ClkBvj72+7p1dLlUg6fRnabMIuDBWLknGn1SWmd1z0KoZUGbWs5Kfgla4W0d07MWZB6mq27C3cNCdpbjd/QQfBiKDmX6zB2cVdfEzlsuxdaF1OE21C8DjkzPMArSAQG+Pvb7vnX79doa/d1YhajXr9N33/tQXxHWQCPSnKfAUikE8gFrCiaf5RKTeoCOJiJ7FgzT4nARYwklnHJmMYYyi6WNuLxME8M+1SHRYL2kxTqP1Zel1fMnMUX6329Y6CfKrWyZkkQNkKNiNHwdah0cqtKgc9qJnrloUkYzb8GbxPzViAw1C3LqJXzSE+fbcuMdCjPMpekqZhZ8N+Y7Zij7/WlybHgedArAfKViITO857rgMBpeMXsW5qqB4QR8/6gBBCq1d4Bc4/1uH9AzVBVzoAoqAb4+9vuNlRhXbKUCh26x8R5FdRjiDpd8pSQEqRvE8Lw9f47cvgbSpoEt\"}],\"role\":
+      string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"umbrella\"}],\"role\":
+        \"model\"},\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 202,\"candidatesTokenCount\":
+        1,\"totalTokenCount\": 238,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
+        202}],\"thoughtsTokenCount\": 35,\"serviceTier\": \"standard\"},\"modelVersion\":
+        \"gemini-3.5-flash\",\"responseId\": \"PIFfavHXOJzJ-8YPuK2GiAk\"}\r\n\r\ndata:
+        {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"\",\"thoughtSignature\":
+        \"EvwBCvkBARFNMg+iNOBMKDgGfwYClm2bBQV/0AoXa9NepLuvXvOvxJL2SPdxOctq3seUnWm2qFOBG6A2hj+goqwVGqLOaTO+troImQM8bpYBO/zlvpEonj9cDydp4XgfMeIJFFH3cvENVYfbrET7a7FNtbiuwm5Ffhe09/xCAg9tghrQvHxR2KP+DFYXTg/sMqxW0m05/OKzuvEdE5MaEYB/qtbH0GwfqILQPwYiv2Euc20R1aBn1en/l6C6xyIyST8VkGvxJS/7JaKSc5o7V0KPzb5SKs2/RP8iIiuYiIuOyy99Wj2suzJY0yKN92GTnOg06YjHvhazXVuCMyza\"}],\"role\":
         \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
-        331,\"candidatesTokenCount\": 1,\"totalTokenCount\": 397,\"promptTokensDetails\":
-        [{\"modality\": \"TEXT\",\"tokenCount\": 331}],\"thoughtsTokenCount\": 65},\"modelVersion\":
-        \"gemini-2.5-flash\",\"responseId\": \"ta3NaYXIH-CTjMcP5Yi98Ac\"}\r\n\r\n"
+        409,\"candidatesTokenCount\": 1,\"totalTokenCount\": 445,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 409}],\"thoughtsTokenCount\": 35,\"serviceTier\":
+        \"standard\"},\"modelVersion\": \"gemini-3.5-flash\",\"responseId\": \"PIFfavHXOJzJ-8YPuK2GiAk\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -187,11 +203,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Wed, 01 Apr 2026 23:43:50 GMT
+      - Tue, 21 Jul 2026 14:25:01 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=780
+      - gfet4t7; dur=883
       Transfer-Encoding:
       - chunked
       Vary:

--- a/tests/_vcr/test_provider_google/test_tools_simple.yaml
+++ b/tests/_vcr/test_provider_google/test_tools_simple.yaml
@@ -7,31 +7,36 @@ interactions:
       "name": "get_date", "parameters": {"properties": {}, "required": [], "type":
       "OBJECT"}}]}], "generationConfig": {"temperature": 0}}'
     headers:
-      Accept:
+      accept:
       - '*/*'
-      Accept-Encoding:
+      accept-encoding:
       - gzip, deflate, zstd
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
+      content-length:
       - '438'
-      Content-Type:
+      content-type:
       - application/json
-      Host:
+      host:
       - generativelanguage.googleapis.com
       x-goog-api-client:
-      - google-genai-sdk/1.64.0 gl-python/3.12.11
+      - google-genai-sdk/2.10.0 gl-python/3.12.13
     method: POST
-    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:streamGenerateContent?alt=sse
   response:
     body:
       string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"functionCall\":
-        {\"name\": \"get_date\",\"args\": {}},\"thoughtSignature\": \"CiQBvj72+3gg4MjXy3a6oWPmDJVQaOxg2Zc1TV/nTcI0E0okxbQKWgG+Pvb7SRkGymJsu3K2rsBL/XwkbxwqE6WX0wQTGtJ5QjgqA1DZMQg09nCtxtROi7fWWgmxAX5PLycgoCCik2jBOJhGfLFXNtGyoWlAA5VKWFj+Z9Ms51Yp4wqrAQG+Pvb7PzEc/A9jjsG6Ag3IxTV5xx82IeDHaxsuhNTMw7czgO+aiXUudtYfjQ82arm3lX+CjzSqf22WHPHGpMpuT1sxvARpSTTDB1ftZ8r6LtnUMejZTsSyVTGcraPLcFD3j0g2rmi9QX0XAdngJkt4onaL7edU3tk21O9u0CUIeCBY8ofDkPiVa4HMMc1WeWIOngCQRH/O5RT7wiH97TlhxACMJ5Jn0K1nfw==\"}],\"role\":
-        \"model\"},\"finishReason\": \"STOP\",\"index\": 0,\"finishMessage\": \"Model
-        generated function call(s).\"}],\"usageMetadata\": {\"promptTokenCount\":
-        59,\"candidatesTokenCount\": 10,\"totalTokenCount\": 117,\"promptTokensDetails\":
-        [{\"modality\": \"TEXT\",\"tokenCount\": 59}],\"thoughtsTokenCount\": 48},\"modelVersion\":
-        \"gemini-2.5-flash\",\"responseId\": \"ra3NafjcCYe3jMcP0K6xyAk\"}\r\n\r\n"
+        {\"name\": \"get_date\",\"args\": {},\"id\": \"adeuph8e\"},\"thoughtSignature\":
+        \"EvICCu8CARFNMg9onwzKtZeiu62WQ4ZabXbNN5ylxf6mIA/v10Woqc3uGA358BO+p36CJUWwukin2QWjFbToT/0afD1ZfLk8Ta7LvHiTdHR+4CiM/U1A/TbfyFUrvx1TobutSZolDY4QIMnLlqu/v225rspEKhhrhx8qG8PQbEm47gpTsz2PatD9iB88xvzr+MarC+er1XWh86U2fpiKlVjqds2YZ2PuffBLrsyx1F1Jx/haIK7Tw4MO6bKEe1q5WMaAiJaBHuEX6vVc64ffW3PDbUWcdbGjTDCz304ICH1hYbLUMw+3E1Fb1lDR72EidftanQPHi/TdhKsJ6S225r7cxX62o5yDdEHtUoZEOa3Iv8XtfJz6rhlKnbd9wagcDsVg8FIZETR9Hk1MwJw1LpVX9/PQSslQ0NokxLCNyKVJEu2kDvRVlk+Fcbbdw8KQyw8K7Kk+vOAjyBzlkeWm5cYSs7YjkxZMs4A5NKowdvfMmiDVbw==\"}],\"role\":
+        \"model\"},\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 59,\"candidatesTokenCount\":
+        10,\"totalTokenCount\": 141,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
+        59}],\"thoughtsTokenCount\": 72,\"serviceTier\": \"standard\"},\"modelVersion\":
+        \"gemini-3.5-flash\",\"responseId\": \"LoFfasuoAbad_uMPtoSC8Qc\"}\r\n\r\ndata:
+        {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"\"}],\"role\": \"model\"},\"finishReason\":
+        \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 59,\"candidatesTokenCount\":
+        10,\"totalTokenCount\": 141,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
+        59}],\"thoughtsTokenCount\": 72,\"serviceTier\": \"standard\"},\"modelVersion\":
+        \"gemini-3.5-flash\",\"responseId\": \"LoFfasuoAbad_uMPtoSC8Qc\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -40,11 +45,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Wed, 01 Apr 2026 23:43:41 GMT
+      - Tue, 21 Jul 2026 14:24:46 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=765
+      - gfet4t7; dur=975
       Transfer-Encoding:
       - chunked
       Vary:
@@ -62,42 +67,44 @@ interactions:
       message: OK
 - request:
     body: '{"contents": [{"parts": [{"text": "What''s the current date in YYYY-MM-DD
-      format?"}], "role": "user"}, {"parts": [{"functionCall": {"args": {}, "name":
-      "get_date"}, "thoughtSignature": "CiQBvj72-3gg4MjXy3a6oWPmDJVQaOxg2Zc1TV_nTcI0E0okxbQKWgG-Pvb7SRkGymJsu3K2rsBL_XwkbxwqE6WX0wQTGtJ5QjgqA1DZMQg09nCtxtROi7fWWgmxAX5PLycgoCCik2jBOJhGfLFXNtGyoWlAA5VKWFj-Z9Ms51Yp4wqrAQG-Pvb7PzEc_A9jjsG6Ag3IxTV5xx82IeDHaxsuhNTMw7czgO-aiXUudtYfjQ82arm3lX-CjzSqf22WHPHGpMpuT1sxvARpSTTDB1ftZ8r6LtnUMejZTsSyVTGcraPLcFD3j0g2rmi9QX0XAdngJkt4onaL7edU3tk21O9u0CUIeCBY8ofDkPiVa4HMMc1WeWIOngCQRH_O5RT7wiH97TlhxACMJ5Jn0K1nfw=="}],
-      "role": "model"}, {"parts": [{"functionResponse": {"name": "get_date", "response":
-      {"result": "2024-01-01"}}}], "role": "user"}], "systemInstruction": {"parts":
-      [{"text": "Always use a tool to help you answer. Reply with ''It is ____.''."}],
-      "role": "user"}, "tools": [{"functionDeclarations": [{"description": "Gets the
-      current date", "name": "get_date", "parameters": {"properties": {}, "required":
-      [], "type": "OBJECT"}}]}], "generationConfig": {"temperature": 0}}'
+      format?"}], "role": "user"}, {"parts": [{"functionCall": {"id": "adeuph8e",
+      "args": {}, "name": "get_date"}, "thoughtSignature": "EvICCu8CARFNMg9onwzKtZeiu62WQ4ZabXbNN5ylxf6mIA_v10Woqc3uGA358BO-p36CJUWwukin2QWjFbToT_0afD1ZfLk8Ta7LvHiTdHR-4CiM_U1A_TbfyFUrvx1TobutSZolDY4QIMnLlqu_v225rspEKhhrhx8qG8PQbEm47gpTsz2PatD9iB88xvzr-MarC-er1XWh86U2fpiKlVjqds2YZ2PuffBLrsyx1F1Jx_haIK7Tw4MO6bKEe1q5WMaAiJaBHuEX6vVc64ffW3PDbUWcdbGjTDCz304ICH1hYbLUMw-3E1Fb1lDR72EidftanQPHi_TdhKsJ6S225r7cxX62o5yDdEHtUoZEOa3Iv8XtfJz6rhlKnbd9wagcDsVg8FIZETR9Hk1MwJw1LpVX9_PQSslQ0NokxLCNyKVJEu2kDvRVlk-Fcbbdw8KQyw8K7Kk-vOAjyBzlkeWm5cYSs7YjkxZMs4A5NKowdvfMmiDVbw=="}],
+      "role": "model"}, {"parts": [{"functionResponse": {"id": "adeuph8e", "name":
+      "get_date", "response": {"result": "2024-01-01"}}}], "role": "user"}], "systemInstruction":
+      {"parts": [{"text": "Always use a tool to help you answer. Reply with ''It is
+      ____.''."}], "role": "user"}, "tools": [{"functionDeclarations": [{"description":
+      "Gets the current date", "name": "get_date", "parameters": {"properties": {},
+      "required": [], "type": "OBJECT"}}]}], "generationConfig": {"temperature": 0}}'
     headers:
-      Accept:
+      accept:
       - '*/*'
-      Accept-Encoding:
+      accept-encoding:
       - gzip, deflate, zstd
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '1063'
-      Content-Type:
+      content-length:
+      - '1191'
+      content-type:
       - application/json
-      Host:
+      host:
       - generativelanguage.googleapis.com
       x-goog-api-client:
-      - google-genai-sdk/1.64.0 gl-python/3.12.11
+      - google-genai-sdk/2.10.0 gl-python/3.12.13
     method: POST
-    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:streamGenerateContent?alt=sse
   response:
     body:
-      string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"It\"}],\"role\":
-        \"model\"},\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 141,\"candidatesTokenCount\":
-        1,\"totalTokenCount\": 142,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
-        141}]},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\": \"rq3NaZSmB-fTjMcPxMSaiAU\"}\r\n\r\ndata:
-        {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \" is 2024-01-01.\"}],\"role\":
+      string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"It
+        is 2024-01-01.\"}],\"role\": \"model\"},\"index\": 0}],\"usageMetadata\":
+        {\"promptTokenCount\": 92,\"candidatesTokenCount\": 14,\"totalTokenCount\":
+        158,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 92}],\"thoughtsTokenCount\":
+        52,\"serviceTier\": \"standard\"},\"modelVersion\": \"gemini-3.5-flash\",\"responseId\":
+        \"L4FfaprABJbO_uMPkf6JaQ\"}\r\n\r\ndata: {\"candidates\": [{\"content\": {\"parts\":
+        [{\"text\": \"\",\"thoughtSignature\": \"EvQBCvEBARFNMg+ZGUn6aGst99dvCIDAX5YnD14+hop3tSqqrVIblVX5lICFYaxvKbFeK2t4NrvN3vgGjrYJ3qr7HQdMeDRVDcubQ/evexSnBpAMM0T6wmUSwp5R7D+Ma7EJCK0ZD9+qpyMtwIJwgp/oLtj6kekyEYXW+h217TNnR4UOqKwDfafZoD/0TvRLBn9liGZ9iGg3e3hk00LRMe8/CwOpd1bgJg2nM2m6leAEvhjPnkS/IG53UYd460ThYYVxQ7Zelx8Kp5nGmOnLm1rGnsb0VSL2cH06Sef5tJ6T8v1BkuKcDhkgMdgdL3rAqiz38K6sVA==\"}],\"role\":
         \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
-        141,\"candidatesTokenCount\": 14,\"totalTokenCount\": 155,\"promptTokensDetails\":
-        [{\"modality\": \"TEXT\",\"tokenCount\": 141}]},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\":
-        \"rq3NaZSmB-fTjMcPxMSaiAU\"}\r\n\r\n"
+        164,\"candidatesTokenCount\": 14,\"totalTokenCount\": 230,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 164}],\"thoughtsTokenCount\": 52,\"serviceTier\":
+        \"standard\"},\"modelVersion\": \"gemini-3.5-flash\",\"responseId\": \"L4FfaprABJbO_uMPkf6JaQ\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -106,11 +113,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Wed, 01 Apr 2026 23:43:42 GMT
+      - Tue, 21 Jul 2026 14:24:47 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=427
+      - gfet4t7; dur=980
       Transfer-Encoding:
       - chunked
       Vary:
@@ -128,42 +135,47 @@ interactions:
       message: OK
 - request:
     body: '{"contents": [{"parts": [{"text": "What''s the current date in YYYY-MM-DD
-      format?"}], "role": "user"}, {"parts": [{"functionCall": {"args": {}, "name":
-      "get_date"}, "thoughtSignature": "CiQBvj72-3gg4MjXy3a6oWPmDJVQaOxg2Zc1TV_nTcI0E0okxbQKWgG-Pvb7SRkGymJsu3K2rsBL_XwkbxwqE6WX0wQTGtJ5QjgqA1DZMQg09nCtxtROi7fWWgmxAX5PLycgoCCik2jBOJhGfLFXNtGyoWlAA5VKWFj-Z9Ms51Yp4wqrAQG-Pvb7PzEc_A9jjsG6Ag3IxTV5xx82IeDHaxsuhNTMw7czgO-aiXUudtYfjQ82arm3lX-CjzSqf22WHPHGpMpuT1sxvARpSTTDB1ftZ8r6LtnUMejZTsSyVTGcraPLcFD3j0g2rmi9QX0XAdngJkt4onaL7edU3tk21O9u0CUIeCBY8ofDkPiVa4HMMc1WeWIOngCQRH_O5RT7wiH97TlhxACMJ5Jn0K1nfw=="}],
-      "role": "model"}, {"parts": [{"functionResponse": {"name": "get_date", "response":
-      {"result": "2024-01-01"}}}], "role": "user"}, {"parts": [{"text": "It"}, {"text":
-      " is 2024-01-01."}], "role": "model"}, {"parts": [{"text": "What month is it?
-      Provide the full name."}], "role": "user"}], "systemInstruction": {"parts":
-      [{"text": "Always use a tool to help you answer. Reply with ''It is ____.''."}],
-      "role": "user"}, "tools": [{"functionDeclarations": [{"description": "Gets the
-      current date", "name": "get_date", "parameters": {"properties": {}, "required":
-      [], "type": "OBJECT"}}]}], "generationConfig": {"temperature": 0}}'
+      format?"}], "role": "user"}, {"parts": [{"functionCall": {"id": "adeuph8e",
+      "args": {}, "name": "get_date"}, "thoughtSignature": "EvICCu8CARFNMg9onwzKtZeiu62WQ4ZabXbNN5ylxf6mIA_v10Woqc3uGA358BO-p36CJUWwukin2QWjFbToT_0afD1ZfLk8Ta7LvHiTdHR-4CiM_U1A_TbfyFUrvx1TobutSZolDY4QIMnLlqu_v225rspEKhhrhx8qG8PQbEm47gpTsz2PatD9iB88xvzr-MarC-er1XWh86U2fpiKlVjqds2YZ2PuffBLrsyx1F1Jx_haIK7Tw4MO6bKEe1q5WMaAiJaBHuEX6vVc64ffW3PDbUWcdbGjTDCz304ICH1hYbLUMw-3E1Fb1lDR72EidftanQPHi_TdhKsJ6S225r7cxX62o5yDdEHtUoZEOa3Iv8XtfJz6rhlKnbd9wagcDsVg8FIZETR9Hk1MwJw1LpVX9_PQSslQ0NokxLCNyKVJEu2kDvRVlk-Fcbbdw8KQyw8K7Kk-vOAjyBzlkeWm5cYSs7YjkxZMs4A5NKowdvfMmiDVbw=="}],
+      "role": "model"}, {"parts": [{"functionResponse": {"id": "adeuph8e", "name":
+      "get_date", "response": {"result": "2024-01-01"}}}], "role": "user"}, {"parts":
+      [{"text": "It is 2024-01-01."}], "role": "model"}, {"parts": [{"text": "What
+      month is it? Provide the full name."}], "role": "user"}], "systemInstruction":
+      {"parts": [{"text": "Always use a tool to help you answer. Reply with ''It is
+      ____.''."}], "role": "user"}, "tools": [{"functionDeclarations": [{"description":
+      "Gets the current date", "name": "get_date", "parameters": {"properties": {},
+      "required": [], "type": "OBJECT"}}]}], "generationConfig": {"temperature": 0}}'
     headers:
-      Accept:
+      accept:
       - '*/*'
-      Accept-Encoding:
+      accept-encoding:
       - gzip, deflate, zstd
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '1221'
-      Content-Type:
+      content-length:
+      - '1335'
+      content-type:
       - application/json
-      Host:
+      host:
       - generativelanguage.googleapis.com
       x-goog-api-client:
-      - google-genai-sdk/1.64.0 gl-python/3.12.11
+      - google-genai-sdk/2.10.0 gl-python/3.12.13
     method: POST
-    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:streamGenerateContent?alt=sse
   response:
     body:
       string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"functionCall\":
-        {\"name\": \"get_date\",\"args\": {}},\"thoughtSignature\": \"CiQBvj72+3X6FaU1RwzOPuF+gKzs3qZGvQkQdGZdYZDBCeuxUDgKXQG+Pvb7FI6xesYBPPIf7YIKvApjTK2w1+ipPJbSGhHMciJ76WzE5etY1KU5+mMJX90rfZ7HO6M1l5w/Lomd8WHp67wV4rPRfWllCaucp5ZwheBOZrcu1zTtMkLwdwqiAQG+Pvb7ML3JufxAAoAa/BWjSWYyfS6npDSxY5fB/CQyVREbXp8azLm0K0IUfW45RmqSbF6avu35ZucPB5KXT8CSkjSf5QKDAHg0tY2wdY451lPv7kjWsp6h29n6DvfDBc5Kn9yzeLAYgsVPG9xOBeJy4+cHENAb/Qeptg0vM4rnbn2FVXISr0PEdLUhs7Eni4nqKs/26GCa29yrpQZYHp4KBQ==\"}],\"role\":
-        \"model\"},\"finishReason\": \"STOP\",\"index\": 0,\"finishMessage\": \"Model
-        generated function call(s).\"}],\"usageMetadata\": {\"promptTokenCount\":
-        119,\"candidatesTokenCount\": 10,\"totalTokenCount\": 180,\"promptTokensDetails\":
-        [{\"modality\": \"TEXT\",\"tokenCount\": 119}],\"thoughtsTokenCount\": 51},\"modelVersion\":
-        \"gemini-2.5-flash\",\"responseId\": \"rq3Nad6NL4e3jMcP0K6xyAk\"}\r\n\r\n"
+        {\"name\": \"get_date\",\"args\": {},\"id\": \"f0sssgi0\"},\"thoughtSignature\":
+        \"EoIDCv8CARFNMg8uAI/9u83/u1a8ie/GGFewxdEOxQ3SM/eQrBZN6FBlp0pPz4r7hJy3K2wwnvahqvbyLh9/hbTFnDxBCpWCdTi/sqhwJL2x04BzpIvWEtELh8VoFPxGXCUaP1b6/Fhe7dPU2Aom4zDga2kZ2eMD7tsPb9fIR3TuRAbIz4B3AU7HuSZPQNazFGLhMBWodvtY8d2LnygEmX0agQmSVPQsj0cRKWEgIkwc5DT7vvsQZepeiSQO2muhAGq5/f5MO4XiC+L0gsHFTj8JdC8ZR/tZFGgUM0eEbKC89bIEj931PUvody71JDxIBc/xpPVS2YGiQSpFGV5lmuffPD4uNSl2iS4Jf0rjknWVXUoAWdUwiAIimvXhm1/h8R3Yfr8lGTHe2medJd4W5tdt22hNhDhKY4XYdX8G2FppLnTaO9n20dAEZP7Xmi8g3VK/6frvjp9yJMlB1y/ke1UnjYRSDhFPe8UtULOVFQJIqRdep7C3/KAVJrhCrUoGdccFceg=\"}],\"role\":
+        \"model\"},\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 118,\"candidatesTokenCount\":
+        10,\"totalTokenCount\": 199,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
+        118}],\"thoughtsTokenCount\": 71,\"serviceTier\": \"standard\"},\"modelVersion\":
+        \"gemini-3.5-flash\",\"responseId\": \"MIFfas-WCa_i_uMPqtKcsQ4\"}\r\n\r\ndata:
+        {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"\"}],\"role\": \"model\"},\"finishReason\":
+        \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 190,\"candidatesTokenCount\":
+        10,\"totalTokenCount\": 271,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
+        190}],\"thoughtsTokenCount\": 71,\"serviceTier\": \"standard\"},\"modelVersion\":
+        \"gemini-3.5-flash\",\"responseId\": \"MIFfas-WCa_i_uMPqtKcsQ4\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -172,11 +184,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Wed, 01 Apr 2026 23:43:43 GMT
+      - Tue, 21 Jul 2026 14:24:49 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=656
+      - gfet4t7; dur=1142
       Transfer-Encoding:
       - chunked
       Vary:
@@ -194,47 +206,49 @@ interactions:
       message: OK
 - request:
     body: '{"contents": [{"parts": [{"text": "What''s the current date in YYYY-MM-DD
-      format?"}], "role": "user"}, {"parts": [{"functionCall": {"args": {}, "name":
-      "get_date"}, "thoughtSignature": "CiQBvj72-3gg4MjXy3a6oWPmDJVQaOxg2Zc1TV_nTcI0E0okxbQKWgG-Pvb7SRkGymJsu3K2rsBL_XwkbxwqE6WX0wQTGtJ5QjgqA1DZMQg09nCtxtROi7fWWgmxAX5PLycgoCCik2jBOJhGfLFXNtGyoWlAA5VKWFj-Z9Ms51Yp4wqrAQG-Pvb7PzEc_A9jjsG6Ag3IxTV5xx82IeDHaxsuhNTMw7czgO-aiXUudtYfjQ82arm3lX-CjzSqf22WHPHGpMpuT1sxvARpSTTDB1ftZ8r6LtnUMejZTsSyVTGcraPLcFD3j0g2rmi9QX0XAdngJkt4onaL7edU3tk21O9u0CUIeCBY8ofDkPiVa4HMMc1WeWIOngCQRH_O5RT7wiH97TlhxACMJ5Jn0K1nfw=="}],
-      "role": "model"}, {"parts": [{"functionResponse": {"name": "get_date", "response":
-      {"result": "2024-01-01"}}}], "role": "user"}, {"parts": [{"text": "It"}, {"text":
-      " is 2024-01-01."}], "role": "model"}, {"parts": [{"text": "What month is it?
-      Provide the full name."}], "role": "user"}, {"parts": [{"functionCall": {"args":
-      {}, "name": "get_date"}, "thoughtSignature": "CiQBvj72-3X6FaU1RwzOPuF-gKzs3qZGvQkQdGZdYZDBCeuxUDgKXQG-Pvb7FI6xesYBPPIf7YIKvApjTK2w1-ipPJbSGhHMciJ76WzE5etY1KU5-mMJX90rfZ7HO6M1l5w_Lomd8WHp67wV4rPRfWllCaucp5ZwheBOZrcu1zTtMkLwdwqiAQG-Pvb7ML3JufxAAoAa_BWjSWYyfS6npDSxY5fB_CQyVREbXp8azLm0K0IUfW45RmqSbF6avu35ZucPB5KXT8CSkjSf5QKDAHg0tY2wdY451lPv7kjWsp6h29n6DvfDBc5Kn9yzeLAYgsVPG9xOBeJy4-cHENAb_Qeptg0vM4rnbn2FVXISr0PEdLUhs7Eni4nqKs_26GCa29yrpQZYHp4KBQ=="}],
-      "role": "model"}, {"parts": [{"functionResponse": {"name": "get_date", "response":
-      {"result": "2024-01-01"}}}], "role": "user"}], "systemInstruction": {"parts":
-      [{"text": "Always use a tool to help you answer. Reply with ''It is ____.''."}],
-      "role": "user"}, "tools": [{"functionDeclarations": [{"description": "Gets the
-      current date", "name": "get_date", "parameters": {"properties": {}, "required":
-      [], "type": "OBJECT"}}]}], "generationConfig": {"temperature": 0}}'
+      format?"}], "role": "user"}, {"parts": [{"functionCall": {"id": "adeuph8e",
+      "args": {}, "name": "get_date"}, "thoughtSignature": "EvICCu8CARFNMg9onwzKtZeiu62WQ4ZabXbNN5ylxf6mIA_v10Woqc3uGA358BO-p36CJUWwukin2QWjFbToT_0afD1ZfLk8Ta7LvHiTdHR-4CiM_U1A_TbfyFUrvx1TobutSZolDY4QIMnLlqu_v225rspEKhhrhx8qG8PQbEm47gpTsz2PatD9iB88xvzr-MarC-er1XWh86U2fpiKlVjqds2YZ2PuffBLrsyx1F1Jx_haIK7Tw4MO6bKEe1q5WMaAiJaBHuEX6vVc64ffW3PDbUWcdbGjTDCz304ICH1hYbLUMw-3E1Fb1lDR72EidftanQPHi_TdhKsJ6S225r7cxX62o5yDdEHtUoZEOa3Iv8XtfJz6rhlKnbd9wagcDsVg8FIZETR9Hk1MwJw1LpVX9_PQSslQ0NokxLCNyKVJEu2kDvRVlk-Fcbbdw8KQyw8K7Kk-vOAjyBzlkeWm5cYSs7YjkxZMs4A5NKowdvfMmiDVbw=="}],
+      "role": "model"}, {"parts": [{"functionResponse": {"id": "adeuph8e", "name":
+      "get_date", "response": {"result": "2024-01-01"}}}], "role": "user"}, {"parts":
+      [{"text": "It is 2024-01-01."}], "role": "model"}, {"parts": [{"text": "What
+      month is it? Provide the full name."}], "role": "user"}, {"parts": [{"functionCall":
+      {"id": "f0sssgi0", "args": {}, "name": "get_date"}, "thoughtSignature": "EoIDCv8CARFNMg8uAI_9u83_u1a8ie_GGFewxdEOxQ3SM_eQrBZN6FBlp0pPz4r7hJy3K2wwnvahqvbyLh9_hbTFnDxBCpWCdTi_sqhwJL2x04BzpIvWEtELh8VoFPxGXCUaP1b6_Fhe7dPU2Aom4zDga2kZ2eMD7tsPb9fIR3TuRAbIz4B3AU7HuSZPQNazFGLhMBWodvtY8d2LnygEmX0agQmSVPQsj0cRKWEgIkwc5DT7vvsQZepeiSQO2muhAGq5_f5MO4XiC-L0gsHFTj8JdC8ZR_tZFGgUM0eEbKC89bIEj931PUvody71JDxIBc_xpPVS2YGiQSpFGV5lmuffPD4uNSl2iS4Jf0rjknWVXUoAWdUwiAIimvXhm1_h8R3Yfr8lGTHe2medJd4W5tdt22hNhDhKY4XYdX8G2FppLnTaO9n20dAEZP7Xmi8g3VK_6frvjp9yJMlB1y_ke1UnjYRSDhFPe8UtULOVFQJIqRdep7C3_KAVJrhCrUoGdccFceg="}],
+      "role": "model"}, {"parts": [{"functionResponse": {"id": "f0sssgi0", "name":
+      "get_date", "response": {"result": "2024-01-01"}}}], "role": "user"}], "systemInstruction":
+      {"parts": [{"text": "Always use a tool to help you answer. Reply with ''It is
+      ____.''."}], "role": "user"}, "tools": [{"functionDeclarations": [{"description":
+      "Gets the current date", "name": "get_date", "parameters": {"properties": {},
+      "required": [], "type": "OBJECT"}}]}], "generationConfig": {"temperature": 0}}'
     headers:
-      Accept:
+      accept:
       - '*/*'
-      Accept-Encoding:
+      accept-encoding:
       - gzip, deflate, zstd
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '1838'
-      Content-Type:
+      content-length:
+      - '2108'
+      content-type:
       - application/json
-      Host:
+      host:
       - generativelanguage.googleapis.com
       x-goog-api-client:
-      - google-genai-sdk/1.64.0 gl-python/3.12.11
+      - google-genai-sdk/2.10.0 gl-python/3.12.13
     method: POST
-    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:streamGenerateContent?alt=sse
   response:
     body:
-      string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"It\"}],\"role\":
-        \"model\"},\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 204,\"candidatesTokenCount\":
-        1,\"totalTokenCount\": 205,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
-        204}]},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\": \"r63NaaePJoe3jMcP0K6xyAk\"}\r\n\r\ndata:
-        {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \" is January.\"}],\"role\":
+      string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"It
+        is January.\"}],\"role\": \"model\"},\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
+        151,\"candidatesTokenCount\": 4,\"totalTokenCount\": 212,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 151}],\"thoughtsTokenCount\": 57,\"serviceTier\":
+        \"standard\"},\"modelVersion\": \"gemini-3.5-flash\",\"responseId\": \"MYFfariQF4-o_uMPvvHgWQ\"}\r\n\r\ndata:
+        {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"\",\"thoughtSignature\":
+        \"EqACCp0CARFNMg9k4S9uipefeWDlD7snZHBHENCDHte6+oj73ECcof9SJFHCoNv7+ffDrxB/0guGS3Wl6Bfgg5v16fiIpJs5VcgEwAaKMeg+KW3L4BtMSNWJhXAr/bh+CeaoNfg6u6HcYAUsJzVhY0UgP1XTbyk5xKSJD5qpZY72WgG1vFIbBugEqPb04CnI0FGiMeSpoReKP1+iys3RrFu3p9FODwtcxEx+V5RVoX/q1qGFOn/TVflCpugjQ3GXQh1G3K3U33HTTRAkUdVgNhnLyA3vch2hqW0sj7Pf5nkJ8C5ETBIeVx442Abbm+0mQiabbdYhXrWV/+uvrCUsgQT1q5TFg8IbwO3q2XjCzb5ofs4LBnWeIQTeEMRkRhi6v0vM\"}],\"role\":
         \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
-        204,\"candidatesTokenCount\": 4,\"totalTokenCount\": 208,\"promptTokensDetails\":
-        [{\"modality\": \"TEXT\",\"tokenCount\": 204}]},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\":
-        \"r63NaaePJoe3jMcP0K6xyAk\"}\r\n\r\n"
+        294,\"candidatesTokenCount\": 4,\"totalTokenCount\": 355,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 294}],\"thoughtsTokenCount\": 57,\"serviceTier\":
+        \"standard\"},\"modelVersion\": \"gemini-3.5-flash\",\"responseId\": \"MYFfariQF4-o_uMPvvHgWQ\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -243,11 +257,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Wed, 01 Apr 2026 23:43:43 GMT
+      - Tue, 21 Jul 2026 14:24:50 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=356
+      - gfet4t7; dur=862
       Transfer-Encoding:
       - chunked
       Vary:

--- a/tests/_vcr/test_provider_google/test_tools_simple_stream_content.yaml
+++ b/tests/_vcr/test_provider_google/test_tools_simple_stream_content.yaml
@@ -7,31 +7,36 @@ interactions:
       {"properties": {}, "required": [], "type": "OBJECT"}}]}], "generationConfig":
       {"temperature": 0}}'
     headers:
-      Accept:
+      accept:
       - '*/*'
-      Accept-Encoding:
+      accept-encoding:
       - gzip, deflate, zstd
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
+      content-length:
       - '411'
-      Content-Type:
+      content-type:
       - application/json
-      Host:
+      host:
       - generativelanguage.googleapis.com
       x-goog-api-client:
-      - google-genai-sdk/1.64.0 gl-python/3.12.11
+      - google-genai-sdk/2.10.0 gl-python/3.12.13
     method: POST
-    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:streamGenerateContent?alt=sse
   response:
     body:
       string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"functionCall\":
-        {\"name\": \"get_date\",\"args\": {}},\"thoughtSignature\": \"CiQBvj72+09q6FXkm32yuMdnLY3gss8ZTRGFG4AmVBS5PC+NB5IKcAG+Pvb7Iuxj1GAsULBuNlAuH7R5g8D06qAhMPsiTVVfCh73R96mjtXTfi64GyoUQCNCyHfHXfwG01bZMTIbOK5tyavsYwpXmJaPnjq+ydy0lwPmDA1fmGavUskpYvnFP2MTKcNy2h62dZbV1rjWGz8KlQEBvj72+//VlnVKZhLvbC033P0j6SBzF5LEXgcr+tFEJVgmaptMYH4mmI0XAVIbxfHCl9seCJoZOr1Atha/E0mN6MhLNSMrSCoaIS9HMvVx3goHczKErMXYVnWTRYt3c/+KHRwHHs2yYF/jSn/DTYMXgtvbTRwzxOi8bVyAE7xztOlbi0qE0flKsbhyCCgE6qxzQ+SFrg==\"}],\"role\":
-        \"model\"},\"finishReason\": \"STOP\",\"index\": 0,\"finishMessage\": \"Model
-        generated function call(s).\"}],\"usageMetadata\": {\"promptTokenCount\":
-        51,\"candidatesTokenCount\": 10,\"totalTokenCount\": 104,\"promptTokensDetails\":
-        [{\"modality\": \"TEXT\",\"tokenCount\": 51}],\"thoughtsTokenCount\": 43},\"modelVersion\":
-        \"gemini-2.5-flash\",\"responseId\": \"sK3NaejWEe_VjMcP9K_jiA0\"}\r\n\r\n"
+        {\"name\": \"get_date\",\"args\": {},\"id\": \"q6jp54w8\"},\"thoughtSignature\":
+        \"EqkDCqYDARFNMg/dHfnRQrYi6QhVFieLeDiJRisTSD6I84yNtj3M//61Tpz6lTLvM/Cb/hn8tI2E2tlMlWcVsUlS9wrI8NZiALqKIVa35SBMPu9JBypTWjPLt/T9LWigCHrc5A1gdec1ZnDTOfB/Zl2P3DiaSjViBYuyLzsupPDdy6bp7wx99GArtezxkY5++U3MPoJvGZtr0SkMTZ5MtNASE5WXkYoeD4PfRAHPOUp6k6HKYxr3hOaJLcZlRlDGRwh7HmyPlY7F/j6BXaDHFtu0H49/Wgput4C6+aslvVqLSNr069A3mB51pAOO1VIxpU8oTQ/xbhImFFmF2GTnp+bUWjlo9oM7ZQC5pXDlalMEfqx1c4XZlmMBkC8tarbM0gJ8TS86UfexlrgcQbr30EdOBcEaaAheOCo+PwW4wu7Om0abweSUS+RJtEoLVmE3IFwaiKMvbFAJrKF9XrehwNKLToI1VIZqVkEZO/al0rMIpOVUu2TRoeIDVnZESHIHrgKROO9iQPap7dKa1VTDunE4J37fkmiQDSiq/YLIsYub8CTPbFocDQTqW0A=\"}],\"role\":
+        \"model\"},\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 51,\"candidatesTokenCount\":
+        10,\"totalTokenCount\": 156,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
+        51}],\"thoughtsTokenCount\": 95,\"serviceTier\": \"standard\"},\"modelVersion\":
+        \"gemini-3.5-flash\",\"responseId\": \"MoFfapbBLoak1MkPp8qRsAw\"}\r\n\r\ndata:
+        {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"\"}],\"role\": \"model\"},\"finishReason\":
+        \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 51,\"candidatesTokenCount\":
+        10,\"totalTokenCount\": 156,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
+        51}],\"thoughtsTokenCount\": 95,\"serviceTier\": \"standard\"},\"modelVersion\":
+        \"gemini-3.5-flash\",\"responseId\": \"MoFfapbBLoak1MkPp8qRsAw\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -40,11 +45,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Wed, 01 Apr 2026 23:43:44 GMT
+      - Tue, 21 Jul 2026 14:24:51 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=648
+      - gfet4t7; dur=1195
       Transfer-Encoding:
       - chunked
       Vary:
@@ -62,42 +67,44 @@ interactions:
       message: OK
 - request:
     body: '{"contents": [{"parts": [{"text": "What''s the current date in YYYY-MM-DD
-      format?"}], "role": "user"}, {"parts": [{"functionCall": {"args": {}, "name":
-      "get_date"}, "thoughtSignature": "CiQBvj72-09q6FXkm32yuMdnLY3gss8ZTRGFG4AmVBS5PC-NB5IKcAG-Pvb7Iuxj1GAsULBuNlAuH7R5g8D06qAhMPsiTVVfCh73R96mjtXTfi64GyoUQCNCyHfHXfwG01bZMTIbOK5tyavsYwpXmJaPnjq-ydy0lwPmDA1fmGavUskpYvnFP2MTKcNy2h62dZbV1rjWGz8KlQEBvj72-__VlnVKZhLvbC033P0j6SBzF5LEXgcr-tFEJVgmaptMYH4mmI0XAVIbxfHCl9seCJoZOr1Atha_E0mN6MhLNSMrSCoaIS9HMvVx3goHczKErMXYVnWTRYt3c_-KHRwHHs2yYF_jSn_DTYMXgtvbTRwzxOi8bVyAE7xztOlbi0qE0flKsbhyCCgE6qxzQ-SFrg=="}],
-      "role": "model"}, {"parts": [{"functionResponse": {"name": "get_date", "response":
-      {"result": "2024-01-01"}}}], "role": "user"}], "systemInstruction": {"parts":
-      [{"text": "Be very terse, not even punctuation."}], "role": "user"}, "tools":
-      [{"functionDeclarations": [{"description": "Gets the current date", "name":
-      "get_date", "parameters": {"properties": {}, "required": [], "type": "OBJECT"}}]}],
-      "generationConfig": {"temperature": 0}}'
+      format?"}], "role": "user"}, {"parts": [{"functionCall": {"id": "q6jp54w8",
+      "args": {}, "name": "get_date"}, "thoughtSignature": "EqkDCqYDARFNMg_dHfnRQrYi6QhVFieLeDiJRisTSD6I84yNtj3M__61Tpz6lTLvM_Cb_hn8tI2E2tlMlWcVsUlS9wrI8NZiALqKIVa35SBMPu9JBypTWjPLt_T9LWigCHrc5A1gdec1ZnDTOfB_Zl2P3DiaSjViBYuyLzsupPDdy6bp7wx99GArtezxkY5--U3MPoJvGZtr0SkMTZ5MtNASE5WXkYoeD4PfRAHPOUp6k6HKYxr3hOaJLcZlRlDGRwh7HmyPlY7F_j6BXaDHFtu0H49_Wgput4C6-aslvVqLSNr069A3mB51pAOO1VIxpU8oTQ_xbhImFFmF2GTnp-bUWjlo9oM7ZQC5pXDlalMEfqx1c4XZlmMBkC8tarbM0gJ8TS86UfexlrgcQbr30EdOBcEaaAheOCo-PwW4wu7Om0abweSUS-RJtEoLVmE3IFwaiKMvbFAJrKF9XrehwNKLToI1VIZqVkEZO_al0rMIpOVUu2TRoeIDVnZESHIHrgKROO9iQPap7dKa1VTDunE4J37fkmiQDSiq_YLIsYub8CTPbFocDQTqW0A="}],
+      "role": "model"}, {"parts": [{"functionResponse": {"id": "q6jp54w8", "name":
+      "get_date", "response": {"result": "2024-01-01"}}}], "role": "user"}], "systemInstruction":
+      {"parts": [{"text": "Be very terse, not even punctuation."}], "role": "user"},
+      "tools": [{"functionDeclarations": [{"description": "Gets the current date",
+      "name": "get_date", "parameters": {"properties": {}, "required": [], "type":
+      "OBJECT"}}]}], "generationConfig": {"temperature": 0}}'
     headers:
-      Accept:
+      accept:
       - '*/*'
-      Accept-Encoding:
+      accept-encoding:
       - gzip, deflate, zstd
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '1036'
-      Content-Type:
+      content-length:
+      - '1236'
+      content-type:
       - application/json
-      Host:
+      host:
       - generativelanguage.googleapis.com
       x-goog-api-client:
-      - google-genai-sdk/1.64.0 gl-python/3.12.11
+      - google-genai-sdk/2.10.0 gl-python/3.12.13
     method: POST
-    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:streamGenerateContent?alt=sse
   response:
     body:
-      string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"2024\"}],\"role\":
-        \"model\"},\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 128,\"candidatesTokenCount\":
-        4,\"totalTokenCount\": 132,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
-        128}]},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\": \"sa3NaYSRCcP1jMcP4OHtgAo\"}\r\n\r\ndata:
-        {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"-01-01\"}],\"role\":
+      string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"2024-01-01\"}],\"role\":
+        \"model\"},\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 84,\"candidatesTokenCount\":
+        10,\"totalTokenCount\": 345,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
+        84}],\"thoughtsTokenCount\": 251,\"serviceTier\": \"standard\"},\"modelVersion\":
+        \"gemini-3.5-flash\",\"responseId\": \"M4Ffar2zOP2o1MkPl92DmA4\"}\r\n\r\ndata:
+        {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"\",\"thoughtSignature\":
+        \"EqQICqEIARFNMg9tdBEJ+6SPyfU82ra8oqbvZ1HbYiSP2YsE1yQYwAIodhYlsftP/dgdNnJAO7dAyJ91B/VoI/cVOyt/nkBni6cXwvmwzV77KcEIYVWq8Wb4GJGTqOtY15D8W3DAw8u8Bytp/+xuhnCXB8NpdTe4l1yglKm1WvglGTog+CC+AAEp/gVcd6M1A2UC6CPwWoOP7J6z9Xqz+hR/+0YmZBebpnqYpxLd1qyob+slysWh8lnnKzwSyyCSOF9YOkQGe7eyK41XZGlpyw5sZCpxbkC10920ECZ2Ie87QKjK1I+cvOakdUH4PqAHSEFtpuClnxgtLa8TmtsmrBkDw0vhaxAFm/WzgVSDbA0pIjugFKJYMiqFNrFH9lNvyt2u2KPo8ZSbQ7UgL1mCtsAPO09t7NGRRK88LzB8r4LIzgr8UlY6BfZLVaYGOCD7tOhBihcvSpCGs+COdFq3dp14QSLF9uzxmWhDPdBIb3i+fGcbm+1ISAJjox/r0Oo1yRr4GMPmvpulAVNReehbfOiRW4fsADfk6DOYQBZyoHPXP7nJdb0c4iVo1coOHKhCmYRV0n3muMfTk3R0ZqYCw4ccMUWfh1FA2Bg7wr1tgolPyy71uSDz0x+4g42zrhRMKcB+Tbc+8nMiNH9wJpiDFPQjjg4QuRG4mOeo0i7kgAHr08j8kWz2Gch6Z51OzrBIlH/zLxl2KqamVNhTl2wzBys1kelLwSu2BTfIbQB3vCUdm6iOfwjXUkLt5PL4fSSU3ggc4KFzAbqHHSg2sC0Fd5ywGlXkJkAZhCsidoX/VOEmEPtc2FER595WTlHQ7a3wu1bkrzIjGMVVr/c4hDql3hQF4olP/Jr5JXfwyAKOVvMGxiyEH80YFGrs/z5f7DAPXZHNDpaxooKhToWz11EgXCJa+L0drRUphDwsf8oWV2nmKGRrBSEpGq9aR839OHeeemsYYDRKjWBiQWKy/Me2RD7qTG6/3HItFYzF2cVXZN8T6E24gTSCo4Bl7jCeS+Lr009gRrJ9LBikKKdZ1fjR0lynVIyEAOSkLEt4RStSUq3AgEgEsK7UAy46/MP2/Rj+ad8Ijf4qOY7LKZfS88L2tBfTZc4ZbeASadCvj2YU5enfyi5rNnAXL1KaB64MEjsUE1XWXhLtY+JuXGreNhDH2UCa3HsbkyPsqq20wWP5kkcxgXNd0lwmfEFOUQKoIVqJUZyL602osRiVYtYaAOmDO2CK5jSqJONv6Br1I5IhHXsSt+23ZlSEXtU2fdhpxpiVyD7bYN+yc8SWOakMDIhqLaclG8yPytClgXQBLeFXbhhNBI9iqr56BTpILRXH4P1GJcuQ0AH0JS9c5KvLn+b9SW1GT7i79K2D0fKaRdBF5fSbw8/+NJbWSj00A5qBLURcaXwCMpk2VQ==\"}],\"role\":
         \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
-        128,\"candidatesTokenCount\": 10,\"totalTokenCount\": 138,\"promptTokensDetails\":
-        [{\"modality\": \"TEXT\",\"tokenCount\": 128}]},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\":
-        \"sa3NaYSRCcP1jMcP4OHtgAo\"}\r\n\r\n"
+        179,\"candidatesTokenCount\": 10,\"totalTokenCount\": 440,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 179}],\"thoughtsTokenCount\": 251,\"serviceTier\":
+        \"standard\"},\"modelVersion\": \"gemini-3.5-flash\",\"responseId\": \"M4Ffar2zOP2o1MkPl92DmA4\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -106,11 +113,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Wed, 01 Apr 2026 23:43:45 GMT
+      - Tue, 21 Jul 2026 14:24:53 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=399
+      - gfet4t7; dur=1864
       Transfer-Encoding:
       - chunked
       Vary:


### PR DESCRIPTION
## Summary

Bumps `ChatGoogle()` and `ChatVertex()` default `model` from `gemini-2.5-flash` to `gemini-3.5-flash`

Pricing data for `gemini-3.5-flash` was already present in `chatlas/data/prices.json` for both the `Google/Gemini` and `Google/Vertex` price tables, so cost tracking works out of the box with no further changes there.

## What changed

* `ChatGoogle()` / `ChatVertex()` default model bumped from `gemini-2.5-flash` to `gemini-3.5-flash` (`chatlas/_provider_google.py`).
* Re-recorded the 11 VCR cassettes under `tests/_vcr/test_provider_google/` whose tests rely on the default model (Google's API encodes the model name in the request path, so the old cassettes wouldn't replay against the new default).
* Added a changelog entry.

## Test plan

- [x] `make check-format`
- [x] `make check-types`
- [x] `uv run pytest` (full suite, 569 passed / 12 skipped)
- [x] Re-recorded affected cassettes live against `GOOGLE_API_KEY` and confirmed no secrets leaked (`make check-vcr-secrets` — full-repo scan hit an unrelated pre-existing token-limit error scanning all 172 cassettes at once; manually verified the raw key doesn't appear in the newly rewritten files)