### PR TITLE
Ignore local scratch scripts and planning docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,13 +13,6 @@ logs/
 docs/plans/
 docs/superpowers/
 
-# Root-level scratch scripts
-/bedrock.py
-/deepseek.py
-/reprex.py
-/think.py
-/think.R
-
 /.luarc.json
 
 # worktrees

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,17 @@ uv.lock
 sandbox/
 logs/
 
+# Local scratch / AI-generated planning docs
+docs/plans/
+docs/superpowers/
+
+# Root-level scratch scripts
+/bedrock.py
+/deepseek.py
+/reprex.py
+/think.py
+/think.R
+
 /.luarc.json
 
 # worktrees


### PR DESCRIPTION
## Why this matters

`docs/plans/`, `docs/superpowers/`, and a handful of root-level scratch scripts
are local working files. Nothing in the repo stopped them from being committed —
a single `git add -A` staged all of them, which is how ~17k lines of planning
docs ended up in #318 twice and had to be rewritten out both times.

This makes `git add -A` safe in this repo rather than relying on everyone to
remember to stage paths explicitly.

## Notes for reviewers

- Nothing currently tracked matches any of these patterns, so this shadows no
  existing file — verified with `git ls-files`.
- Neither `docs/_quarto.yml`, `docs/_sidebar.yml`, nor the `Makefile` references
  `docs/plans` or `docs/superpowers`, so the docs build is unaffected.
- The scratch scripts are anchored with a leading `/` so the patterns only match
  at the repo root and can't catch a legitimately-named module deeper in the
  tree.
- Sits alongside the existing `sandbox/` and `logs/` entries, which cover the
  same category of local-only working files.
