### PR TITLE
fix(mcp): support mcp 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+* MCP support now requires `mcp>=2.0.0`. The 2.0 release of the `mcp` SDK renamed its model fields (and removed `mcp.server.fastmcp.FastMCP`), so older `mcp` versions are no longer compatible. This only affects users of the optional `mcp` extra (i.e., `register_mcp_tools_*()`).
 * `Turn.finish_reason` is now normalized to a consistent set of values (`"success"`, `"tool_use"`, `"max_tokens"`, `"content_filter"`, `"context_window"`, `"stop_sequence"`) across most providers, so you no longer need provider-specific logic to check why a turn ended. Previously each provider surfaced its own raw string (e.g. Anthropic's `"end_turn"`/`"tool_use"` vs. OpenAI Completions' `"stop"`/`"tool_calls"` vs. Google's `"STOP"`/`"SAFETY"`), so the same outcome could require different checks depending on which `Chat*()` you used. Reasons chatlas doesn't yet recognize still pass through unchanged.
 
 ### Bug fixes

--- a/chatlas/_chat.py
+++ b/chatlas/_chat.py
@@ -1788,7 +1788,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
             for mathematical operations, you might use `math` as the namespace.
         transport_kwargs
             Additional keyword arguments for the transport layer (i.e.,
-            `mcp.client.streamable_http.streamablehttp_client`).
+            `mcp.client.streamable_http.streamable_http_client`).
 
         Returns
         -------
@@ -1813,9 +1813,9 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         MCP server like so:
 
         ```python
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server.mcpserver import MCPServer
 
-        app = FastMCP("my_server")
+        app = MCPServer("my_server")
 
         @app.tool(description="Add two numbers.")
         def add(x: int, y: int) -> int:
@@ -1945,9 +1945,9 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         MCP server like so
 
         ```python
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server.mcpserver import MCPServer
 
-        app = FastMCP("my_server")
+        app = MCPServer("my_server")
 
         @app.tool(description="Add two numbers.")
         def add(y: int, z: int) -> int:

--- a/chatlas/_mcp_manager.py
+++ b/chatlas/_mcp_manager.py
@@ -98,7 +98,7 @@ class HTTPSessionInfo(SessionInfo):
         mcp = try_import_mcp()
         from mcp.client.streamable_http import streamable_http_client
 
-        read, write, _ = await self.exit_stack.enter_async_context(
+        read, write = await self.exit_stack.enter_async_context(
             streamable_http_client(
                 self.url,
                 **self.transport_kwargs,
@@ -110,7 +110,7 @@ class HTTPSessionInfo(SessionInfo):
         server = await session.initialize()
         self.session = session
         if not self.name:
-            self.name = server.serverInfo.name or "mcp"
+            self.name = server.server_info.name or "mcp"
 
 
 @dataclass
@@ -138,7 +138,7 @@ class STDIOSessionInfo(SessionInfo):
         server = await session.initialize()
         self.session = session
         if not self.name:
-            self.name = server.serverInfo.name or "mcp"
+            self.name = server.server_info.name or "mcp"
 
 
 class MCPSessionManager:

--- a/chatlas/_tools.py
+++ b/chatlas/_tools.py
@@ -176,7 +176,7 @@ class Tool:
             # very well defined how to get at the error message, but it appears that it gets
             # stored in the `text` attribute of the content. Also, empirically, the error
             # message seems to include `Error executing tool {tool_name}: ...`, so
-            if result.isError:
+            if result.is_error:
                 err_msg = getattr(
                     result.content[0],
                     "text",
@@ -188,19 +188,19 @@ class Tool:
                 if content.type == "text":
                     yield ContentToolResult(value=content.text)
                 elif content.type == "image":
-                    if content.mimeType not in (
+                    if content.mime_type not in (
                         "image/png",
                         "image/jpeg",
                         "image/webp",
                         "image/gif",
                     ):
                         raise ValueError(
-                            f"Unsupported image MIME type: {content.mimeType}"
+                            f"Unsupported image MIME type: {content.mime_type}"
                         )
 
                     img = ContentImageInline(
                         data=content.data,
-                        image_content_type=content.mimeType,
+                        image_content_type=content.mime_type,
                     )
                     yield ContentToolResult(value=img)
                 elif content.type == "resource":
@@ -212,7 +212,7 @@ class Tool:
                     else:
                         blob = resource.blob.encode("utf-8")
 
-                    mime_type = content.resource.mimeType
+                    mime_type = content.resource.mime_type
                     if mime_type != "application/pdf":
                         raise ValueError(f"Unsupported resource MIME type: {mime_type}")
 
@@ -221,12 +221,16 @@ class Tool:
                 else:
                     raise RuntimeError(f"Unexpected content type: {content.type}")
 
-        params = mcp_tool_input_schema_to_param_schema(mcp_tool.inputSchema)
+        params = mcp_tool_input_schema_to_param_schema(mcp_tool.input_schema)
 
-        # Convert MCP ToolAnnotations to our TypedDict format
+        # Convert MCP ToolAnnotations to our TypedDict format. mcp 2.0 renamed
+        # its fields to snake_case, so dump by alias to keep the camelCase names
+        # that match the MCP wire spec (and chatlas's ToolAnnotations).
         annotations = None
         if mcp_tool.annotations:
-            annotations = cast(ToolAnnotations, mcp_tool.annotations.model_dump())
+            annotations = cast(
+                ToolAnnotations, mcp_tool.annotations.model_dump(by_alias=True)
+            )
 
         return cls(
             func=_utils.wrap_async(_call),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ docs = [
     "numpy",
 ]
 mcp = [
-    "mcp>=1.4.0;python_version>='3.10'"
+    "mcp>=2.0.0;python_version>='3.10'"
 ]
 eval = [
     "inspect-ai;python_version>='3.10'"

--- a/tests/mcp_servers/http_add.py
+++ b/tests/mcp_servers/http_add.py
@@ -1,8 +1,8 @@
 import os
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
-app = FastMCP("test", port=int(os.getenv("MCP_PORT", "8000")))
+app = MCPServer("test")
 
 
 @app.tool(description="Add two numbers.")
@@ -10,4 +10,4 @@ def add(x: int, y: int) -> int:
     return x + y
 
 
-app.run(transport="streamable-http")
+app.run(transport="streamable-http", port=int(os.getenv("MCP_PORT", "8000")))

--- a/tests/mcp_servers/http_current_date.py
+++ b/tests/mcp_servers/http_current_date.py
@@ -1,8 +1,8 @@
 import os
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
-app = FastMCP("test", port=int(os.getenv("MCP_PORT", "8000")))
+app = MCPServer("test")
 
 
 @app.tool(description="Gets the current date")
@@ -13,4 +13,4 @@ async def get_current_date():
     return "2024-01-01"
 
 
-app.run(transport="streamable-http")
+app.run(transport="streamable-http", port=int(os.getenv("MCP_PORT", "8000")))

--- a/tests/mcp_servers/stdio_current_date.py
+++ b/tests/mcp_servers/stdio_current_date.py
@@ -1,8 +1,6 @@
-import os
+from mcp.server.mcpserver import MCPServer
 
-from mcp.server.fastmcp import FastMCP
-
-app = FastMCP("test", port=int(os.getenv("MCP_PORT", "8000")))
+app = MCPServer("test")
 
 
 @app.tool(description="Gets the current date")

--- a/tests/mcp_servers/stdio_subtract_multiply.py
+++ b/tests/mcp_servers/stdio_subtract_multiply.py
@@ -1,8 +1,6 @@
-import os
+from mcp.server.mcpserver import MCPServer
 
-from mcp.server.fastmcp import FastMCP
-
-app = FastMCP("test", port=int(os.getenv("MCP_PORT", "8000")))
+app = MCPServer("test")
 
 
 @app.tool(description="Subtract two numbers.")

--- a/tests/test_tool_from_mcp.py
+++ b/tests/test_tool_from_mcp.py
@@ -7,7 +7,6 @@ import pytest
 from chatlas._content import ContentImageInline, ContentPDF
 from chatlas._tools import Tool
 from chatlas.types import ContentToolResult
-from pydantic.networks import AnyUrl
 
 try:
     import mcp  # noqa: F401
@@ -25,7 +24,7 @@ class TestToolFromMCP:
         tool = MagicMock()
         tool.name = name
         tool.description = description
-        tool.inputSchema = input_schema
+        tool.input_schema = input_schema
         tool.annotations = annotations
         return tool
 
@@ -133,7 +132,7 @@ class TestToolFromMCP:
         # Mock the session call_tool response
         session = self.create_mock_session()
         mock_result = MagicMock()
-        mock_result.isError = False
+        mock_result.is_error = False
 
         mock_content = MagicMock()
         mock_content.type = "text"
@@ -168,12 +167,12 @@ class TestToolFromMCP:
 
         session = self.create_mock_session()
         mock_result = MagicMock()
-        mock_result.isError = False
+        mock_result.is_error = False
 
         mock_content = MagicMock()
         mock_content.type = "image"
         mock_content.data = "base64imagedata"
-        mock_content.mimeType = "image/png"
+        mock_content.mime_type = "image/png"
         mock_result.content = [mock_content]
 
         session.call_tool.return_value = mock_result
@@ -205,7 +204,7 @@ class TestToolFromMCP:
 
         session = self.create_mock_session()
         mock_result = MagicMock()
-        mock_result.isError = False
+        mock_result.is_error = False
 
         mock_content = MagicMock()
         mock_content.type = "resource"
@@ -213,9 +212,9 @@ class TestToolFromMCP:
         # Mock text resource
         mock_resource = TextResourceContents(
             text="File contents here",
-            uri=AnyUrl("file://path/to/file.txt"),
+            uri="file://path/to/file.txt",
+            mime_type="application/pdf",
         )
-        mock_resource.mimeType = "application/pdf"
         mock_content.resource = mock_resource
         mock_result.content = [mock_content]
 
@@ -246,7 +245,7 @@ class TestToolFromMCP:
 
         session = self.create_mock_session()
         mock_result = MagicMock()
-        mock_result.isError = False
+        mock_result.is_error = False
 
         # Multiple content items
         mock_content1 = MagicMock()
@@ -283,7 +282,7 @@ class TestToolFromMCP:
 
         session = self.create_mock_session()
         mock_result = MagicMock()
-        mock_result.isError = True
+        mock_result.is_error = True
 
         mock_content = MagicMock()
         mock_content.text = "Error executing tool error_tool: Something went wrong"
@@ -310,7 +309,7 @@ class TestToolFromMCP:
 
         session = self.create_mock_session()
         mock_result = MagicMock()
-        mock_result.isError = True
+        mock_result.is_error = True
 
         mock_content = MagicMock()
         # No text attribute
@@ -336,12 +335,12 @@ class TestToolFromMCP:
 
         session = self.create_mock_session()
         mock_result = MagicMock()
-        mock_result.isError = False
+        mock_result.is_error = False
 
         mock_content = MagicMock()
         mock_content.type = "image"
         mock_content.data = "imagedata"
-        mock_content.mimeType = "image/unsupported"
+        mock_content.mime_type = "image/unsupported"
         mock_result.content = [mock_content]
 
         session.call_tool.return_value = mock_result
@@ -365,7 +364,7 @@ class TestToolFromMCP:
 
         session = self.create_mock_session()
         mock_result = MagicMock()
-        mock_result.isError = False
+        mock_result.is_error = False
 
         mock_content = MagicMock()
         mock_content.type = "unknown_type"


### PR DESCRIPTION
## Why this matters

The `mcp` SDK just released **2.0.0**, a breaking major version. Because chatlas doesn't pin `mcp`, CI (and any fresh install) now resolves 2.0.0, and the MCP integration breaks: tool registration fails, and the MCP test suite goes red. This is already failing on `main`'s next run, not just one branch.

This PR migrates chatlas's MCP support to the 2.0 API so `register_mcp_tools_*()` works again.

## What changed for users

- MCP support now requires **`mcp>=2.0.0`**. This only affects users of the optional `mcp` extra; everything else is unchanged.

## What broke in mcp 2.0 (for reviewers)

The 2.0 SDK:

- Renamed model fields to snake_case: `inputSchema` → `input_schema`, `mimeType` → `mime_type`, `isError` → `is_error`, `serverInfo` → `server_info` (camelCase is kept only as a serialization alias).
- Made `TextResourceContents.uri` a plain `str` (was `AnyUrl`).
- Removed `mcp.server.fastmcp.FastMCP` (the high-level server is now `mcp.server.mcpserver.MCPServer`).
- Changed `streamable_http_client` to yield 2 values `(read, write)` instead of 3.

The fixes mirror those changes in `_tools.py` and `_mcp_manager.py`, dump `ToolAnnotations` with `by_alias=True` so chatlas keeps emitting the camelCase wire names its public `ToolAnnotations` type documents, and rewrite the four test servers onto `MCPServer`.

## Verification

Full suite passes locally against mcp 2.0.0: **604 passed, 12 skipped**. Type and format checks pass.
