### PR TITLE
Name the streamed-content union, and don't try to merge unmergeable content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `ChatGoogle()` no longer errors when mixing custom tools and built-in tools (e.g. `tool_web_search()`) on Gemini 3+ models.
 * Turns containing web search/fetch content can now be passed to a different provider (e.g. `ChatAnthropic().set_turns(openai_chat.get_turns())`). Previously this raised `ValueError: Unsupported content type` on `ChatOpenAI()`, and `ChatAnthropic()` forwarded the other provider's raw payload as if it were its own, producing an invalid request. Each provider now replays only the built-in tool content it produced and drops the rest.
 * `ChatOpenAI()` web search `open_page` actions now surface as `ContentToolRequestFetch` (with the URL) rather than a `ContentToolRequestSearch` whose "query" was the URL, so renderers no longer show "searched for: https://…". Relatedly, a `search` action that reports only the plural `queries` field no longer falls through to the literal string `"web search"`.
+* Streaming two adjacent pieces of same-typed content that can't be merged (e.g. two web search requests) no longer raises `TypeError`.
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `ChatGoogle()` no longer errors when mixing custom tools and built-in tools (e.g. `tool_web_search()`) on Gemini 3+ models.
 * Turns containing web search/fetch content can now be passed to a different provider (e.g. `ChatAnthropic().set_turns(openai_chat.get_turns())`). Previously this raised `ValueError: Unsupported content type` on `ChatOpenAI()`, and `ChatAnthropic()` forwarded the other provider's raw payload as if it were its own, producing an invalid request. Each provider now replays only the built-in tool content it produced and drops the rest.
 * `ChatOpenAI()` web search `open_page` actions now surface as `ContentToolRequestFetch` (with the URL) rather than a `ContentToolRequestSearch` whose "query" was the URL, so renderers no longer show "searched for: https://…". Relatedly, a `search` action that reports only the plural `queries` field no longer falls through to the literal string `"web search"`.
-* Streaming two adjacent pieces of same-typed content that can't be merged (e.g. two web search requests) no longer raises `TypeError`.
+* Streaming two adjacent pieces of same-typed content that define no merge behavior (e.g. two tool requests) no longer raises `TypeError`. They are now appended as separate content instead.
 
 ### Breaking changes
 

--- a/chatlas/_chat.py
+++ b/chatlas/_chat.py
@@ -23,6 +23,7 @@ from typing import (
     Optional,
     Sequence,
     TypeVar,
+    Union,
     cast,
     overload,
 )
@@ -95,6 +96,15 @@ class TokensDict(TypedDict):
 CompletionT = TypeVar("CompletionT")
 
 EchoOptions = Literal["output", "all", "none", "text"]
+
+# The values yielded by `.stream()`/`.stream_async()`. Plain text is always
+# yielded; the richer content objects only appear when `content="all"`.
+StreamedContent = Union[
+    str,
+    ContentThinkingDelta,
+    ContentToolRequest,
+    ContentToolResult,
+]
 
 T = TypeVar("T")
 BaseModelT = TypeVar("BaseModelT", bound=BaseModel)
@@ -1194,9 +1204,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         data_model: Optional[type[BaseModel]] = None,
         kwargs: Optional[SubmitInputArgsT] = None,
         controller: StreamController | None = None,
-    ) -> Generator[
-        str | ContentThinkingDelta | ContentToolRequest | ContentToolResult, None, None
-    ]: ...
+    ) -> Generator[StreamedContent, None, None]: ...
 
     def stream(
         self,
@@ -1206,9 +1214,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         data_model: Optional[type[BaseModel]] = None,
         kwargs: Optional[SubmitInputArgsT] = None,
         controller: StreamController | None = None,
-    ) -> Generator[
-        str | ContentThinkingDelta | ContentToolRequest | ContentToolResult, None, None
-    ]:
+    ) -> Generator[StreamedContent, None, None]:
         """
         Generate a response from the chat in a streaming fashion.
 
@@ -1282,11 +1288,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
             controller=controller,
         )
 
-        def wrapper() -> Generator[
-            str | ContentThinkingDelta | ContentToolRequest | ContentToolResult,
-            None,
-            None,
-        ]:
+        def wrapper() -> Generator[StreamedContent, None, None]:
             with display:
                 for chunk in generator:
                     yield chunk
@@ -1313,9 +1315,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         data_model: Optional[type[BaseModel]] = None,
         kwargs: Optional[SubmitInputArgsT] = None,
         controller: StreamController | None = None,
-    ) -> AsyncGenerator[
-        str | ContentThinkingDelta | ContentToolRequest | ContentToolResult, None
-    ]: ...
+    ) -> AsyncGenerator[StreamedContent, None]: ...
 
     async def stream_async(
         self,
@@ -1325,9 +1325,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         data_model: Optional[type[BaseModel]] = None,
         kwargs: Optional[SubmitInputArgsT] = None,
         controller: StreamController | None = None,
-    ) -> AsyncGenerator[
-        str | ContentThinkingDelta | ContentToolRequest | ContentToolResult, None
-    ]:
+    ) -> AsyncGenerator[StreamedContent, None]:
         """
         Generate a response from the chat in a streaming fashion asynchronously.
 
@@ -1406,9 +1404,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
             controller=controller,
         )
 
-        async def wrapper() -> AsyncGenerator[
-            str | ContentThinkingDelta | ContentToolRequest | ContentToolResult, None
-        ]:
+        async def wrapper() -> AsyncGenerator[StreamedContent, None]:
             try:
                 with display:
                     async for chunk in generator:
@@ -2570,9 +2566,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         data_model: Optional[type[BaseModel]] = None,
         *,
         controller: StreamController,
-    ) -> Generator[
-        str | ContentThinkingDelta | ContentToolRequest | ContentToolResult, None, None
-    ]: ...
+    ) -> Generator[StreamedContent, None, None]: ...
 
     def _chat_impl(
         self,
@@ -2659,9 +2653,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         data_model: Optional[type[BaseModel]] = None,
         *,
         controller: StreamController,
-    ) -> AsyncGenerator[
-        str | ContentThinkingDelta | ContentToolRequest | ContentToolResult, None
-    ]: ...
+    ) -> AsyncGenerator[StreamedContent, None]: ...
 
     async def _chat_impl_async(
         self,

--- a/chatlas/_turn_accumulator.py
+++ b/chatlas/_turn_accumulator.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Callable, Literal, Sequence
 
 from ._content import (
-    PROVIDER_ANNOTATION_TYPES,
     Content,
     ContentThinkingDelta,
 )
@@ -120,19 +119,18 @@ class TurnAccumulator:
         if self._turn_idx is None:
             raise RuntimeError("_update_turn called before begin_turn")
         contents = self._turns[self._turn_idx].contents
-        # Provider annotations define no __add__, so consecutive ones are appended
-        # rather than merged (two search results aren't one search result). The
-        # `NotImplemented` check below can't catch that: Python raises TypeError
-        # when neither operand implements the operator.
+        # Only content that opts in via __add__ (text, thinking) merges with its
+        # predecessor; everything else appends, since two tool requests aren't
+        # one tool request. Testing for __add__ rather than catching TypeError
+        # keeps a genuine bug inside __add__ from silently degrading into an
+        # append.
         if (
             contents
             and type(contents[-1]) is type(content)
-            and not isinstance(content, PROVIDER_ANNOTATION_TYPES)
+            and hasattr(content, "__add__")
         ):
-            merged = contents[-1] + content  # type: ignore[operator]
-            if merged is not NotImplemented:
-                contents[-1] = merged
-                return
+            contents[-1] = contents[-1] + content  # type: ignore[operator]
+            return
         # Content is the base class; contents is typed as list[ContentUnion]
         # (discriminated union). At runtime all Content subclasses are ContentUnion
         # members, so the append is safe.

--- a/chatlas/_turn_accumulator.py
+++ b/chatlas/_turn_accumulator.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Callable, Literal, Sequence
 
 from ._content import (
+    PROVIDER_ANNOTATION_TYPES,
     Content,
     ContentThinkingDelta,
 )
@@ -119,7 +120,15 @@ class TurnAccumulator:
         if self._turn_idx is None:
             raise RuntimeError("_update_turn called before begin_turn")
         contents = self._turns[self._turn_idx].contents
-        if contents and type(contents[-1]) is type(content):
+        # Provider annotations define no __add__, so consecutive ones are appended
+        # rather than merged (two search results aren't one search result). The
+        # `NotImplemented` check below can't catch that: Python raises TypeError
+        # when neither operand implements the operator.
+        if (
+            contents
+            and type(contents[-1]) is type(content)
+            and not isinstance(content, PROVIDER_ANNOTATION_TYPES)
+        ):
             merged = contents[-1] + content  # type: ignore[operator]
             if merged is not NotImplemented:
                 contents[-1] = merged

--- a/tests/test_turn_accumulator.py
+++ b/tests/test_turn_accumulator.py
@@ -1,7 +1,13 @@
-from chatlas._content import ContentText, ContentToolRequestSearch
+import pytest
+from chatlas._content import (
+    ContentJson,
+    ContentText,
+    ContentToolRequest,
+    ContentToolRequestSearch,
+)
+from chatlas._stream_controller import StreamController
 from chatlas._turn import AssistantTurn, UserTurn
 from chatlas._turn_accumulator import TurnAccumulator
-from chatlas._stream_controller import StreamController
 
 
 def test_begin_turn_inserts_partial():
@@ -27,17 +33,27 @@ def test_update_turn_merges_adjacent_content():
     assert turns[1].contents[0].text == "ab"
 
 
-def test_update_turn_appends_non_mergeable_adjacent_content():
+@pytest.mark.parametrize(
+    "first,second",
+    [
+        (ContentToolRequestSearch(query="a"), ContentToolRequestSearch(query="b")),
+        (
+            ContentToolRequest(id="1", name="f", arguments={}),
+            ContentToolRequest(id="2", name="f", arguments={}),
+        ),
+        (ContentJson(value={"a": 1}), ContentJson(value={"b": 2})),
+    ],
+)
+def test_update_turn_appends_non_mergeable_adjacent_content(first, second):
     # Same-typed content with no __add__ must append. `contents[-1] + content`
     # would raise TypeError rather than returning NotImplemented.
     turns: list = []
     acc = TurnAccumulator(turns, StreamController())
     acc.begin_turn(UserTurn("hello"))
-    acc._update_turn(ContentToolRequestSearch(query="a"))
-    acc._update_turn(ContentToolRequestSearch(query="b"))
+    acc._update_turn(first)
+    acc._update_turn(second)
     contents = turns[1].contents
-    assert len(contents) == 2
-    assert [c.query for c in contents] == ["a", "b"]
+    assert contents == [first, second]
 
 
 def test_complete_turn_replaces_partial():

--- a/tests/test_turn_accumulator.py
+++ b/tests/test_turn_accumulator.py
@@ -1,4 +1,4 @@
-from chatlas._content import ContentText
+from chatlas._content import ContentText, ContentToolRequestSearch
 from chatlas._turn import AssistantTurn, UserTurn
 from chatlas._turn_accumulator import TurnAccumulator
 from chatlas._stream_controller import StreamController
@@ -25,6 +25,19 @@ def test_update_turn_merges_adjacent_content():
     acc._update_turn(ContentText.model_construct(text="b"))
     assert len(turns[1].contents) == 1
     assert turns[1].contents[0].text == "ab"
+
+
+def test_update_turn_appends_non_mergeable_adjacent_content():
+    # Same-typed content with no __add__ must append. `contents[-1] + content`
+    # would raise TypeError rather than returning NotImplemented.
+    turns: list = []
+    acc = TurnAccumulator(turns, StreamController())
+    acc.begin_turn(UserTurn("hello"))
+    acc._update_turn(ContentToolRequestSearch(query="a"))
+    acc._update_turn(ContentToolRequestSearch(query="b"))
+    contents = turns[1].contents
+    assert len(contents) == 2
+    assert [c.query for c in contents] == ["a", "b"]
 
 
 def test_complete_turn_replaces_partial():


### PR DESCRIPTION
Two small, independent cleanups on the streaming path.

**A repeated union gets a name.** `Generator[str | ContentThinkingDelta | ContentToolRequest | ContentToolResult, ...]` was spelled out at **8 sites** in `_chat.py` — `stream()`, `stream_async()`, `_chat_impl()`, `_chat_impl_async()`, their `@overload`s, and the two `wrapper()` closures. Adding a member meant editing all eight and hoping none were missed. It's now `StreamedContent`, declared once.

**A guard that never fires.** `TurnAccumulator._update_turn` merges adjacent same-typed content:

```python
if contents and type(contents[-1]) is type(content):
    merged = contents[-1] + content
    if merged is not NotImplemented:
        contents[-1] = merged
        return
```

`NotImplemented` is what `__add__` returns when *it* declines; when neither operand implements the operator at all, Python raises `TypeError` before the check is ever reached. So same-typed content without an `__add__` — two `ContentToolRequestSearch`, say — crashes rather than appending. Checked up front instead, with a regression test.

Nothing user-visible changes today, since only text and thinking content currently reach `_update_turn` during streaming, and both merge fine. The crash is reachable as soon as a provider streams anything else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)