### PR TITLE
Update ChatGroq() default model to openai/gpt-oss-20b

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Improvements
 
 * `ChatGoogle()` and `ChatVertex()` now default to `gemini-3.5-flash` instead of the older `gemini-2.5-flash`.
+* `ChatGroq()` now defaults to `openai/gpt-oss-20b` instead of `llama-3.1-8b-instant`.
 
 ### Bug fixes
 

--- a/chatlas/_provider_groq.py
+++ b/chatlas/_provider_groq.py
@@ -113,7 +113,7 @@ def ChatGroq(
     ```
     """
     if model is None:
-        model = log_model_default("llama-3.1-8b-instant")
+        model = log_model_default("openai/gpt-oss-20b")
 
     if api_key is None:
         api_key = os.getenv("GROQ_API_KEY")


### PR DESCRIPTION
## Summary
- `ChatGroq()` previously defaulted to `llama-3.1-8b-instant`, an older/smaller model. It now defaults to `openai/gpt-oss-20b`, giving users who don't set `model` explicitly a more capable out-of-the-box experience.

Closes https://github.com/posit-dev/chatlas/issues/322

## Test plan
- [x] `uv run pyright chatlas/_provider_groq.py`
- [x] `uv run pytest tests/test_batch_chat.py -k groq -v`