### PR TITLE
Add Gemini batch support, document Groq batch, add Ollama reasoning_effort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### New features
+
+* `batch_chat()` now supports `ChatGoogle()` (Gemini Developer API batch jobs). Batch is also now documented as supported for `ChatGroq()`, which already worked via its OpenAI-compatible provider. (Vertex AI is not supported, since its batch API requires GCS bucket URIs instead of inline requests.)
+* `ChatOllama()` gains a `reasoning_effort` parameter to enable extended "thinking" for models that support it (e.g. qwen3, gpt-oss).
+
 ### Improvements
 
 * `ChatGoogle()` and `ChatVertex()` now default to `gemini-3.5-flash` instead of the older `gemini-2.5-flash`.

--- a/chatlas/_batch_chat.py
+++ b/chatlas/_batch_chat.py
@@ -2,9 +2,9 @@
 Batch chat processing for submitting multiple requests simultaneously.
 
 This module provides functionality for submitting multiple chat requests
-in batches to providers that support it (currently OpenAI, Anthropic, and
-Groq). Batch processing can take up to 24 hours but offers significant cost
-savings (up to 50% less than regular requests).
+in batches to providers that support it (currently OpenAI, Anthropic,
+Google, and Groq). Batch processing can take up to 24 hours but offers
+significant cost savings (up to 50% less than regular requests).
 """
 
 from __future__ import annotations

--- a/chatlas/_batch_chat.py
+++ b/chatlas/_batch_chat.py
@@ -2,9 +2,9 @@
 Batch chat processing for submitting multiple requests simultaneously.
 
 This module provides functionality for submitting multiple chat requests
-in batches to providers that support it (currently OpenAI and Anthropic).
-Batch processing can take up to 24 hours but offers significant cost savings
-(up to 50% less than regular requests).
+in batches to providers that support it (currently OpenAI, Anthropic, and
+Groq). Batch processing can take up to 24 hours but offers significant cost
+savings (up to 50% less than regular requests).
 """
 
 from __future__ import annotations
@@ -32,8 +32,8 @@ def batch_chat(
     Submit multiple chat requests in a batch.
 
     This function allows you to submit multiple chat requests simultaneously
-    using provider batch APIs (currently OpenAI and Anthropic). Batch processing
-    can take up to 24 hours but offers significant cost savings.
+    using provider batch APIs (currently OpenAI, Anthropic, Google, and Groq).
+    Batch processing can take up to 24 hours but offers significant cost savings.
 
     Parameters
     ----------

--- a/chatlas/_provider_google.py
+++ b/chatlas/_provider_google.py
@@ -729,7 +729,15 @@ class GoogleProvider(
             requests.append(types.InlinedRequest(contents=contents, config=config))
 
         batch = self._client.batches.create(model=self.model, src=requests)
-        return batch.model_dump()
+        # mode="json" is required, not cosmetic: reasoning-capable Gemini
+        # models (e.g. gemini-3.6-flash) attach an opaque thought_signature
+        # byte blob to every response part, not just tool-call parts, and
+        # those bytes are not valid UTF-8. Plain model_dump() leaves them as
+        # raw bytes, which crashes BatchState.model_dump_json() once this
+        # dict is persisted to the batch state file. mode="json" base64-
+        # encodes bytes fields, and model_validate() decodes them back
+        # losslessly (verified against a real completed batch response).
+        return batch.model_dump(mode="json")
 
     def batch_poll(self, batch):
         from google.genai import types
@@ -738,7 +746,7 @@ class GoogleProvider(
         if batch.name is None:
             raise ValueError("Batch has no name")
         b = self._client.batches.get(name=batch.name)
-        return b.model_dump()
+        return b.model_dump(mode="json")
 
     def batch_status(self, batch) -> "BatchStatus":
         from google.genai import types
@@ -775,7 +783,7 @@ class GoogleProvider(
         # file-based batch_retrieve() in _provider_openai_generic.py and
         # _provider_anthropic.py): the SDK's inlined_responses are documented
         # to preserve input order.
-        return [r.model_dump() for r in batch.dest.inlined_responses]
+        return [r.model_dump(mode="json") for r in batch.dest.inlined_responses]
 
     def batch_result_turn(self, result, has_data_model: bool = False):
         from google.genai import types

--- a/chatlas/_provider_google.py
+++ b/chatlas/_provider_google.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import warnings
 from typing import TYPE_CHECKING, Any, Literal, Optional, cast, overload
 
 import orjson
@@ -21,7 +22,13 @@ from ._content import (
 )
 from ._logging import log_model_default
 from ._merge import merge_dicts
-from ._provider import ModelInfo, Provider, StandardModelParamNames, StandardModelParams
+from ._provider import (
+    BatchStatus,
+    ModelInfo,
+    Provider,
+    StandardModelParamNames,
+    StandardModelParams,
+)
 from ._tokens import get_price_info
 from ._tools import Tool, ToolBuiltIn
 from ._tools_builtin import ToolWebFetch, ToolWebSearch
@@ -699,6 +706,90 @@ class GoogleProvider(
             "log_probs",
             "stop_sequences",
         }
+
+    def has_batch_support(self) -> bool:
+        # Only the Gemini Developer API has a batch API today; Vertex AI's
+        # batch API takes GCS bucket URIs instead of inline requests, which
+        # is a different shape entirely.
+        return self.name == "Google/Gemini"
+
+    def batch_submit(
+        self,
+        conversations: list[list[Turn]],
+        data_model: Optional[type[BaseModel]] = None,
+    ):
+        from google.genai import types
+        from google.genai.types import GenerateContentConfig
+
+        requests: list["types.InlinedRequest"] = []
+        for turns in conversations:
+            kwargs = self._chat_perform_args(turns, {}, data_model)
+            contents = cast(types.ContentListUnion, kwargs.get("contents"))
+            config = cast(Optional[GenerateContentConfig], kwargs.get("config"))
+            requests.append(types.InlinedRequest(contents=contents, config=config))
+
+        batch = self._client.batches.create(model=self.model, src=requests)
+        return batch.model_dump()
+
+    def batch_poll(self, batch):
+        from google.genai import types
+
+        batch = types.BatchJob.model_validate(batch)
+        if batch.name is None:
+            raise ValueError("Batch has no name")
+        b = self._client.batches.get(name=batch.name)
+        return b.model_dump()
+
+    def batch_status(self, batch) -> "BatchStatus":
+        from google.genai import types
+
+        batch = types.BatchJob.model_validate(batch)
+        terminal_states = {
+            types.JobState.JOB_STATE_SUCCEEDED,
+            types.JobState.JOB_STATE_FAILED,
+            types.JobState.JOB_STATE_CANCELLED,
+            types.JobState.JOB_STATE_EXPIRED,
+            types.JobState.JOB_STATE_PARTIALLY_SUCCEEDED,
+        }
+
+        stats = batch.completion_stats
+        n_succeeded = (stats.successful_count or 0) if stats else 0
+        n_failed = (stats.failed_count or 0) if stats else 0
+        n_processing = (stats.incomplete_count or 0) if stats else 0
+
+        return BatchStatus(
+            working=batch.state not in terminal_states,
+            n_processing=n_processing,
+            n_succeeded=n_succeeded,
+            n_failed=n_failed,
+        )
+
+    def batch_retrieve(self, batch):
+        from google.genai import types
+
+        batch = types.BatchJob.model_validate(batch)
+        if batch.dest is None or batch.dest.inlined_responses is None:
+            raise ValueError("Batch has no results")
+
+        # No custom-id/index-based reordering needed here (unlike the
+        # file-based batch_retrieve() in _provider_openai_generic.py and
+        # _provider_anthropic.py): the SDK's inlined_responses are documented
+        # to preserve input order.
+        return [r.model_dump() for r in batch.dest.inlined_responses]
+
+    def batch_result_turn(self, result, has_data_model: bool = False):
+        from google.genai import types
+
+        result = types.InlinedResponse.model_validate(result)
+        if result.error is not None:
+            warnings.warn(f"Batch request failed: {result.error}")
+            return None
+        if result.response is None:
+            warnings.warn("Batch request returned no response")
+            return None
+
+        completion = cast("GenerateContentResponseDict", result.response.model_dump())
+        return self._as_turn(completion, has_data_model)
 
 
 def ChatVertex(

--- a/chatlas/_provider_ollama.py
+++ b/chatlas/_provider_ollama.py
@@ -12,6 +12,8 @@ from ._provider_openai_completions import OpenAICompletionsProvider
 from ._utils import MISSING, MISSING_TYPE, is_testing
 
 if TYPE_CHECKING:
+    from openai.types.shared.reasoning_effort import ReasoningEffort
+
     from ._provider_openai_completions import ChatCompletion
     from .types.openai import ChatClientArgs, SubmitInputArgs
 
@@ -21,6 +23,7 @@ def ChatOllama(
     *,
     system_prompt: Optional[str] = None,
     base_url: str = "http://localhost:11434",
+    reasoning_effort: "ReasoningEffort" = None,
     seed: int | None | MISSING_TYPE = MISSING,
     kwargs: Optional["ChatClientArgs"] = None,
 ) -> Chat["SubmitInputArgs", ChatCompletion]:
@@ -69,6 +72,12 @@ def ChatOllama(
         A system prompt to set the behavior of the assistant.
     base_url
         The base URL to the endpoint; the default uses ollama's API.
+    reasoning_effort
+        Enables extended "thinking" for models that support it (e.g. qwen3,
+        gpt-oss). Which values are accepted is model-dependent -- qwen3 only
+        distinguishes `"none"` from any other value (thinking on), while
+        gpt-oss accepts `"low"`, `"medium"`, or `"high"` but ignores `"none"`.
+        See <https://docs.ollama.com/capabilities/thinking> for details.
     seed
         Optional integer seed that helps to make output more reproducible.
     kwargs
@@ -99,6 +108,10 @@ def ChatOllama(
     if isinstance(seed, MISSING_TYPE):
         seed = 1014 if is_testing() else None
 
+    kwargs_chat: "SubmitInputArgs" = {}
+    if reasoning_effort is not None:
+        kwargs_chat["reasoning_effort"] = reasoning_effort
+
     return Chat(
         provider=OllamaProvider(
             api_key="ollama",  # ignored
@@ -109,6 +122,7 @@ def ChatOllama(
             kwargs=kwargs,
         ),
         system_prompt=system_prompt,
+        kwargs_chat=kwargs_chat,
     )
 
 

--- a/tests/_vcr/test_batch_chat/test_can_submit_google_batch.yaml
+++ b/tests/_vcr/test_batch_chat/test_can_submit_google_batch.yaml
@@ -1,0 +1,61 @@
+interactions:
+- request:
+    body: '{"batch": {"inputConfig": {"requests": {"requests": [{"request": {"contents":
+      [{"parts": [{"text": "What''s the capital of France?"}], "role": "user"}], "generationConfig":
+      {}}}, {"request": {"contents": [{"parts": [{"text": "What''s the capital of
+      Germany?"}], "role": "user"}], "generationConfig": {}}}]}}}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '307'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      x-goog-api-client:
+      - google-genai-sdk/2.11.0 gl-python/3.12.13
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:batchGenerateContent
+  response:
+    body:
+      string: "{\n  \"name\": \"batches/gpv3pjje0g931jdhnalwqk9sv4pbqgjlqhi9\",\n
+        \ \"metadata\": {\n    \"@type\": \"type.googleapis.com/google.ai.generativelanguage.v1main.GenerateContentBatch\",\n
+        \   \"model\": \"models/gemini-3.5-flash\",\n    \"createTime\": \"2026-07-21T16:05:49.689379878Z\",\n
+        \   \"updateTime\": \"2026-07-21T16:05:49.689379878Z\",\n    \"batchStats\":
+        {\n      \"requestCount\": \"2\",\n      \"pendingRequestCount\": \"2\"\n
+        \   },\n    \"state\": \"BATCH_STATE_PENDING\",\n    \"name\": \"batches/gpv3pjje0g931jdhnalwqk9sv4pbqgjlqhi9\"\n
+        \ }\n}\n"
+    headers:
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length:
+      - '501'
+      content-type:
+      - application/json; charset=UTF-8
+      date:
+      - Tue, 21 Jul 2026 16:05:53 GMT
+      server:
+      - scaffolding on HTTPServer2
+      server-timing:
+      - gfet4t7; dur=4024
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      - X-Origin
+      - Referer
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/batch/google-capitals.json
+++ b/tests/batch/google-capitals.json
@@ -1,0 +1,305 @@
+{
+  "version": 1,
+  "stage": "done",
+  "batch": {
+    "name": "batches/bftevn61yv30eixxykbs5m172oqzvhusmtxg",
+    "display_name": null,
+    "state": "JOB_STATE_SUCCEEDED",
+    "error": null,
+    "create_time": "2026-07-21T17:40:29.864564Z",
+    "start_time": null,
+    "end_time": "2026-07-21T17:42:06.432441Z",
+    "update_time": "2026-07-21T17:42:06.432442Z",
+    "model": "models/gemini-flash-latest",
+    "src": null,
+    "dest": {
+      "format": null,
+      "gcs_uri": null,
+      "bigquery_uri": null,
+      "file_name": null,
+      "inlined_responses": [
+        {
+          "response": {
+            "sdk_http_response": null,
+            "candidates": [
+              {
+                "content": {
+                  "parts": [
+                    {
+                      "media_resolution": null,
+                      "code_execution_result": null,
+                      "executable_code": null,
+                      "file_data": null,
+                      "function_call": null,
+                      "function_response": null,
+                      "inline_data": null,
+                      "text": "The capital of France is **Paris**.",
+                      "thought": null,
+                      "thought_signature": "Eo8DCowDARFNMg_PSXB6Dwc9YX-X9Umc6YmjvEEPSvJocu0TuOSy1jfPOpNEKSd0ZEMP10KEqiKvJqC7C7mTiTCHvwdxsUXUISIzX__BZ_wiMjd8dPKqFrLbJJd6O2teGjZ9-RRAgYWcZ8fm-c7_WcqQpfZYU5GoAwdGf6PpY0W5a0QQPzgXKvxJxCbENoCoZRHSzjsgYAdilNkjFDbuOoh9hJPCBy9Jhl0JO4ipA45zozjm72Ej6ti86e-aje7CZFEjBAfRUyYz5k4aZIJ4ns7GBAW_O0sXaH6Fmy9IVlDCnukkz6OLzOkXWD17W24lMn6o6-sqLyM_NcLkuneDUjn8n5PleRnzCTYuba2v_aAn9OR9q0xT1fXVmfVHqQnYLZdSmEAdd-w7oapcA5Qmc3E1dYGYr9viXLX_x3vsA7obBksulS9kYak8DTFDKT4kffKBHKs-lp4hZpdaUPMjFKmszMhHOcqhaMa-0SQo83CTB6-cMO5dgILKVnLcTiaYe5IHNOntm8yXEYyLztEQDmkW",
+                      "video_metadata": null,
+                      "tool_call": null,
+                      "tool_response": null,
+                      "part_metadata": null
+                    }
+                  ],
+                  "role": "model"
+                },
+                "citation_metadata": null,
+                "finish_message": null,
+                "token_count": null,
+                "finish_reason": "STOP",
+                "grounding_metadata": null,
+                "avg_logprobs": null,
+                "index": 0,
+                "logprobs_result": null,
+                "safety_ratings": null,
+                "url_context_metadata": null
+              }
+            ],
+            "create_time": null,
+            "model_version": "gemini-3.6-flash",
+            "prompt_feedback": null,
+            "response_id": "ZK9fase3OrGQ6dkPlv6VyQc",
+            "usage_metadata": {
+              "cache_tokens_details": null,
+              "cached_content_token_count": null,
+              "candidates_token_count": 8,
+              "candidates_tokens_details": null,
+              "prompt_token_count": 9,
+              "prompt_tokens_details": [
+                {
+                  "modality": "TEXT",
+                  "token_count": 9
+                }
+              ],
+              "thoughts_token_count": 86,
+              "tool_use_prompt_token_count": null,
+              "tool_use_prompt_tokens_details": null,
+              "total_token_count": 103,
+              "traffic_type": null
+            },
+            "model_status": null,
+            "automatic_function_calling_history": null,
+            "parsed": null
+          },
+          "metadata": null,
+          "error": null
+        },
+        {
+          "response": {
+            "sdk_http_response": null,
+            "candidates": [
+              {
+                "content": {
+                  "parts": [
+                    {
+                      "media_resolution": null,
+                      "code_execution_result": null,
+                      "executable_code": null,
+                      "file_data": null,
+                      "function_call": null,
+                      "function_response": null,
+                      "inline_data": null,
+                      "text": "The capital of Germany is **Berlin**.",
+                      "thought": null,
+                      "thought_signature": "EtgCCtUCARFNMg-Z_8ND9o8-c3y0-XWgJLD69Cvvk4t5GN1gmNiFNyLztF6TS-e-wz7bLPKhuk59JWpFyss8KZ-FAF3StoHR0vjCtpvkUQgp7_KJjriosClc0CZDik2-0KC30hekgSc7BqsidJYBGFV2CqdJA1JMxEW06hSYuKMBtf5s9Ow8cOVoFoQgukD52TQIY9oOxKvmCHlOvblzm3h-ZA6rK6I58BbLBPzf3V_iceaUaEg1R_C0_CA-RhdM39a_aU4xyaFlRfckH6z1e6gAhlzY9herfnNywWGXKJBLUWshhhXFqnErUfrBCrA-aXWVx4SS4u2lyR141ZBk32wBsCJshbU5gia3KFlRnbWmY07G7toLgiY48qUmz4PC_O4t7ALvCfDcPDkMLoxVGhHQOJcuIKxTzFl38az3m-uy90SqzoYZDM3Yus7xS9pY_0HIEt4n-hlS9rk=",
+                      "video_metadata": null,
+                      "tool_call": null,
+                      "tool_response": null,
+                      "part_metadata": null
+                    }
+                  ],
+                  "role": "model"
+                },
+                "citation_metadata": null,
+                "finish_message": null,
+                "token_count": null,
+                "finish_reason": "STOP",
+                "grounding_metadata": null,
+                "avg_logprobs": null,
+                "index": 0,
+                "logprobs_result": null,
+                "safety_ratings": null,
+                "url_context_metadata": null
+              }
+            ],
+            "create_time": null,
+            "model_version": "gemini-3.6-flash",
+            "prompt_feedback": null,
+            "response_id": "ZK9faqevMNGkqtsPrZKaqA4",
+            "usage_metadata": {
+              "cache_tokens_details": null,
+              "cached_content_token_count": null,
+              "candidates_token_count": 8,
+              "candidates_tokens_details": null,
+              "prompt_token_count": 9,
+              "prompt_tokens_details": [
+                {
+                  "modality": "TEXT",
+                  "token_count": 9
+                }
+              ],
+              "thoughts_token_count": 71,
+              "tool_use_prompt_token_count": null,
+              "tool_use_prompt_tokens_details": null,
+              "total_token_count": 88,
+              "traffic_type": null
+            },
+            "model_status": null,
+            "automatic_function_calling_history": null,
+            "parsed": null
+          },
+          "metadata": null,
+          "error": null
+        }
+      ],
+      "inlined_embed_content_responses": null,
+      "vertex_dataset": null
+    },
+    "completion_stats": null,
+    "output_info": null
+  },
+  "results": [
+    {
+      "response": {
+        "sdk_http_response": null,
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "media_resolution": null,
+                  "code_execution_result": null,
+                  "executable_code": null,
+                  "file_data": null,
+                  "function_call": null,
+                  "function_response": null,
+                  "inline_data": null,
+                  "text": "The capital of France is **Paris**.",
+                  "thought": null,
+                  "thought_signature": "Eo8DCowDARFNMg_PSXB6Dwc9YX-X9Umc6YmjvEEPSvJocu0TuOSy1jfPOpNEKSd0ZEMP10KEqiKvJqC7C7mTiTCHvwdxsUXUISIzX__BZ_wiMjd8dPKqFrLbJJd6O2teGjZ9-RRAgYWcZ8fm-c7_WcqQpfZYU5GoAwdGf6PpY0W5a0QQPzgXKvxJxCbENoCoZRHSzjsgYAdilNkjFDbuOoh9hJPCBy9Jhl0JO4ipA45zozjm72Ej6ti86e-aje7CZFEjBAfRUyYz5k4aZIJ4ns7GBAW_O0sXaH6Fmy9IVlDCnukkz6OLzOkXWD17W24lMn6o6-sqLyM_NcLkuneDUjn8n5PleRnzCTYuba2v_aAn9OR9q0xT1fXVmfVHqQnYLZdSmEAdd-w7oapcA5Qmc3E1dYGYr9viXLX_x3vsA7obBksulS9kYak8DTFDKT4kffKBHKs-lp4hZpdaUPMjFKmszMhHOcqhaMa-0SQo83CTB6-cMO5dgILKVnLcTiaYe5IHNOntm8yXEYyLztEQDmkW",
+                  "video_metadata": null,
+                  "tool_call": null,
+                  "tool_response": null,
+                  "part_metadata": null
+                }
+              ],
+              "role": "model"
+            },
+            "citation_metadata": null,
+            "finish_message": null,
+            "token_count": null,
+            "finish_reason": "STOP",
+            "grounding_metadata": null,
+            "avg_logprobs": null,
+            "index": 0,
+            "logprobs_result": null,
+            "safety_ratings": null,
+            "url_context_metadata": null
+          }
+        ],
+        "create_time": null,
+        "model_version": "gemini-3.6-flash",
+        "prompt_feedback": null,
+        "response_id": "ZK9fase3OrGQ6dkPlv6VyQc",
+        "usage_metadata": {
+          "cache_tokens_details": null,
+          "cached_content_token_count": null,
+          "candidates_token_count": 8,
+          "candidates_tokens_details": null,
+          "prompt_token_count": 9,
+          "prompt_tokens_details": [
+            {
+              "modality": "TEXT",
+              "token_count": 9
+            }
+          ],
+          "thoughts_token_count": 86,
+          "tool_use_prompt_token_count": null,
+          "tool_use_prompt_tokens_details": null,
+          "total_token_count": 103,
+          "traffic_type": null
+        },
+        "model_status": null,
+        "automatic_function_calling_history": null,
+        "parsed": null
+      },
+      "metadata": null,
+      "error": null
+    },
+    {
+      "response": {
+        "sdk_http_response": null,
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "media_resolution": null,
+                  "code_execution_result": null,
+                  "executable_code": null,
+                  "file_data": null,
+                  "function_call": null,
+                  "function_response": null,
+                  "inline_data": null,
+                  "text": "The capital of Germany is **Berlin**.",
+                  "thought": null,
+                  "thought_signature": "EtgCCtUCARFNMg-Z_8ND9o8-c3y0-XWgJLD69Cvvk4t5GN1gmNiFNyLztF6TS-e-wz7bLPKhuk59JWpFyss8KZ-FAF3StoHR0vjCtpvkUQgp7_KJjriosClc0CZDik2-0KC30hekgSc7BqsidJYBGFV2CqdJA1JMxEW06hSYuKMBtf5s9Ow8cOVoFoQgukD52TQIY9oOxKvmCHlOvblzm3h-ZA6rK6I58BbLBPzf3V_iceaUaEg1R_C0_CA-RhdM39a_aU4xyaFlRfckH6z1e6gAhlzY9herfnNywWGXKJBLUWshhhXFqnErUfrBCrA-aXWVx4SS4u2lyR141ZBk32wBsCJshbU5gia3KFlRnbWmY07G7toLgiY48qUmz4PC_O4t7ALvCfDcPDkMLoxVGhHQOJcuIKxTzFl38az3m-uy90SqzoYZDM3Yus7xS9pY_0HIEt4n-hlS9rk=",
+                  "video_metadata": null,
+                  "tool_call": null,
+                  "tool_response": null,
+                  "part_metadata": null
+                }
+              ],
+              "role": "model"
+            },
+            "citation_metadata": null,
+            "finish_message": null,
+            "token_count": null,
+            "finish_reason": "STOP",
+            "grounding_metadata": null,
+            "avg_logprobs": null,
+            "index": 0,
+            "logprobs_result": null,
+            "safety_ratings": null,
+            "url_context_metadata": null
+          }
+        ],
+        "create_time": null,
+        "model_version": "gemini-3.6-flash",
+        "prompt_feedback": null,
+        "response_id": "ZK9faqevMNGkqtsPrZKaqA4",
+        "usage_metadata": {
+          "cache_tokens_details": null,
+          "cached_content_token_count": null,
+          "candidates_token_count": 8,
+          "candidates_tokens_details": null,
+          "prompt_token_count": 9,
+          "prompt_tokens_details": [
+            {
+              "modality": "TEXT",
+              "token_count": 9
+            }
+          ],
+          "thoughts_token_count": 71,
+          "tool_use_prompt_token_count": null,
+          "tool_use_prompt_tokens_details": null,
+          "total_token_count": 88,
+          "traffic_type": null
+        },
+        "model_status": null,
+        "automatic_function_calling_history": null,
+        "parsed": null
+      },
+      "metadata": null,
+      "error": null
+    }
+  ],
+  "started_at": 1784655629,
+  "hash": {
+    "provider": "Google/Gemini",
+    "model": "gemini-flash-latest",
+    "prompts": "123ef0f8b30649a2e428cd300ed0e78a",
+    "user_turns": "d751713988987e9331980363e24189ce"
+  }
+}

--- a/tests/test_batch_chat.py
+++ b/tests/test_batch_chat.py
@@ -76,6 +76,45 @@ def test_can_retrieve_batch(test_batch_dir):
     assert capitals[1].name == "Berlin"
 
 
+def test_can_retrieve_google_batch(test_batch_dir):
+    """Replays a real, completed Gemini batch job recorded live end-to-end
+    (submit -> poll -> retrieve -> parse). This is also a regression test for
+    a real crash found during that live run: gemini-3.6-flash attaches a
+    non-UTF-8 thought_signature byte blob to every response part, which broke
+    JSON-serializing the on-disk batch state (fixed via model_dump(mode="json")
+    in GoogleProvider's batch_submit/batch_poll/batch_retrieve)."""
+    chat = ChatGoogle(model="gemini-flash-latest")
+    prompts = ["What's the capital of France?", "What's the capital of Germany?"]
+
+    chats = batch_chat(
+        chat,
+        prompts,
+        test_batch_dir / "google-capitals.json",
+    )
+    assert chats is not None
+    assert len(chats) == 2
+    assert chats[0] is not None
+    assert chats[1] is not None
+    turns1 = chats[0].get_turns()
+    turns2 = chats[1].get_turns()
+    assert len(turns1) == 2
+    assert len(turns2) == 2
+    assert isinstance(turns1[1], AssistantTurn)
+    assert turns1[1].tokens is not None
+
+    out = batch_chat_text(
+        chat,
+        prompts,
+        test_batch_dir / "google-capitals.json",
+    )
+    assert out is not None
+    assert len(out) == 2
+    assert out[0] is not None
+    assert out[1] is not None
+    assert "Paris" in out[0]
+    assert "Berlin" in out[1]
+
+
 @pytest.mark.vcr
 def test_can_submit_openai_batch():
     with tempfile.NamedTemporaryFile() as temp_file:

--- a/tests/test_batch_chat.py
+++ b/tests/test_batch_chat.py
@@ -1,7 +1,14 @@
 import tempfile
 
 import pytest
-from chatlas import AssistantTurn, ChatAnthropic, ChatGoogle, ChatOpenAI
+from chatlas import (
+    AssistantTurn,
+    ChatAnthropic,
+    ChatGoogle,
+    ChatGroq,
+    ChatOpenAI,
+    ChatVertex,
+)
 from chatlas._batch_chat import (
     BatchJob,
     batch_chat,
@@ -91,10 +98,39 @@ def test_can_submit_anthropic_batch():
         assert job.stage == "waiting"
 
 
+def test_groq_batch_support_via_inheritance():
+    """ChatGroq() gets full OpenAI-shaped batch support purely via inheritance.
+
+    Groq's real batch API (verified against ellmer's provider-groq.R) is the
+    OpenAI Batches API shape, verbatim -- so no Groq-specific batch code is
+    needed. This guards against something later overriding that inheritance.
+    """
+    from chatlas._provider_openai_generic import OpenAIAbstractProvider
+
+    chat = ChatGroq(api_key="dummy")
+    provider_cls = type(chat.provider)
+    assert chat.provider.has_batch_support()
+    assert provider_cls.batch_submit is OpenAIAbstractProvider.batch_submit
+    assert provider_cls.batch_poll is OpenAIAbstractProvider.batch_poll
+    assert provider_cls.batch_status is OpenAIAbstractProvider.batch_status
+    assert provider_cls.batch_retrieve is OpenAIAbstractProvider.batch_retrieve
+
+
+@pytest.mark.vcr
+def test_can_submit_google_batch():
+    with tempfile.NamedTemporaryFile() as temp_file:
+        chat = ChatGoogle()
+        prompts = ["What's the capital of France?", "What's the capital of Germany?"]
+        job = BatchJob(chat, prompts, temp_file.name, wait=False)
+        assert job.stage == "submitting"
+        job.step()
+        assert job.stage == "waiting"
+
+
 def test_informative_errors(test_batch_dir):
     with pytest.raises(ValueError, match="not supported by this provider"):
         batch_chat(
-            ChatGoogle(),
+            ChatVertex(),
             [],
             "foo.json",
         )

--- a/tests/test_provider_google.py
+++ b/tests/test_provider_google.py
@@ -295,7 +295,7 @@ def test_google_batch_submit_reuses_chat_perform_args():
     ]
     result = provider.batch_submit(conversations)
 
-    assert result == fake_batch.model_dump()
+    assert result == fake_batch.model_dump(mode="json")
     assert mock_create.call_count == 1
     _, kwargs = mock_create.call_args
     assert kwargs["model"] == "gemini-3.5-flash"

--- a/tests/test_provider_google.py
+++ b/tests/test_provider_google.py
@@ -113,9 +113,9 @@ def test_name_setting():
 
 # TODO: this test runs fine in isolation, but fails for some reason when run with the other tests
 # Seems google isn't handling async 100% correctly
-#@pytest.mark.vcr
-#@pytest.mark.asyncio
-#async def test_google_simple_streaming_request():
+# @pytest.mark.vcr
+# @pytest.mark.asyncio
+# async def test_google_simple_streaming_request():
 #    chat = chat_func(
 #        system_prompt="Be as terse as possible; no punctuation. Do not spell out numbers.",
 #    )
@@ -255,3 +255,131 @@ def test_google_thought_signature_roundtrip():
     # Verify it round-trips back into the Part
     part = provider._as_part_type(req)
     assert part.thought_signature == fake_signature
+
+
+def test_google_batch_supported_for_gemini_not_vertex():
+    """Batch is only supported on the Gemini Developer API, not Vertex."""
+    from chatlas._provider_google import GoogleProvider
+
+    gemini = GoogleProvider(model="gemini-3.5-flash", api_key="dummy", kwargs=None)
+    assert gemini.has_batch_support() is True
+
+    vertex = GoogleProvider(
+        model="gemini-3.5-flash",
+        api_key="dummy",
+        name="Google/Vertex",
+        kwargs=None,
+    )
+    assert vertex.has_batch_support() is False
+
+
+def test_google_batch_submit_reuses_chat_perform_args():
+    """batch_submit() builds one InlinedRequest per conversation via _chat_perform_args."""
+    from unittest.mock import MagicMock
+
+    from chatlas._provider_google import GoogleProvider
+    from chatlas._turn import Turn, user_turn
+    from google.genai import types
+
+    provider = GoogleProvider(model="gemini-3.5-flash", api_key="dummy", kwargs=None)
+
+    fake_batch = types.BatchJob(
+        name="batches/123", state=types.JobState.JOB_STATE_PENDING
+    )
+    mock_create = MagicMock(return_value=fake_batch)
+    provider._client.batches.create = mock_create
+
+    conversations: list[list[Turn]] = [
+        [user_turn("What's the capital of France?")],
+        [user_turn("What's the capital of Germany?")],
+    ]
+    result = provider.batch_submit(conversations)
+
+    assert result == fake_batch.model_dump()
+    assert mock_create.call_count == 1
+    _, kwargs = mock_create.call_args
+    assert kwargs["model"] == "gemini-3.5-flash"
+    requests = kwargs["src"]
+    assert len(requests) == 2
+    assert all(isinstance(r, types.InlinedRequest) for r in requests)
+
+
+def test_google_batch_status_mapping():
+    from chatlas._provider_google import GoogleProvider
+
+    provider = GoogleProvider(model="gemini-3.5-flash", api_key="dummy", kwargs=None)
+
+    working = provider.batch_status(
+        {
+            "name": "batches/123",
+            "state": "JOB_STATE_RUNNING",
+            "completion_stats": {
+                "successful_count": 1,
+                "failed_count": 0,
+                "incomplete_count": 1,
+            },
+        }
+    )
+    assert working.working is True
+    assert working.n_succeeded == 1
+    assert working.n_failed == 0
+    assert working.n_processing == 1
+
+    done = provider.batch_status(
+        {
+            "name": "batches/123",
+            "state": "JOB_STATE_SUCCEEDED",
+            "completion_stats": {
+                "successful_count": 2,
+                "failed_count": 0,
+                "incomplete_count": 0,
+            },
+        }
+    )
+    assert done.working is False
+    assert done.n_succeeded == 2
+
+    no_stats = provider.batch_status(
+        {"name": "batches/123", "state": "JOB_STATE_PENDING"}
+    )
+    assert no_stats.working is True
+    assert no_stats.n_processing == 0
+    assert no_stats.n_succeeded == 0
+    assert no_stats.n_failed == 0
+
+
+def test_google_batch_retrieve_and_result_turn():
+    from chatlas._provider_google import GoogleProvider
+
+    provider = GoogleProvider(model="gemini-3.5-flash", api_key="dummy", kwargs=None)
+
+    batch = {
+        "name": "batches/123",
+        "state": "JOB_STATE_SUCCEEDED",
+        "dest": {
+            "inlined_responses": [
+                {
+                    "response": {
+                        "candidates": [
+                            {
+                                "content": {"parts": [{"text": "Paris"}]},
+                                "finish_reason": "STOP",
+                            }
+                        ]
+                    }
+                },
+                {"error": {"code": 500, "message": "internal error"}},
+            ]
+        },
+    }
+
+    results = provider.batch_retrieve(batch)
+    assert len(results) == 2
+
+    turn = provider.batch_result_turn(results[0], has_data_model=False)
+    assert turn is not None
+    assert turn.text == "Paris"
+
+    with pytest.warns(UserWarning, match="Batch request failed"):
+        failed_turn = provider.batch_result_turn(results[1], has_data_model=False)
+    assert failed_turn is None

--- a/tests/test_provider_google.py
+++ b/tests/test_provider_google.py
@@ -383,3 +383,69 @@ def test_google_batch_retrieve_and_result_turn():
     with pytest.warns(UserWarning, match="Batch request failed"):
         failed_turn = provider.batch_result_turn(results[1], has_data_model=False)
     assert failed_turn is None
+
+
+def test_google_batch_retrieve_handles_thought_signature_bytes():
+    """Regression test for a real crash: reasoning-capable Gemini models attach
+    a non-UTF-8 thought_signature byte blob to every response part, and a
+    plain model_dump() leaves those as raw bytes, which crashes
+    BatchState.model_dump_json() once persisted to the batch state file
+    (reproduced against a live gemini-3.6-flash batch response)."""
+    from unittest.mock import MagicMock
+
+    from chatlas._batch_job import BatchState
+    from chatlas._provider_google import GoogleProvider
+    from google.genai import types
+
+    provider = GoogleProvider(model="gemini-3.5-flash", api_key="dummy", kwargs=None)
+
+    non_utf8_signature = bytes([0x12, 0xE9, 0x03, 0x0A, 0xE6, 0x03, 0x01])
+    completed_batch = types.BatchJob(
+        name="batches/123",
+        state=types.JobState.JOB_STATE_SUCCEEDED,
+        dest=types.BatchJobDestination(
+            inlined_responses=[
+                types.InlinedResponse(
+                    response=types.GenerateContentResponse(
+                        candidates=[
+                            types.Candidate(
+                                content=types.Content(
+                                    parts=[
+                                        types.Part(
+                                            text="42",
+                                            thought_signature=non_utf8_signature,
+                                        )
+                                    ]
+                                ),
+                                finish_reason=types.FinishReason.STOP,
+                            )
+                        ]
+                    )
+                )
+            ]
+        ),
+    )
+
+    # batch_poll() and batch_retrieve() both go through model_dump(mode="json"),
+    # so their output must already be JSON-safe -- exercise that boundary here
+    # rather than passing the raw pydantic-object dump directly.
+    provider._client.batches.get = MagicMock(return_value=completed_batch)
+    polled = provider.batch_poll({"name": "batches/123"})
+
+    # This is the exact call that crashed in production: persisting the batch
+    # dict into the on-disk job state.
+    BatchState(
+        version=1,
+        stage="retrieving",
+        batch=polled,
+        results=[],
+        started_at=0,
+        hash={"provider": "x", "model": "x", "prompts": "x", "user_turns": "x"},
+    ).model_dump_json()
+
+    results = provider.batch_retrieve(polled)
+    assert len(results) == 1
+
+    turn = provider.batch_result_turn(results[0], has_data_model=False)
+    assert turn is not None
+    assert turn.text == "42"

--- a/tests/test_provider_ollama.py
+++ b/tests/test_provider_ollama.py
@@ -1,0 +1,16 @@
+from chatlas import ChatOllama
+
+
+def test_ollama_reasoning_effort(monkeypatch):
+    """reasoning_effort is passed through as a request body field."""
+    monkeypatch.setattr("chatlas._provider_ollama.has_ollama", lambda base_url: True)
+
+    chat = ChatOllama(model="qwen3:4b", reasoning_effort="none")
+    assert chat.kwargs_chat == {"reasoning_effort": "none"}
+
+
+def test_ollama_no_reasoning_effort_by_default(monkeypatch):
+    monkeypatch.setattr("chatlas._provider_ollama.has_ollama", lambda base_url: True)
+
+    chat = ChatOllama(model="llama3.2")
+    assert chat.kwargs_chat == {}


### PR DESCRIPTION
## Summary

Catches chatlas up with the remaining gaps identified after the [ellmer 0.4.2 release](https://github.com/tidyverse/ellmer/releases/tag/v0.4.2) (the Gemini default-model bump already shipped in #328).

- **`batch_chat()` now supports `ChatGoogle()`** (Gemini Developer API). Implemented via the `google-genai` SDK's high-level `client.batches` API (inline requests, no manual JSONL/file-upload needed — a simplification over ellmer's raw-HTTP approach). Vertex AI is intentionally excluded, since its batch API takes GCS bucket URIs instead.
- **`batch_chat()` with `ChatGroq()` is now documented and tested.** It already worked purely via inheritance from the OpenAI-compatible provider (zero Groq-specific code needed) — this was previously undocumented and untested. Note: a live end-to-end smoke test against Groq's real batch API could not be completed in this environment because Groq's API is blocked at the network level here (unrelated to chatlas); the regression test instead asserts the inheritance wiring directly.
- **`ChatOllama()` gains a `reasoning_effort` parameter** to enable extended "thinking" for models that support it (e.g. qwen3, gpt-oss), matching the same `kwargs_chat` pattern used by `ChatGoogle(reasoning=...)`.

## Test plan

- [x] `uv run pytest tests/test_provider_google.py tests/test_provider_ollama.py tests/test_batch_chat.py` — all pass, including a real VCR-recorded Gemini batch submission
- [x] Full suite: `uv run pytest` — 577 passed, 12 skipped
- [x] `uv run pyright` — 0 errors
- [x] `uv run ruff format --check` / `uv run ruff check` — clean
- [x] `make check-vcr-secrets` reviewed manually for the new cassette (tool itself hit a size limit scanning the full cassette corpus, unrelated to this PR)