### PR TITLE
feat!: let a provider emit several contents per chunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `ChatGoogle()` no longer errors when mixing custom tools and built-in tools (e.g. `tool_web_search()`) on Gemini 3+ models.
 
+### Breaking changes
+
+* The `Provider` abstract base class changed shape, which affects third-party `Provider` subclasses (not users of the built-in `Chat*()` functions): `stream_text()` was removed, and `stream_content()` both returns a `Sequence[Content]` (subsuming what `stream_text()` did) and takes a second `completion` argument holding the merged-so-far completion. Implementations needing state across chunks should read it from `completion` rather than storing it on `self`, since one provider instance is shared across forked chats.
+
 ## [0.19.2] - 2026-07-08
 
 ### New features

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,7 +220,7 @@ When implementing a new LLM provider, follow this systematic approach:
 
 **Custom API Providers**:
 - Inherit from `Provider` directly
-- Implement all abstract methods: `chat_perform()`, `chat_perform_async()`, `stream_text()`, etc.
+- Implement all abstract methods: `chat_perform()`, `chat_perform_async()`, `stream_content()`, `stream_merge_chunks()`, etc.
 - Handle model-specific response formats
 
 ### 6. Common Patterns

--- a/chatlas/_chat.py
+++ b/chatlas/_chat.py
@@ -34,6 +34,7 @@ from ._content import (
     Content,
     ContentJson,
     ContentText,
+    ContentThinking,
     ContentThinkingDelta,
     ContentToolRequest,
     ContentToolResult,
@@ -101,6 +102,14 @@ BaseModelT = TypeVar("BaseModelT", bound=BaseModel)
 
 def is_present(value: T | None | MISSING_TYPE) -> TypeGuard[T]:
     return value is not None and not isinstance(value, MISSING_TYPE)
+
+
+def display_text(content: "Content") -> "Optional[str]":
+    if isinstance(content, ContentText):
+        return content.text
+    if isinstance(content, (ContentThinking, ContentThinkingDelta)):
+        return content.thinking
+    return None
 
 
 class Chat(Generic[SubmitInputArgsT, CompletionT]):
@@ -2809,13 +2818,11 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
                             break
                         if controller.cancelled:
                             break
-                        content = self.provider.stream_content(chunk)
-                        if content is not None:
-                            text = self.provider.stream_text(chunk)
-                            yield from acc.process_content(
-                                content, text, content_mode, emit
-                            )
                         result = self.provider.stream_merge_chunks(result, chunk)
+                        for content in self.provider.stream_content(chunk, result):
+                            yield from acc.process_content(
+                                content, display_text(content), content_mode, emit
+                            )
 
                     yield from acc.flush_thinking(content_mode, emit)
 
@@ -2947,14 +2954,12 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
                             break
                         if controller.cancelled:
                             break
-                        content = self.provider.stream_content(chunk)
-                        if content is not None:
-                            text = self.provider.stream_text(chunk)
+                        result = self.provider.stream_merge_chunks(result, chunk)
+                        for content in self.provider.stream_content(chunk, result):
                             for item in acc.process_content(
-                                content, text, content_mode, emit
+                                content, display_text(content), content_mode, emit
                             ):
                                 yield item
-                        result = self.provider.stream_merge_chunks(result, chunk)
 
                     for item in acc.flush_thinking(content_mode, emit):
                         yield item

--- a/chatlas/_provider.py
+++ b/chatlas/_provider.py
@@ -9,13 +9,14 @@ from typing import (
     Iterable,
     Literal,
     Optional,
+    Sequence,
     TypeVar,
     overload,
 )
 
 from pydantic import BaseModel
 
-from ._content import Content, ContentText, ContentThinking
+from ._content import Content
 from ._tools import Tool, ToolBuiltIn
 from ._turn import AssistantTurn, Turn
 from ._typing_extensions import NotRequired, TypedDict
@@ -230,17 +231,22 @@ class Provider(
     ) -> AsyncIterable[ChatCompletionChunkT] | ChatCompletionT: ...
 
     @abstractmethod
-    def stream_content(self, chunk: ChatCompletionChunkT) -> Optional["Content"]: ...
+    def stream_content(
+        self,
+        chunk: ChatCompletionChunkT,
+        completion: Optional[ChatCompletionDictT],
+    ) -> "Sequence[Content]":
+        """
+        Content to yield for `chunk`.
 
-    def stream_text(self, chunk: ChatCompletionChunkT) -> Optional[str]:
-        content = self.stream_content(chunk)
-        if content is None:
-            return None
-        if isinstance(content, ContentThinking):
-            return content.thinking
-        if isinstance(content, ContentText):
-            return content.text
-        return str(content)
+        `completion` is the result of merging every chunk up to and including
+        `chunk` (i.e. `stream_merge_chunks` runs first). Providers needing
+        cross-chunk state read it from there rather than storing it on `self`: a
+        single provider instance is shared across forked chats
+        (`Chat.__deepcopy__` keeps `provider` by reference), so several streams
+        can be in flight at once.
+        """
+        ...
 
     @abstractmethod
     def stream_merge_chunks(

--- a/chatlas/_provider_anthropic.py
+++ b/chatlas/_provider_anthropic.py
@@ -539,13 +539,13 @@ class AnthropicProvider(
 
         return data_model_tool
 
-    def stream_content(self, chunk) -> Optional[Content]:
+    def stream_content(self, chunk, completion) -> list[Content]:
         if chunk.type == "content_block_delta":
             if chunk.delta.type == "text_delta":
-                return ContentText.model_construct(text=chunk.delta.text)
+                return [ContentText.model_construct(text=chunk.delta.text)]
             if chunk.delta.type == "thinking_delta":
-                return ContentThinkingDelta(thinking=chunk.delta.thinking)
-        return None
+                return [ContentThinkingDelta(thinking=chunk.delta.thinking)]
+        return []
 
     def stream_merge_chunks(self, completion, chunk):
         if chunk.type == "message_start":

--- a/chatlas/_provider_google.py
+++ b/chatlas/_provider_google.py
@@ -443,23 +443,23 @@ class GoogleProvider(
 
         return kwargs_full
 
-    def stream_content(self, chunk) -> Optional[Content]:
+    def stream_content(self, chunk, completion) -> list[Content]:
         candidates = getattr(chunk, "candidates", None)
         if not candidates:
-            return None
+            return []
         content = candidates[0].content
         if content is None:
-            return None
+            return []
         parts = content.parts
         if not parts:
-            return None
+            return []
         part = parts[0]
         text = getattr(part, "text", None)
         if text is None:
-            return None
+            return []
         if getattr(part, "thought", None):
-            return ContentThinkingDelta(thinking=text)
-        return ContentText.model_construct(text=text)
+            return [ContentThinkingDelta(thinking=text)]
+        return [ContentText.model_construct(text=text)]
 
     def stream_merge_chunks(self, completion, chunk):
         chunkd = chunk.model_dump()

--- a/chatlas/_provider_openai.py
+++ b/chatlas/_provider_openai.py
@@ -319,18 +319,14 @@ class OpenAIProvider(
 
         return kwargs_full
 
-    def stream_content(self, chunk) -> Optional[Content]:
+    def stream_content(self, chunk, completion) -> list[Content]:
         if chunk.type == "response.output_text.delta":
             # https://platform.openai.com/docs/api-reference/responses-streaming/response/output_text/delta
-            return ContentText.model_construct(text=chunk.delta)
+            return [ContentText.model_construct(text=chunk.delta)]
         if chunk.type == "response.reasoning_summary_text.delta":
             # https://platform.openai.com/docs/api-reference/responses-streaming/response/reasoning_summary_text/delta
-            return ContentThinkingDelta(thinking=chunk.delta)
-        if chunk.type == "response.reasoning_summary_text.done":
-            # The thinking→text transition in _submit_turns already emits
-            # "\n</thinking>\n\n" which provides the visual separator.
-            return None
-        return None
+            return [ContentThinkingDelta(thinking=chunk.delta)]
+        return []
 
     def stream_merge_chunks(self, completion, chunk):
         if chunk.type == "response.completed" or chunk.type == "response.incomplete":

--- a/chatlas/_provider_openai_completions.py
+++ b/chatlas/_provider_openai_completions.py
@@ -236,9 +236,9 @@ class OpenAICompletionsProvider(
 
         return kwargs_full
 
-    def stream_content(self, chunk) -> Optional[Content]:
+    def stream_content(self, chunk, completion) -> list[Content]:
         if not chunk.choices:
-            return None
+            return []
         delta = chunk.choices[0].delta
 
         # Some OpenAI-compatible providers (e.g. Ollama with qwen3) return
@@ -247,12 +247,12 @@ class OpenAICompletionsProvider(
             delta, "reasoning_content", None
         )
         if reasoning is not None:
-            return ContentThinkingDelta(thinking=reasoning)
+            return [ContentThinkingDelta(thinking=reasoning)]
 
         text = delta.content
         if text is None:
-            return None
-        return ContentText.model_construct(text=text)
+            return []
+        return [ContentText.model_construct(text=text)]
 
     def stream_merge_chunks(self, completion, chunk):
         chunkd = chunk.model_dump()

--- a/chatlas/_provider_snowflake.py
+++ b/chatlas/_provider_snowflake.py
@@ -356,13 +356,13 @@ class SnowflakeProvider(
 
         return req
 
-    def stream_content(self, chunk) -> Optional[Content]:
+    def stream_content(self, chunk, completion) -> list[Content]:
         if not chunk.choices:
-            return None
+            return []
         delta = chunk.choices[0].delta
         if delta is None or "content" not in delta:
-            return None
-        return ContentText.model_construct(text=delta["content"])
+            return []
+        return [ContentText.model_construct(text=delta["content"])]
 
     # Snowflake sort-of follows OpenAI/Anthropic streaming formats except they
     # don't have the critical "index" field in the delta that the merge logic

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -415,8 +415,7 @@ def test_stream_iteration_provider_span_nests_under_chat_span(
         return gen()
 
     chat.provider.chat_perform = streaming_perform  # type: ignore[method-assign]
-    chat.provider.stream_content = lambda chunk: ContentText(text="hi")  # type: ignore[method-assign]
-    chat.provider.stream_text = lambda chunk: "hi"  # type: ignore[method-assign]
+    chat.provider.stream_content = lambda chunk, completion: [ContentText(text="hi")]  # type: ignore[method-assign]
     chat.provider.stream_merge_chunks = (  # type: ignore[method-assign]
         lambda result, chunk: chunk
     )
@@ -449,8 +448,7 @@ async def test_async_stream_iteration_provider_span_nests_under_chat_span(
         return gen()
 
     chat.provider.chat_perform_async = streaming_perform_async  # type: ignore[method-assign]
-    chat.provider.stream_content = lambda chunk: ContentText(text="hi")  # type: ignore[method-assign]
-    chat.provider.stream_text = lambda chunk: "hi"  # type: ignore[method-assign]
+    chat.provider.stream_content = lambda chunk, completion: [ContentText(text="hi")]  # type: ignore[method-assign]
     chat.provider.stream_merge_chunks = (  # type: ignore[method-assign]
         lambda result, chunk: chunk
     )

--- a/tests/test_provider_openai_completions.py
+++ b/tests/test_provider_openai_completions.py
@@ -155,14 +155,12 @@ def test_stream_content_extracts_reasoning_content():
             self.choices = choices
 
     chunk = FakeChunk([FakeChoice(FakeDelta(reasoning_content="think"))])
-    result = provider.stream_content(chunk)
-    assert isinstance(result, ContentThinkingDelta)
-    assert result.thinking == "think"
+    result = provider.stream_content(chunk, None)
+    assert result == [ContentThinkingDelta(thinking="think")]
 
     chunk = FakeChunk([FakeChoice(FakeDelta(content="hello"))])
-    result = provider.stream_content(chunk)
-    assert isinstance(result, ContentText)
-    assert result.text == "hello"
+    result = provider.stream_content(chunk, None)
+    assert result == [ContentText(text="hello")]
 
 
 def test_response_as_turn_extracts_reasoning_content():
@@ -203,9 +201,8 @@ def test_stream_content_extracts_reasoning_field():
             self.choices = choices
 
     chunk = FakeChunk([FakeChoice(FakeDelta(reasoning="think"))])
-    result = provider.stream_content(chunk)
-    assert isinstance(result, ContentThinkingDelta)
-    assert result.thinking == "think"
+    result = provider.stream_content(chunk, None)
+    assert result == [ContentThinkingDelta(thinking="think")]
 
 
 def test_response_as_turn_extracts_reasoning_field():

--- a/tests/test_provider_stream_contract.py
+++ b/tests/test_provider_stream_contract.py
@@ -1,0 +1,158 @@
+"""The `Provider` streaming contract.
+
+`stream_content()` gets the merged-so-far `completion` precisely so a provider
+never has to keep per-stream state on `self`: `Chat.__deepcopy__` shares one
+provider instance across forked chats, and those forks stream concurrently.
+"""
+
+from typing import Optional
+
+import pytest
+from chatlas import Chat
+from chatlas._content import (
+    Content,
+    ContentText,
+    ContentThinkingDelta,
+    ContentToolRequestSearch,
+)
+from chatlas._provider import Provider
+from chatlas._turn import AssistantTurn
+
+
+class Chunk:
+    def __init__(self, text: str = "", emit_request: bool = False):
+        self.text = text
+        self.emit_request = emit_request
+
+
+class AccumulatingProvider(Provider):
+    """Derives its output from `completion` rather than from `self`.
+
+    `stream_merge_chunks` accumulates each chunk's text onto the completion, and
+    `stream_content` reads that accumulation back out. Any provider that needs
+    cross-chunk context (Anthropic's citations, say) has this shape.
+    """
+
+    def __init__(self, chunks: list[Chunk]):
+        super().__init__(name="fake", model="fake-model")
+        self._chunks = chunks
+        self.seen_completions: list[Optional[dict]] = []
+
+    def stream_merge_chunks(self, completion, chunk) -> dict:
+        merged = dict(completion or {"text": ""})
+        merged["text"] += chunk.text
+        return merged
+
+    def stream_content(self, chunk, completion) -> list[Content]:
+        self.seen_completions.append(completion)
+        out: list[Content] = []
+        if chunk.text:
+            out.append(ContentText.model_construct(text=chunk.text))
+        if chunk.emit_request:
+            # Only correct if `completion` is this stream's accumulation
+            out.append(ContentToolRequestSearch(query=(completion or {})["text"]))
+        return out
+
+    def chat_perform(self, *, stream, turns, tools, data_model, kwargs):
+        if stream:
+            return iter(self._chunks)
+        raise NotImplementedError
+
+    async def chat_perform_async(self, *, stream, turns, tools, data_model, kwargs):
+        if stream:
+
+            async def gen():
+                for c in self._chunks:
+                    yield c
+
+            return gen()
+        raise NotImplementedError
+
+    def stream_turn(self, completion, has_data_model):
+        return AssistantTurn(
+            contents=[ContentText.model_construct(text=completion["text"])],
+            tokens=None,
+            completion=None,
+        )
+
+    def list_models(self):
+        return []
+
+    def value_turn(self, completion, has_data_model):
+        raise NotImplementedError
+
+    def value_tokens(self, completion):
+        return None
+
+    def value_cost(self, completion, tokens=None):
+        return None
+
+    def token_count(self, *args, **kwargs):
+        return 0
+
+    async def token_count_async(self, *args, **kwargs):
+        return 0
+
+    def translate_model_params(self, *args, **kwargs):
+        return {}
+
+    def supported_model_params(self):
+        return set()
+
+
+def test_interleaved_streams_on_one_provider_stay_independent():
+    provider = AccumulatingProvider([])
+
+    stream_a = [Chunk("alpha "), Chunk("answer"), Chunk(emit_request=True)]
+    stream_b = [Chunk("beta "), Chunk("answer"), Chunk(emit_request=True)]
+
+    completions: dict[str, Optional[dict]] = {"a": None, "b": None}
+    requests: dict[str, list[str]] = {"a": [], "b": []}
+    for chunk_a, chunk_b in zip(stream_a, stream_b):
+        for key, chunk in (("a", chunk_a), ("b", chunk_b)):
+            completions[key] = provider.stream_merge_chunks(completions[key], chunk)
+            requests[key].extend(
+                c.query
+                for c in provider.stream_content(chunk, completions[key])
+                if isinstance(c, ContentToolRequestSearch)
+            )
+
+    assert requests["a"] == ["alpha answer"]
+    assert requests["b"] == ["beta answer"]
+
+
+def test_stream_content_sees_completion_including_current_chunk():
+    """`stream_merge_chunks` runs first, so `completion` already has this chunk."""
+    provider = AccumulatingProvider([Chunk("a"), Chunk("b"), Chunk("c")])
+    chat = Chat(provider=provider)
+
+    assert "".join(chat.stream("hi")) == "abc"
+    assert [c["text"] for c in provider.seen_completions if c] == ["a", "ab", "abc"]
+
+
+def test_multiple_contents_from_one_chunk_are_all_processed():
+    provider = AccumulatingProvider([])
+    chat = Chat(provider=provider)
+    # Bypass chat_perform so this test owns the chunk -> content mapping
+    provider.stream_content = lambda chunk, completion: [  # type: ignore[method-assign]
+        ContentThinkingDelta(thinking="why"),
+        ContentText.model_construct(text="what"),
+    ]
+    provider.chat_perform = lambda **kwargs: iter([Chunk("x")])  # type: ignore[method-assign]
+
+    out = list(chat.stream("hi", content="all"))
+
+    assert [x for x in out if isinstance(x, str)] == ["what"]
+    thinking = [x for x in out if isinstance(x, ContentThinkingDelta)]
+    assert [t.thinking for t in thinking] == ["why", ""]
+
+
+@pytest.mark.asyncio
+async def test_stream_content_sees_completion_including_current_chunk_async():
+    provider = AccumulatingProvider([Chunk("a"), Chunk("b")])
+    chat = Chat(provider=provider)
+
+    out = [x async for x in await chat.stream_async("hi")]
+
+    assert "".join(out) == "ab"
+    assert [c["text"] for c in provider.seen_completions if c] == ["a", "ab"]

--- a/tests/test_provider_stream_contract.py
+++ b/tests/test_provider_stream_contract.py
@@ -138,7 +138,7 @@ def test_multiple_contents_from_one_chunk_are_all_processed():
         ContentThinkingDelta(thinking="why"),
         ContentText.model_construct(text="what"),
     ]
-    provider.chat_perform = lambda **kwargs: iter([Chunk("x")])  # type: ignore[method-assign]
+    provider.chat_perform = lambda **kwargs: iter([Chunk("what")])  # type: ignore[method-assign]
 
     out = list(chat.stream("hi", content="all"))
 

--- a/tests/test_stream_thinking.py
+++ b/tests/test_stream_thinking.py
@@ -42,8 +42,8 @@ class FakeProvider(Provider):
             return _gen()
         raise NotImplementedError
 
-    def stream_content(self, chunk) -> Optional[Content]:
-        return chunk.content
+    def stream_content(self, chunk, completion) -> list[Content]:
+        return [chunk.content] if chunk.content is not None else []
 
     def stream_merge_chunks(self, completion, chunk):
         return completion or {}


### PR DESCRIPTION
Groundwork for surfacing citations during streaming. A provider currently gets one chunk and returns at most one `Content`, which rules out the two things richer streaming needs:

- **More than one content per chunk.** A single Anthropic `content_block_stop` can carry several citations; one Google chunk carries text *and* grounding metadata.
- **Cross-chunk context.** A citation only makes sense against the text block it annotates, which is spread across earlier chunks.

`stream_content()` now returns a `Sequence[Content]` and takes the merged-so-far `completion` as a second argument. `_chat_impl` calls `stream_merge_chunks` *before* `stream_content`, so `completion` already includes the current chunk.

The `completion` argument matters more than it looks. The obvious way to get cross-chunk state is to stash it on `self` — and that is a bug here, because `Chat.__deepcopy__` keeps `provider` by reference. Every forked chat shares one provider instance, and forks stream concurrently (each `eval_inspect()` sample, for one), so per-stream state on `self` lets one stream's citations leak into another's answer. Passing the completion through removes the temptation and makes the correct thing the easy thing. The ABC docstring says so, and `tests/test_provider_stream_contract.py` pins it with two interleaved streams through a single provider instance.

## Breaking change

Third-party `Provider` subclasses need updating; users of the built-in `Chat*()` functions are unaffected. `stream_text()` is removed — the sequence return subsumes it, with text extraction now in `display_text()`. Both ABC changes land together so third-party providers break once rather than twice.

All five built-in providers (OpenAI, OpenAI Completions, Anthropic, Google, Snowflake) are updated; each override is mechanical at this point, since no provider yet emits more than one content per chunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)