### PR TITLE
Replay built-in tool content only to the provider that produced it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug fixes
 
 * `ChatGoogle()` no longer errors when mixing custom tools and built-in tools (e.g. `tool_web_search()`) on Gemini 3+ models.
+* Turns containing web search/fetch content can now be passed to a different provider (e.g. `ChatAnthropic().set_turns(openai_chat.get_turns())`). Previously this raised `ValueError: Unsupported content type` on `ChatOpenAI()`, and `ChatAnthropic()` forwarded the other provider's raw payload as if it were its own, producing an invalid request. Each provider now replays only the built-in tool content it produced and drops the rest.
+* `ChatOpenAI()` web search `open_page` actions now surface as `ContentToolRequestFetch` (with the URL) rather than a `ContentToolRequestSearch` whose "query" was the URL, so renderers no longer show "searched for: https://…". Relatedly, a `search` action that reports only the plural `queries` field no longer falls through to the literal string `"web search"`.
 
 ## [0.19.2] - 2026-07-08
 

--- a/chatlas/_content.py
+++ b/chatlas/_content.py
@@ -863,7 +863,7 @@ ProviderAnnotation = Union[
 ]
 """
 Content a provider reports about its own server-side work, rather than content
-the user authored. All of it carries a raw provider payload in `extra`.
+the user authored. When produced by a provider, this content may carry a raw provider payload in `extra`.
 
 Because `extra` is in the producing provider's own shape, only that provider can
 resend one. Providers replay their own and drop the rest, so turns stay portable

--- a/chatlas/_content.py
+++ b/chatlas/_content.py
@@ -855,6 +855,30 @@ ContentUnion = Union[
 ]
 
 
+ProviderAnnotation = Union[
+    ContentToolRequestSearch,
+    ContentToolResponseSearch,
+    ContentToolRequestFetch,
+    ContentToolResponseFetch,
+]
+"""
+Content a provider reports about its own server-side work, rather than content
+the user authored. All of it carries a raw provider payload in `extra`.
+
+Because `extra` is in the producing provider's own shape, only that provider can
+resend one. Providers replay their own and drop the rest, so turns stay portable
+across providers.
+"""
+
+PROVIDER_ANNOTATION_TYPES = (
+    ContentToolRequestSearch,
+    ContentToolResponseSearch,
+    ContentToolRequestFetch,
+    ContentToolResponseFetch,
+)
+"""Runtime `isinstance` form of `ProviderAnnotation` (keep the two in sync)."""
+
+
 BYTES_SENTINEL = "__base64_bytes__"
 
 

--- a/chatlas/_provider_anthropic.py
+++ b/chatlas/_provider_anthropic.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel
 
 from ._chat import Chat
 from ._content import (
+    PROVIDER_ANNOTATION_TYPES,
     Content,
     ContentImageInline,
     ContentImageRemote,
@@ -33,6 +34,7 @@ from ._content import (
     ContentToolResponseFetch,
     ContentToolResponseSearch,
     ContentToolResult,
+    ProviderAnnotation,
 )
 from ._logging import log_model_default
 from ._provider import (
@@ -705,7 +707,12 @@ class AnthropicProvider(
             if not isinstance(turn, (UserTurn, AssistantTurn)):
                 raise ValueError(f"Unknown role {turn.role}")
 
-            content = [self._as_content_block(c) for c in turn.contents]
+            content = [
+                self._as_content_block(c)
+                for c in turn.contents
+                if not isinstance(c, PROVIDER_ANNOTATION_TYPES)
+                or anthropic_replayable(c)
+            ]
 
             # Drop empty assistant turns to avoid an API error
             # (all messages must have non-empty content)
@@ -1343,3 +1350,24 @@ class AnthropicBedrockProvider(AnthropicProvider):
             res.append(info)
 
         return res
+
+
+ANTHROPIC_SERVER_TOOL_BLOCK_TYPES = frozenset(
+    {"server_tool_use", "web_search_tool_result", "web_fetch_tool_result"}
+)
+
+
+def anthropic_replayable(content: ProviderAnnotation) -> bool:
+    """Whether `content.extra` holds an Anthropic block param we can resend.
+
+    Anthropic wants its server-side tool blocks back in the conversation history
+    (citations reference the search results they came from), so we replay the raw
+    block stashed in `extra`. Content produced by another provider carries that
+    provider's payload instead, which we can't translate -- drop it rather than
+    send something the API will reject.
+    """
+    extra = content.extra
+    return (
+        isinstance(extra, dict)
+        and extra.get("type") in ANTHROPIC_SERVER_TOOL_BLOCK_TYPES
+    )

--- a/chatlas/_provider_google.py
+++ b/chatlas/_provider_google.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel
 
 from ._chat import Chat
 from ._content import (
+    PROVIDER_ANNOTATION_TYPES,
     Content,
     ContentImageInline,
     ContentImageRemote,
@@ -559,7 +560,14 @@ class GoogleProvider(
                 parts = [self._as_part_type(c) for c in turn.contents]
                 contents.append(GoogleContent(role=turn.role, parts=parts))
             elif isinstance(turn, AssistantTurn):
-                parts = [self._as_part_type(c) for c in turn.contents]
+                # Google's grounding/url-context metadata has no corresponding
+                # Part to send back, so none of it is replayable here.
+                sendable = [
+                    c
+                    for c in turn.contents
+                    if not isinstance(c, PROVIDER_ANNOTATION_TYPES)
+                ]
+                parts = [self._as_part_type(c) for c in sendable]
                 contents.append(GoogleContent(role="model", parts=parts))
             else:
                 raise ValueError(f"Unknown role {turn.role}")

--- a/chatlas/_provider_openai.py
+++ b/chatlas/_provider_openai.py
@@ -7,10 +7,16 @@ from urllib.parse import urlparse
 
 import orjson
 from openai.types.responses import Response, ResponseStreamEvent
+from openai.types.responses.response_function_web_search import (
+    ActionFind,
+    ActionOpenPage,
+    ResponseFunctionWebSearch,
+)
 from pydantic import BaseModel
 
 from ._chat import Chat
 from ._content import (
+    PROVIDER_ANNOTATION_TYPES,
     Content,
     ContentImageInline,
     ContentImageRemote,
@@ -20,8 +26,10 @@ from ._content import (
     ContentThinking,
     ContentThinkingDelta,
     ContentToolRequest,
+    ContentToolRequestFetch,
     ContentToolRequestSearch,
     ContentToolResult,
+    ProviderAnnotation,
 )
 from ._logging import log_model_default
 from ._provider import StandardModelParamNames, StandardModelParams
@@ -447,23 +455,7 @@ class OpenAIProvider(
                     )
 
             elif output.type == "web_search_call":
-                # https://platform.openai.com/docs/guides/tools-web-search#output-and-citations
-                # Not all action types have a query field (e.g., open_page, find_in_page)
-                action = output.action
-                query = getattr(action, "query", None) or None
-                if not query:
-                    queries = getattr(action, "queries", None) or []
-                    query = queries[0] if queries else None
-                if not query:
-                    query = getattr(action, "pattern", None) or None
-                if not query:
-                    query = getattr(action, "url", None) or "web search"
-                contents.append(
-                    ContentToolRequestSearch(
-                        query=query,
-                        extra=output.model_dump(),
-                    )
-                )
+                contents.append(openai_web_search_request(output))
 
             else:
                 raise ValueError(f"Unknown output type: {output.type}")
@@ -487,7 +479,12 @@ class OpenAIProvider(
     def _turns_as_inputs(self, turns: list[Turn]) -> "list[ResponseInputItemParam]":
         res: "list[ResponseInputItemParam]" = []
         for turn in turns:
-            res.extend([as_input_param(x, turn.role) for x in turn.contents])
+            for x in turn.contents:
+                if isinstance(x, PROVIDER_ANNOTATION_TYPES) and not openai_replayable(
+                    x
+                ):
+                    continue
+                res.append(as_input_param(x, turn.role))
         return res
 
     def translate_model_params(self, params: StandardModelParams) -> "SubmitInputArgs":
@@ -523,6 +520,46 @@ class OpenAIProvider(
     @staticmethod
     def _batch_endpoint():
         return "/v1/responses"
+
+
+def openai_web_search_request(
+    item: "ResponseFunctionWebSearch",
+) -> ContentToolRequestSearch | ContentToolRequestFetch:
+    """Map a `web_search_call` item onto request content.
+
+    https://platform.openai.com/docs/guides/tools-web-search#output-and-citations
+
+    The action is a closed union of three verbs, and they aren't all searches:
+    `open_page` fetches a URL, and `find_in_page` matches a pattern within an
+    already-open page.
+    """
+    action = item.action
+    extra = item.model_dump()
+    if isinstance(action, ActionOpenPage):
+        return ContentToolRequestFetch(url=action.url or "", extra=extra)
+    if isinstance(action, ActionFind):
+        return ContentToolRequestSearch(query=action.pattern, extra=extra)
+    queries = action.queries or []
+    return ContentToolRequestSearch(
+        query=action.query or (queries[0] if queries else "web search"),
+        extra=extra,
+    )
+
+
+def openai_replayable(content: ProviderAnnotation) -> bool:
+    """Whether `content.extra` holds a Responses API item we can resend.
+
+    Only the `web_search_call` item round-trips; the rest of what a web search
+    produces (results, citations) is reported client-side with no item to send
+    back. Content from another provider carries that provider's payload, which
+    the Responses API would reject.
+    """
+    extra = content.extra
+    return (
+        isinstance(content, (ContentToolRequestSearch, ContentToolRequestFetch))
+        and isinstance(extra, dict)
+        and extra.get("type") == "web_search_call"
+    )
 
 
 def as_input_param(content: Content, role: Role) -> "ResponseInputItemParam":
@@ -596,7 +633,8 @@ def as_input_param(content: Content, role: Role) -> "ResponseInputItemParam":
             "name": content.name,
             "arguments": orjson.dumps(content.arguments).decode("utf-8"),
         }
-    elif isinstance(content, ContentToolRequestSearch):
+    elif isinstance(content, (ContentToolRequestSearch, ContentToolRequestFetch)):
+        # The raw `web_search_call` item, replayed verbatim (see openai_replayable)
         return cast("ResponseInputItemParam", content.extra)
     else:
         raise ValueError(f"Unsupported content type: {type(content)}")

--- a/tests/test_cross_provider_turns.py
+++ b/tests/test_cross_provider_turns.py
@@ -1,0 +1,192 @@
+"""Turns from one provider must be sendable to another.
+
+Built-in tool content (web search / fetch) is a provider-native annotation: the
+provider that produced it stashes its own raw payload in `extra` and replays it
+verbatim on the next request. That payload is meaningless to a different
+provider, so each provider replays only what it produced and drops the rest --
+otherwise `Chat.set_turns()` across providers (documented in
+docs/reference/Turn.qmd) raises, or silently sends an invalid payload.
+"""
+
+import pytest
+from chatlas._provider_anthropic import AnthropicProvider
+from chatlas._provider_google import GoogleProvider
+from chatlas._provider_openai import OpenAIProvider
+from chatlas._turn import AssistantTurn, Turn, UserTurn
+from chatlas.types import (
+    ContentText,
+    ContentToolRequestFetch,
+    ContentToolRequestSearch,
+    ContentToolResponseFetch,
+    ContentToolResponseSearch,
+)
+
+
+def google_grounded_turns() -> list[Turn]:
+    return [
+        UserTurn("When was ggplot2 1.0.0 released?"),
+        AssistantTurn(
+            [
+                ContentToolRequestSearch(
+                    query="ggplot2 1.0.0", extra={"web_search_queries": ["ggplot2"]}
+                ),
+                ContentToolResponseSearch(
+                    urls=["https://a.com"], extra={"grounding_metadata": {}}
+                ),
+                ContentText(text="2014-05-21"),
+                ContentToolRequestFetch(
+                    url="https://a.com", extra={"url_metadata": {}}
+                ),
+                ContentToolResponseFetch(
+                    url="https://a.com", extra={"url_metadata": {}}
+                ),
+            ]
+        ),
+    ]
+
+
+def openai_grounded_turns() -> list[Turn]:
+    return [
+        UserTurn("When was ggplot2 1.0.0 released?"),
+        AssistantTurn(
+            [
+                ContentToolRequestSearch(
+                    query="ggplot2 1.0.0",
+                    extra={
+                        "type": "web_search_call",
+                        "id": "ws_1",
+                        "status": "completed",
+                    },
+                ),
+                ContentText(text="2014-05-21"),
+            ]
+        ),
+    ]
+
+
+def anthropic_grounded_turns() -> list[Turn]:
+    return [
+        UserTurn("When was ggplot2 1.0.0 released?"),
+        AssistantTurn(
+            [
+                ContentToolRequestSearch(
+                    query="ggplot2 1.0.0",
+                    extra={
+                        "type": "server_tool_use",
+                        "id": "srvtoolu_1",
+                        "name": "web_search",
+                        "input": {"query": "ggplot2 1.0.0"},
+                    },
+                ),
+                ContentToolResponseSearch(
+                    urls=["https://a.com"],
+                    extra={
+                        "type": "web_search_tool_result",
+                        "tool_use_id": "srvtoolu_1",
+                        "content": [],
+                    },
+                ),
+                ContentText(text="2014-05-21"),
+            ]
+        ),
+    ]
+
+
+def anthropic_provider():
+    return AnthropicProvider(model="claude-sonnet-4-5", api_key="dummy", kwargs=None)
+
+
+def google_provider():
+    return GoogleProvider(
+        model="gemini-2.5-flash", api_key="dummy", name="Google/Gemini", kwargs=None
+    )
+
+
+def openai_provider():
+    return OpenAIProvider(model="gpt-4o", api_key="dummy", kwargs=None)
+
+
+ALL_TURNS = {
+    "google": google_grounded_turns,
+    "openai": openai_grounded_turns,
+    "anthropic": anthropic_grounded_turns,
+}
+
+
+@pytest.mark.parametrize("source_provider", sorted(ALL_TURNS))
+def test_anthropic_accepts_turns_from_any_provider(source_provider: str):
+    turns = ALL_TURNS[source_provider]()
+    messages = anthropic_provider()._as_message_params(turns)
+
+    blocks = [b for m in messages for b in m["content"]]
+    assert any(b["type"] == "text" for b in blocks)
+    # Anthropic block params always carry a "type"; a foreign payload wouldn't.
+    assert all("type" in b for b in blocks)
+    native = [
+        b for b in blocks if b["type"] in ("server_tool_use", "web_search_tool_result")
+    ]
+    assert bool(native) == (source_provider == "anthropic")
+
+
+@pytest.mark.parametrize("source_provider", sorted(ALL_TURNS))
+def test_openai_accepts_turns_from_any_provider(source_provider: str):
+    turns = ALL_TURNS[source_provider]()
+    inputs = openai_provider()._turns_as_inputs(turns)
+
+    native = [x for x in inputs if x.get("type") == "web_search_call"]
+    assert bool(native) == (source_provider == "openai")
+
+
+@pytest.mark.parametrize("source_provider", sorted(ALL_TURNS))
+def test_google_accepts_turns_from_any_provider(source_provider: str):
+    turns = ALL_TURNS[source_provider]()
+    contents = google_provider()._google_contents(turns)
+
+    parts = [p for c in contents for p in (c.parts or [])]
+    assert any(p.text for p in parts)
+
+
+def test_anthropic_replays_its_own_search_payload_verbatim():
+    """Same-provider replay keeps server-side search context in history."""
+    turns = anthropic_grounded_turns()
+    messages = anthropic_provider()._as_message_params(turns)
+
+    blocks = [b for m in messages for b in m["content"]]
+    server_use = next(b for b in blocks if b["type"] == "server_tool_use")
+    assert server_use["id"] == "srvtoolu_1"
+    assert server_use["name"] == "web_search"
+    result = next(b for b in blocks if b["type"] == "web_search_tool_result")
+    assert result["tool_use_id"] == "srvtoolu_1"
+
+
+def test_openai_replays_its_own_search_payload_verbatim():
+    turns = openai_grounded_turns()
+    inputs = openai_provider()._turns_as_inputs(turns)
+
+    call = next(x for x in inputs if x.get("type") == "web_search_call")
+    assert call["id"] == "ws_1"
+
+
+def test_providers_drop_annotations_with_no_payload():
+    """Content whose `extra` was never populated can't be replayed anywhere."""
+    turns: list[Turn] = [
+        UserTurn("hi"),
+        AssistantTurn(
+            [
+                ContentToolRequestSearch(query="q"),
+                ContentToolResponseSearch(urls=["https://a.com"]),
+                ContentText(text="answer"),
+                ContentToolRequestFetch(url="https://a.com"),
+                ContentToolResponseFetch(url="https://a.com"),
+            ]
+        ),
+    ]
+
+    messages = anthropic_provider()._as_message_params(turns)
+    blocks = [b for m in messages for b in m["content"]]
+    assert all("type" in b for b in blocks)
+
+    inputs = openai_provider()._turns_as_inputs(turns)
+    assert all(x for x in inputs)
+
+    google_provider()._google_contents(turns)

--- a/tests/test_provider_openai.py
+++ b/tests/test_provider_openai.py
@@ -225,7 +225,7 @@ def test_can_extract_custom_id_from_malformed_json():
 
 def test_openai_web_search_call_action_types():
     """Handle non-search web_search_call action types (open_page, find_in_page)."""
-    from chatlas._content import ContentToolRequestSearch
+    from chatlas._content import ContentToolRequestFetch, ContentToolRequestSearch
     from chatlas._provider_openai import OpenAIProvider
 
     chat = ChatOpenAI()
@@ -262,13 +262,19 @@ def test_openai_web_search_call_action_types():
     assert isinstance(turn.contents[0], ContentToolRequestSearch)
     assert turn.contents[0].query == "test query"
 
-    # open_page action with url
-    resp = make_response({"type": "open_page", "url": "https://example.com"})
+    # search action with only the plural `queries`
+    resp = make_response({"type": "search", "queries": ["first", "second"]})
     turn = provider._response_as_turn(resp, has_data_model=False)
     assert isinstance(turn.contents[0], ContentToolRequestSearch)
-    assert turn.contents[0].query == "https://example.com"
+    assert turn.contents[0].query == "first"
 
-    # find_in_page action with pattern
+    # open_page is a fetch, not a search
+    resp = make_response({"type": "open_page", "url": "https://example.com"})
+    turn = provider._response_as_turn(resp, has_data_model=False)
+    assert isinstance(turn.contents[0], ContentToolRequestFetch)
+    assert turn.contents[0].url == "https://example.com"
+
+    # find_in_page action carries an in-page pattern, not a query
     resp = make_response(
         {"type": "find_in_page", "pattern": "find this", "url": "https://example.com"}
     )


### PR DESCRIPTION
Today you can't hand a conversation that used web search to a different provider. This works for plain text but breaks the moment a turn contains built-in tool content:

```python
openai_chat = ChatOpenAI(model="gpt-4.1")
openai_chat.register_tool(tool_web_search())
openai_chat.chat("When was ggplot2 1.0.0 released?")

ChatAnthropic().set_turns(openai_chat.get_turns())   # sends an invalid request
ChatOpenAI().set_turns(anthropic_chat.get_turns())   # ValueError: Unsupported content type
```

Search and fetch content stashes the *producing* provider's raw payload in `extra`, because that's what has to be replayed verbatim on the next request. Nothing enforced that, so Anthropic forwarded any provider's payload as if it were its own, and OpenAI raised outright on search/fetch results. Both are pre-existing `main` bugs; `docs/reference/Turn.qmd` documents cross-provider `set_turns()` as supported.

Each provider now replays only what it produced and drops the rest — Anthropic still round-trips its own server-tool blocks (its citations reference the search results they came from), OpenAI still round-trips its `web_search_call` item, and Google replays none since grounding metadata has no corresponding `Part`. Turns stay portable in all nine source/target combinations.

Second fix, same area: `ChatOpenAI()` mapped every `web_search_call` action onto a search request via a `getattr` chain, so an `open_page` action surfaced as a "search" whose query was a URL — renderers showed *searched for: https://…*. `open_page` is now a `ContentToolRequestFetch`, and a `search` action reporting only the plural `queries` field no longer falls through to the literal string `"web search"`.

## Implementation notes

`ProviderAnnotation` / `PROVIDER_ANNOTATION_TYPES` in `_content.py` names the category of content that carries a provider-native payload, and `anthropic_replayable()` / `openai_replayable()` decide what survives the trip back. The action mapping switched from `getattr` probing to `isinstance` narrowing over the SDK's closed 3-member action union, which is what makes the `open_page` distinction fall out rather than needing a special case.

Note that filtering the shared tuple everywhere would be wrong: Anthropic and OpenAI deliberately round-trip their own payloads, and dropping those loses server-side search context from history.

`tests/test_cross_provider_turns.py` covers all nine provider combinations plus same-provider verbatim replay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)