### PR TITLE
feat: token_count() include= control, accurate OpenAI counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `batch_chat()` now supports `ChatGoogle()` (Gemini Developer API batch jobs). Batch is also now documented as supported for `ChatGroq()`, which already worked via its OpenAI-compatible provider. (Vertex AI is not supported, since its batch API requires GCS bucket URIs instead of inline requests.)
 * `ChatOllama()` gains a `reasoning_effort` parameter to enable extended "thinking" for models that support it (e.g. qwen3, gpt-oss).
+* `Chat.token_count()` gained an `include=` argument. The default
+  `include="new"` counts only the supplied input (plus registered tools where
+  the provider supports it), while `include="complete"` estimates the total
+  input tokens for the next request by also including the system prompt and
+  conversation history.
 
 ### Improvements
 
 * `ChatGoogle()` and `ChatVertex()` now default to `gemini-3.5-flash` instead of the older `gemini-2.5-flash`.
 * `ChatGroq()` now defaults to `openai/gpt-oss-20b` instead of `llama-3.1-8b-instant`.
+* `ChatOpenAI().token_count()` now uses OpenAI's token-counting endpoint,
+  which is accurate and accounts for registered tools, instead of a local
+  `tiktoken` estimate. (`ChatGoogle().token_count()` continues to count only
+  message contents — not tools or the system prompt — due to a `google-genai`
+  SDK limitation.)
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,28 +15,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `Chat` gains a `.files` accessor for uploading files to a provider once and referencing them across turns without re-sending bytes, plus listing, fetching metadata, downloading, and deleting them. Supported for OpenAI, Anthropic, and Google Gemini. A new `ContentUploaded` type represents the reference and can be constructed directly to point at a file uploaded out-of-band (e.g. a Vertex `gs://` URI). For Google, `upload()` waits for Gemini to finish processing large media (video, audio) before returning, since the API rejects references to files that aren't yet `ACTIVE`.
 * `batch_chat()` now supports `ChatGoogle()` (Gemini Developer API batch jobs). Batch is also now documented as supported for `ChatGroq()`, which already worked via its OpenAI-compatible provider. (Vertex AI is not supported, since its batch API requires GCS bucket URIs instead of inline requests.)
 * `ChatOllama()` gains a `reasoning_effort` parameter to enable extended "thinking" for models that support it (e.g. qwen3, gpt-oss).
-* `Chat.token_count()` gained an `include=` argument. The default
-  `include="new"` counts only the supplied input (plus registered tools where
-  the provider supports it), while `include="complete"` estimates the total
-  input tokens for the next request by also including the system prompt and
-  conversation history (where the provider's token counter supports it; see
-  the API docs for per-provider details).
+* `Chat.token_count()` gained an `include=` argument: `"new"` (default) counts
+  just the given input, while `"complete"` estimates the total tokens for the
+  next request, including history and system prompt where the provider
+  supports it.
 
 ### Improvements
 
 * `ChatGoogle()` and `ChatVertex()` now default to `gemini-3.5-flash` instead of the older `gemini-2.5-flash`.
 * `ChatGroq()` now defaults to `openai/gpt-oss-20b` instead of `llama-3.1-8b-instant`.
-* `ChatOpenAI().token_count()` now uses OpenAI's token-counting endpoint,
-  which is accurate and accounts for registered tools, instead of a local
-  `tiktoken` estimate. (`ChatGoogle().token_count()` continues to count only
-  message contents — not tools or the system prompt — due to a `google-genai`
-  SDK limitation.)
+* `ChatOpenAI().token_count()` now uses OpenAI's token-counting endpoint for
+  accurate, tool-aware counts instead of a local `tiktoken` estimate.
 
 ### Changes
 
-* `Provider.token_count()` and `Provider.token_count_async()` now take a
-  `turns: list[Turn]` argument instead of `*args: Content | str`. This only
-  affects custom `Provider` subclasses that override these methods.
+* `Provider.token_count()`/`token_count_async()` now take a `turns: list[Turn]`
+  argument instead of `*args: Content | str` (affects custom `Provider`
+  subclasses only).
 * MCP support now requires `mcp>=2.0.0`. The 2.0 release of the `mcp` SDK renamed its model fields (and removed `mcp.server.fastmcp.FastMCP`), so older `mcp` versions are no longer compatible. This only affects users of the optional `mcp` extra (i.e., `register_mcp_tools_*()`).
 * `Turn.finish_reason` is now normalized to a consistent set of values (`"success"`, `"tool_use"`, `"max_tokens"`, `"content_filter"`, `"context_window"`, `"stop_sequence"`) across most providers, so you no longer need provider-specific logic to check why a turn ended. Previously each provider surfaced its own raw string (e.g. Anthropic's `"end_turn"`/`"tool_use"` vs. OpenAI Completions' `"stop"`/`"tool_calls"` vs. Google's `"STOP"`/`"SAFETY"`), so the same outcome could require different checks depending on which `Chat*()` you used. Reasons chatlas doesn't yet recognize still pass through unchanged.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `include="new"` counts only the supplied input (plus registered tools where
   the provider supports it), while `include="complete"` estimates the total
   input tokens for the next request by also including the system prompt and
-  conversation history.
+  conversation history (where the provider's token counter supports it; see
+  the API docs for per-provider details).
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+* `Provider.token_count()` and `Provider.token_count_async()` now take a
+  `turns: list[Turn]` argument instead of `*args: Content | str`. This only
+  affects custom `Provider` subclasses that override these methods.
 * MCP support now requires `mcp>=2.0.0`. The 2.0 release of the `mcp` SDK renamed its model fields (and removed `mcp.server.fastmcp.FastMCP`), so older `mcp` versions are no longer compatible. This only affects users of the optional `mcp` extra (i.e., `register_mcp_tools_*()`).
 * `Turn.finish_reason` is now normalized to a consistent set of values (`"success"`, `"tool_use"`, `"max_tokens"`, `"content_filter"`, `"context_window"`, `"stop_sequence"`) across most providers, so you no longer need provider-specific logic to check why a turn ended. Previously each provider surfaced its own raw string (e.g. Anthropic's `"end_turn"`/`"tool_use"` vs. OpenAI Completions' `"stop"`/`"tool_calls"` vs. Google's `"STOP"`/`"SAFETY"`), so the same outcome could require different checks depending on which `Chat*()` you used. Reasons chatlas doesn't yet recognize still pass through unchanged.
 

--- a/chatlas/_chat.py
+++ b/chatlas/_chat.py
@@ -693,7 +693,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         """
 
         return self.provider.token_count(
-            *args,
+            [user_turn(*args)],
             tools=self._tools,
             data_model=data_model,
         )
@@ -726,7 +726,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         """
 
         return await self.provider.token_count_async(
-            *args,
+            [user_turn(*args)],
             tools=self._tools,
             data_model=data_model,
         )

--- a/chatlas/_chat.py
+++ b/chatlas/_chat.py
@@ -665,7 +665,8 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
             What to include in the count. `"new"` (default) counts only the
             content in `args` plus any registered tools. `"complete"` estimates
             the total input tokens for the next request, adding the system
-            prompt and conversation history (`.get_turns()`).
+            prompt and conversation history (`.get_turns()`). Exactly what
+            each mode counts is provider-dependent; see the Note below.
         data_model
             If the input is meant for data extraction (i.e., `.chat_structured()`), then
             this should be the Pydantic model that describes the structure of the data to
@@ -735,7 +736,8 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
             What to include in the count. `"new"` (default) counts only the
             content in `args` plus any registered tools. `"complete"` estimates
             the total input tokens for the next request, adding the system
-            prompt and conversation history (`.get_turns()`).
+            prompt and conversation history (`.get_turns()`). Exactly what
+            each mode counts is provider-dependent; see the Note below.
         data_model
             If this input is meant for data extraction (i.e., `.chat_structured_async()`),
             then this should be the Pydantic model that describes the structure of the data

--- a/chatlas/_chat.py
+++ b/chatlas/_chat.py
@@ -788,6 +788,10 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
     def _token_count_turns(
         self, include: Literal["new", "complete"], *args: Content | str
     ) -> list[Turn]:
+        if include not in ("new", "complete"):
+            raise ValueError(
+                f"Expected `include` to be one of 'new' or 'complete', not '{include}'"
+            )
         new_turn = user_turn(*args)
         if include == "complete":
             return self.get_turns(include_system_prompt=True) + [new_turn]

--- a/chatlas/_chat.py
+++ b/chatlas/_chat.py
@@ -678,9 +678,19 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
 
         Note
         ----
-        Remember that the token count is an estimate. Also, models based on
-        `ChatOpenAI()` currently does not take tools into account when
-        estimating token counts.
+        The token count is an estimate, and what it accounts for depends on the
+        provider:
+
+        - `ChatOpenAI()` (Responses API) and `ChatAnthropic()` use the provider's
+          token-counting endpoint and account for registered tools (and, with
+          `include="complete"`, the system prompt and conversation history).
+        - `ChatGoogle()` uses Google's token-counting endpoint but counts only the
+          message contents: it does not account for registered tools or the system
+          prompt (a limitation of the `google-genai` SDK's `count_tokens` on the
+          Gemini Developer API). With `include="complete"` the count reflects
+          conversation history but not the system prompt.
+        - `ChatOpenAICompletions()` and other OpenAI-compatible providers fall back
+          to a local `tiktoken` estimate that does not account for tools.
 
         Examples
         --------
@@ -735,6 +745,22 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         -------
         int
             The token count for the input.
+
+        Note
+        ----
+        The token count is an estimate, and what it accounts for depends on the
+        provider:
+
+        - `ChatOpenAI()` (Responses API) and `ChatAnthropic()` use the provider's
+          token-counting endpoint and account for registered tools (and, with
+          `include="complete"`, the system prompt and conversation history).
+        - `ChatGoogle()` uses Google's token-counting endpoint but counts only the
+          message contents: it does not account for registered tools or the system
+          prompt (a limitation of the `google-genai` SDK's `count_tokens` on the
+          Gemini Developer API). With `include="complete"` the count reflects
+          conversation history but not the system prompt.
+        - `ChatOpenAICompletions()` and other OpenAI-compatible providers fall back
+          to a local `tiktoken` estimate that does not account for tools.
         """
 
         return await self.provider.token_count_async(

--- a/chatlas/_chat.py
+++ b/chatlas/_chat.py
@@ -647,6 +647,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
     def token_count(
         self,
         *args: Content | str,
+        include: Literal["new", "complete"] = "new",
         data_model: Optional[type[BaseModel]] = None,
     ) -> int:
         """
@@ -660,6 +661,11 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         ----------
         args
             The input to get a token count for.
+        include
+            What to include in the count. `"new"` (default) counts only the
+            content in `args` plus any registered tools. `"complete"` estimates
+            the total input tokens for the next request, adding the system
+            prompt and conversation history (`.get_turns()`).
         data_model
             If the input is meant for data extraction (i.e., `.chat_structured()`), then
             this should be the Pydantic model that describes the structure of the data to
@@ -693,7 +699,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         """
 
         return self.provider.token_count(
-            [user_turn(*args)],
+            self._token_count_turns(include, *args),
             tools=self._tools,
             data_model=data_model,
         )
@@ -701,6 +707,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
     async def token_count_async(
         self,
         *args: Content | str,
+        include: Literal["new", "complete"] = "new",
         data_model: Optional[type[BaseModel]] = None,
     ) -> int:
         """
@@ -714,6 +721,11 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         ----------
         args
             The input to get a token count for.
+        include
+            What to include in the count. `"new"` (default) counts only the
+            content in `args` plus any registered tools. `"complete"` estimates
+            the total input tokens for the next request, adding the system
+            prompt and conversation history (`.get_turns()`).
         data_model
             If this input is meant for data extraction (i.e., `.chat_structured_async()`),
             then this should be the Pydantic model that describes the structure of the data
@@ -726,10 +738,18 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         """
 
         return await self.provider.token_count_async(
-            [user_turn(*args)],
+            self._token_count_turns(include, *args),
             tools=self._tools,
             data_model=data_model,
         )
+
+    def _token_count_turns(
+        self, include: Literal["new", "complete"], *args: Content | str
+    ) -> list[Turn]:
+        new_turn = user_turn(*args)
+        if include == "complete":
+            return self.get_turns(include_system_prompt=True) + [new_turn]
+        return [new_turn]
 
     def app(
         self,

--- a/chatlas/_provider.py
+++ b/chatlas/_provider.py
@@ -308,7 +308,8 @@ class Provider(
     @abstractmethod
     def token_count(
         self,
-        *args: Content | str,
+        turns: list[Turn],
+        *,
         tools: dict[str, Tool | ToolBuiltIn],
         data_model: Optional[type[BaseModel]],
     ) -> int: ...
@@ -316,7 +317,8 @@ class Provider(
     @abstractmethod
     async def token_count_async(
         self,
-        *args: Content | str,
+        turns: list[Turn],
+        *,
         tools: dict[str, Tool | ToolBuiltIn],
         data_model: Optional[type[BaseModel]],
     ) -> int: ...

--- a/chatlas/_provider_anthropic.py
+++ b/chatlas/_provider_anthropic.py
@@ -47,7 +47,7 @@ from ._provider import (
 from ._tokens import get_price_info
 from ._tools import Tool, ToolBuiltIn, basemodel_to_param_schema
 from ._tools_builtin import ToolWebFetch, ToolWebSearch
-from ._turn import AssistantTurn, FinishReason, SystemTurn, Turn, UserTurn, user_turn
+from ._turn import AssistantTurn, FinishReason, SystemTurn, Turn, UserTurn
 from ._utils import split_http_client_kwargs
 
 if TYPE_CHECKING:
@@ -623,55 +623,40 @@ class AnthropicProvider(
 
     def token_count(
         self,
-        *args: Content | str,
+        turns: list[Turn],
+        *,
         tools: dict[str, Tool | ToolBuiltIn],
         data_model: Optional[type[BaseModel]],
     ) -> int:
-        kwargs = self._token_count_args(
-            *args,
-            tools=tools,
-            data_model=data_model,
-        )
+        kwargs = self._token_count_args(turns, tools=tools, data_model=data_model)
         res = self._client.messages.count_tokens(**kwargs)
         return res.input_tokens
 
     async def token_count_async(
         self,
-        *args: Content | str,
+        turns: list[Turn],
+        *,
         tools: dict[str, Tool | ToolBuiltIn],
         data_model: Optional[type[BaseModel]],
     ) -> int:
-        kwargs = self._token_count_args(
-            *args,
-            tools=tools,
-            data_model=data_model,
-        )
+        kwargs = self._token_count_args(turns, tools=tools, data_model=data_model)
         res = await self._async_client.messages.count_tokens(**kwargs)
         return res.input_tokens
 
     def _token_count_args(
         self,
-        *args: Content | str,
+        turns: list[Turn],
+        *,
         tools: dict[str, Tool | ToolBuiltIn],
         data_model: Optional[type[BaseModel]],
     ) -> dict[str, Any]:
-        turn = user_turn(*args)
-
         kwargs = self._chat_perform_args(
             stream=False,
-            turns=[turn],
+            turns=turns,
             tools=tools,
             data_model=data_model,
         )
-
-        args_to_keep = [
-            "messages",
-            "model",
-            "system",
-            "tools",
-            "tool_choice",
-        ]
-
+        args_to_keep = ["messages", "model", "system", "tools", "tool_choice"]
         return {arg: kwargs[arg] for arg in args_to_keep if arg in kwargs}
 
     def translate_model_params(self, params: StandardModelParams) -> "SubmitInputArgs":

--- a/chatlas/_provider_google.py
+++ b/chatlas/_provider_google.py
@@ -38,7 +38,7 @@ from ._provider import (
 from ._tokens import get_price_info
 from ._tools import Tool, ToolBuiltIn
 from ._tools_builtin import ToolWebFetch, ToolWebSearch
-from ._turn import AssistantTurn, FinishReason, SystemTurn, Turn, UserTurn, user_turn
+from ._turn import AssistantTurn, FinishReason, SystemTurn, Turn, UserTurn
 
 if TYPE_CHECKING:
     from google.genai.types import Content as GoogleContent
@@ -509,50 +509,39 @@ class GoogleProvider(
 
     def token_count(
         self,
-        *args: Content | str,
+        turns: list[Turn],
+        *,
         tools: dict[str, Tool | ToolBuiltIn],
         data_model: Optional[type[BaseModel]],
-    ):
-        kwargs = self._token_count_args(
-            *args,
-            tools=tools,
-            data_model=data_model,
-        )
-
+    ) -> int:
+        kwargs = self._token_count_args(turns, tools=tools, data_model=data_model)
         res = self._client.models.count_tokens(**kwargs)
         return res.total_tokens or 0
 
     async def token_count_async(
         self,
-        *args: Content | str,
+        turns: list[Turn],
+        *,
         tools: dict[str, Tool | ToolBuiltIn],
         data_model: Optional[type[BaseModel]],
-    ):
-        kwargs = self._token_count_args(
-            *args,
-            tools=tools,
-            data_model=data_model,
-        )
-
+    ) -> int:
+        kwargs = self._token_count_args(turns, tools=tools, data_model=data_model)
         res = await self._client.aio.models.count_tokens(**kwargs)
         return res.total_tokens or 0
 
     def _token_count_args(
         self,
-        *args: Content | str,
+        turns: list[Turn],
+        *,
         tools: dict[str, Tool | ToolBuiltIn],
         data_model: Optional[type[BaseModel]],
     ) -> dict[str, Any]:
-        turn = user_turn(*args)
-
         kwargs = self._chat_perform_args(
-            turns=[turn],
+            turns=turns,
             tools=tools,
             data_model=data_model,
         )
-
-        args_to_keep = ["model", "contents", "tools"]
-
+        args_to_keep = ["model", "contents"]
         return {arg: kwargs[arg] for arg in args_to_keep if arg in kwargs}
 
     def _google_contents(self, turns: list[Turn]) -> list["GoogleContent"]:

--- a/chatlas/_provider_openai.py
+++ b/chatlas/_provider_openai.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import base64
 import warnings
-from typing import TYPE_CHECKING, Literal, Optional, cast
+from typing import TYPE_CHECKING, Any, Literal, Optional, cast
 from urllib.parse import urlparse
 
 import orjson
@@ -326,6 +326,46 @@ class OpenAIProvider(
             kwargs_full["include"] = include
 
         return kwargs_full
+
+    def token_count(
+        self,
+        turns: list[Turn],
+        *,
+        tools: dict[str, Tool | ToolBuiltIn],
+        data_model: Optional[type[BaseModel]],
+    ) -> int:
+        kwargs = self._token_count_args(turns, tools=tools, data_model=data_model)
+        res = self._client.responses.input_tokens.count(**kwargs)
+        return res.input_tokens
+
+    async def token_count_async(
+        self,
+        turns: list[Turn],
+        *,
+        tools: dict[str, Tool | ToolBuiltIn],
+        data_model: Optional[type[BaseModel]],
+    ) -> int:
+        kwargs = self._token_count_args(turns, tools=tools, data_model=data_model)
+        res = await self._async_client.responses.input_tokens.count(**kwargs)
+        return res.input_tokens
+
+    def _token_count_args(
+        self,
+        turns: list[Turn],
+        *,
+        tools: dict[str, Tool | ToolBuiltIn],
+        data_model: Optional[type[BaseModel]],
+    ) -> dict[str, Any]:
+        kwargs = self._chat_perform_args(
+            stream=False,
+            turns=turns,
+            tools=tools,
+            data_model=data_model,
+        )
+        # `input_tokens` accepts a subset of `responses.create` params; drop the
+        # rest (e.g. stream/store/include) which the endpoint rejects.
+        args_to_keep = ["input", "model", "tools", "text", "tool_choice", "reasoning"]
+        return {arg: kwargs[arg] for arg in args_to_keep if arg in kwargs}
 
     def stream_content(self, chunk, completion) -> list[Content]:
         if chunk.type == "response.output_text.delta":

--- a/chatlas/_provider_openai_azure.py
+++ b/chatlas/_provider_openai_azure.py
@@ -93,6 +93,12 @@ def ChatAzureOpenAI(
     -------
     Chat
         A Chat object.
+
+    Note
+    ----
+    `token_count()` uses the same OpenAI `responses/input_tokens` endpoint as
+    `ChatOpenAI()`, so it requires an Azure OpenAI deployment and api-version
+    that support that endpoint; otherwise `token_count()` will raise.
     """
 
     kwargs_chat: "ResponsesSubmitInputArgs" = {}

--- a/chatlas/_provider_openai_generic.py
+++ b/chatlas/_provider_openai_generic.py
@@ -13,7 +13,7 @@ from openai import AsyncOpenAI, OpenAI
 from openai.types.batch import Batch
 from pydantic import BaseModel
 
-from ._content import Content, ContentImage, ContentImageRemote
+from ._content import ContentImage, ContentImageRemote
 from ._provider import (
     BatchStatus,
     ChatCompletionChunkT,
@@ -25,7 +25,7 @@ from ._provider import (
 )
 from ._tokens import get_price_info
 from ._tools import Tool, ToolBuiltIn
-from ._turn import AssistantTurn, Turn, UserTurn, user_turn
+from ._turn import AssistantTurn, Turn
 from ._utils import split_http_client_kwargs
 
 if TYPE_CHECKING:
@@ -121,7 +121,8 @@ class OpenAIAbstractProvider(
 
     def token_count(
         self,
-        *args: Content | str,
+        turns: list[Turn],
+        *,
         tools: dict[str, Tool | ToolBuiltIn],
         data_model: Optional[type[BaseModel]],
     ) -> int:
@@ -135,29 +136,31 @@ class OpenAIAbstractProvider(
 
         encoding = tiktoken.encoding_for_model(self._model)
 
-        turn = user_turn(*args)
+        image_tokens = 0
+        stripped: list[Turn] = []
+        for turn in turns:
+            image_tokens += sum(
+                self._image_token_count(x)
+                for x in turn.contents
+                if isinstance(x, ContentImage)
+            )
+            non_images = [x for x in turn.contents if not isinstance(x, ContentImage)]
+            if non_images:
+                stripped.append(turn.model_copy(update={"contents": non_images}))
 
-        # Count the tokens in image contents
-        image_tokens = sum(
-            self._image_token_count(x)
-            for x in turn.contents
-            if isinstance(x, ContentImage)
-        )
-
-        # For other contents, get the token count from the actual message param
-        other_contents = [x for x in turn.contents if not isinstance(x, ContentImage)]
-        other_full = self._turns_as_inputs([UserTurn(other_contents)])
+        other_full = self._turns_as_inputs(stripped)
         other_tokens = len(encoding.encode(str(other_full)))
 
         return other_tokens + image_tokens
 
     async def token_count_async(
         self,
-        *args: Content | str,
+        turns: list[Turn],
+        *,
         tools: dict[str, Tool | ToolBuiltIn],
         data_model: Optional[type[BaseModel]],
     ) -> int:
-        return self.token_count(*args, tools=tools, data_model=data_model)
+        return self.token_count(turns, tools=tools, data_model=data_model)
 
     @staticmethod
     def _image_token_count(image: ContentImage) -> int:

--- a/chatlas/_provider_snowflake.py
+++ b/chatlas/_provider_snowflake.py
@@ -465,7 +465,8 @@ class SnowflakeProvider(
 
     def token_count(
         self,
-        *args: "Content | str",
+        turns: list[Turn],
+        *,
         tools: dict[str, Tool | ToolBuiltIn],
         data_model: Optional[type[BaseModel]],
     ) -> int:
@@ -475,7 +476,8 @@ class SnowflakeProvider(
 
     async def token_count_async(
         self,
-        *args: "Content | str",
+        turns: list[Turn],
+        *,
         tools: dict[str, Tool | ToolBuiltIn],
         data_model: Optional[type[BaseModel]],
     ) -> int:

--- a/tests/_vcr/test_provider_anthropic/test_anthropic_token_count_complete_exceeds_new.yaml
+++ b/tests/_vcr/test_provider_anthropic/test_anthropic_token_count_complete_exceeds_new.yaml
@@ -1,0 +1,118 @@
+interactions:
+- request:
+    body: '{"messages": [{"role": "user", "content": [{"text": "and one more question",
+      "type": "text", "cache_control": {"type": "ephemeral", "ttl": "5m"}}]}], "model":
+      "claude-sonnet-4-6", "tools": []}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, zstd
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '176'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      x-stainless-async:
+      - 'false'
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages/count_tokens
+  response:
+    body:
+      string: '{"input_tokens":11}'
+    headers:
+      cf-cache-status:
+      - DYNAMIC
+      connection:
+      - keep-alive
+      content-length:
+      - '19'
+      content-security-policy:
+      - default-src 'none'; frame-ancestors 'none'
+      content-type:
+      - application/json
+      date:
+      - Mon, 27 Jul 2026 18:27:40 GMT
+      server:
+      - cloudflare
+      server-timing:
+      - x-originResponse;dur=52
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-robots-tag:
+      - none
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"messages": [{"role": "user", "content": [{"text": "an earlier question
+      with some length to it", "type": "text"}]}, {"role": "assistant", "content":
+      [{"text": "an earlier answer", "type": "text"}]}, {"role": "user", "content":
+      [{"text": "and one more question", "type": "text", "cache_control": {"type":
+      "ephemeral", "ttl": "5m"}}]}], "model": "claude-sonnet-4-6", "system": [{"type":
+      "text", "text": "You are a terse assistant.", "cache_control": {"type": "ephemeral",
+      "ttl": "5m"}}], "tools": []}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, zstd
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '459'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      x-stainless-async:
+      - 'false'
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages/count_tokens
+  response:
+    body:
+      string: '{"input_tokens":36}'
+    headers:
+      cf-cache-status:
+      - DYNAMIC
+      connection:
+      - keep-alive
+      content-length:
+      - '19'
+      content-security-policy:
+      - default-src 'none'; frame-ancestors 'none'
+      content-type:
+      - application/json
+      date:
+      - Mon, 27 Jul 2026 18:27:40 GMT
+      server:
+      - cloudflare
+      server-timing:
+      - x-originResponse;dur=53
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-robots-tag:
+      - none
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/_vcr/test_provider_openai/test_openai_token_count_uses_endpoint_and_counts_tools.yaml
+++ b/tests/_vcr/test_provider_openai/test_openai_token_count_uses_endpoint_and_counts_tools.yaml
@@ -1,0 +1,119 @@
+interactions:
+- request:
+    body: '{"input": [{"role": "user", "content": [{"type": "input_text", "text":
+      "What is the weather?"}]}], "model": "gpt-5.4"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '109'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      x-stainless-async:
+      - 'false'
+      x-stainless-read-timeout:
+      - '600'
+    method: POST
+    uri: https://api.openai.com/v1/responses/input_tokens
+  response:
+    body:
+      string: "{\n  \"object\": \"response.input_tokens\",\n  \"input_tokens\": 11\n}"
+    headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      connection:
+      - keep-alive
+      content-length:
+      - '61'
+      content-type:
+      - application/json
+      date:
+      - Mon, 27 Jul 2026 18:35:11 GMT
+      openai-processing-ms:
+      - '75'
+      openai-version:
+      - '2020-10-01'
+      server:
+      - cloudflare
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"input": [{"role": "user", "content": [{"type": "input_text", "text":
+      "What is the weather?"}]}], "model": "gpt-5.4", "tools": [{"type": "function",
+      "name": "get_weather", "description": "Get weather for a city.", "parameters":
+      {"properties": {"city": {"type": "string"}}, "required": ["city"], "type": "object",
+      "additionalProperties": false}, "strict": true}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '334'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      x-stainless-async:
+      - 'false'
+      x-stainless-read-timeout:
+      - '600'
+    method: POST
+    uri: https://api.openai.com/v1/responses/input_tokens
+  response:
+    body:
+      string: "{\n  \"object\": \"response.input_tokens\",\n  \"input_tokens\": 47\n}"
+    headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      connection:
+      - keep-alive
+      content-length:
+      - '61'
+      content-type:
+      - application/json
+      date:
+      - Mon, 27 Jul 2026 18:35:11 GMT
+      openai-processing-ms:
+      - '78'
+      openai-version:
+      - '2020-10-01'
+      server:
+      - cloudflare
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/_vcr/test_tokens/test_token_count_method.yaml
+++ b/tests/_vcr/test_tokens/test_token_count_method.yaml
@@ -1,25 +1,82 @@
 interactions:
 - request:
+    body: '{"input": [{"role": "user", "content": [{"type": "input_text", "text":
+      "What is 1 + 1?"}]}], "model": "gpt-4o-mini"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '107'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      x-stainless-async:
+      - 'false'
+      x-stainless-read-timeout:
+      - '600'
+    method: POST
+    uri: https://api.openai.com/v1/responses/input_tokens
+  response:
+    body:
+      string: "{\n  \"object\": \"response.input_tokens\",\n  \"input_tokens\": 15\n}"
+    headers:
+      access-control-expose-headers:
+      - X-Request-ID
+      - CF-Ray
+      - CF-Ray
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      connection:
+      - keep-alive
+      content-length:
+      - '61'
+      content-type:
+      - application/json
+      date:
+      - Mon, 27 Jul 2026 18:36:40 GMT
+      openai-processing-ms:
+      - '303'
+      openai-version:
+      - '2020-10-01'
+      server:
+      - cloudflare
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      transfer-encoding:
+      - chunked
+      x-content-type-options:
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
     body: '{"messages": [{"role": "user", "content": [{"text": "What is 1 + 1?", "type":
       "text", "cache_control": {"type": "ephemeral", "ttl": "5m"}}]}], "model": "claude-haiku-4-5-20251001",
       "tools": []}'
     headers:
-      Accept:
+      accept:
       - application/json
-      Accept-Encoding:
+      accept-encoding:
       - gzip, deflate, zstd
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '177'
-      Content-Type:
-      - application/json
-      Host:
-      - api.anthropic.com
-      X-Stainless-Async:
-      - 'false'
       anthropic-version:
       - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '177'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      x-stainless-async:
+      - 'false'
       x-stainless-read-timeout:
       - '600'
       x-stainless-timeout:
@@ -30,50 +87,48 @@ interactions:
     body:
       string: '{"input_tokens":16}'
     headers:
-      CF-RAY:
-      - 9f79c766ff714c97-MSP
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '19'
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 06 May 2026 17:41:59 GMT
-      Server:
-      - cloudflare
-      X-Robots-Tag:
-      - none
       cf-cache-status:
       - DYNAMIC
+      connection:
+      - keep-alive
+      content-length:
+      - '19'
+      content-security-policy:
+      - default-src 'none'; frame-ancestors 'none'
+      content-type:
+      - application/json
+      date:
+      - Mon, 27 Jul 2026 18:36:40 GMT
+      server:
+      - cloudflare
       server-timing:
-      - x-originResponse;dur=183
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains; preload
-      x-envoy-upstream-service-time:
-      - '181'
+      - x-originResponse;dur=40
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-robots-tag:
+      - none
     status:
       code: 200
       message: OK
 - request:
     body: '{"contents": [{"parts": [{"text": "What is 1 + 1?"}], "role": "user"}]}'
     headers:
-      Accept:
+      accept:
       - '*/*'
-      Accept-Encoding:
+      accept-encoding:
       - gzip, deflate, zstd
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
+      content-length:
       - '71'
-      Content-Type:
+      content-type:
       - application/json
-      Host:
+      host:
       - generativelanguage.googleapis.com
       x-goog-api-client:
-      - google-genai-sdk/1.74.0 gl-python/3.12.11
+      - google-genai-sdk/2.11.0 gl-python/3.12.13
     method: POST
     uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:countTokens
   response:
@@ -81,30 +136,30 @@ interactions:
       string: "{\n  \"totalTokens\": 9,\n  \"promptTokensDetails\": [\n    {\n      \"modality\":
         \"TEXT\",\n      \"tokenCount\": 9\n    }\n  ]\n}\n"
     headers:
-      Alt-Svc:
+      alt-svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
-      Content-Type:
+      content-length:
+      - '115'
+      content-type:
       - application/json; charset=UTF-8
-      Date:
-      - Wed, 06 May 2026 17:41:59 GMT
-      Server:
+      date:
+      - Mon, 27 Jul 2026 18:36:41 GMT
+      server:
       - scaffolding on HTTPServer2
-      Server-Timing:
-      - gfet4t7; dur=51
-      Transfer-Encoding:
+      server-timing:
+      - gfet4t7; dur=70
+      transfer-encoding:
       - chunked
-      Vary:
+      vary:
       - Origin
       - X-Origin
       - Referer
-      X-Content-Type-Options:
+      x-content-type-options:
       - nosniff
-      X-Frame-Options:
+      x-frame-options:
       - SAMEORIGIN
-      X-XSS-Protection:
+      x-xss-protection:
       - '0'
-      content-length:
-      - '115'
     status:
       code: 200
       message: OK

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -5,6 +5,7 @@ import pytest
 from chatlas import (
     AssistantTurn,
     ChatOpenAI,
+    ChatOpenAICompletions,
     ContentToolRequest,
     ContentToolResult,
     ToolRejectError,
@@ -754,3 +755,21 @@ def test_content_add():
 
     # Mismatched types return NotImplemented
     assert a.__add__(t1) is NotImplemented
+
+
+def test_token_count_complete_includes_history_and_system():
+    chat = ChatOpenAICompletions(
+        model="gpt-4o", system_prompt="You are a terse assistant."
+    )
+    new_only = chat.token_count("hello there", include="new")
+
+    chat.set_turns(
+        [
+            UserTurn("a much earlier and quite lengthy question"),
+            AssistantTurn("an earlier answer", tokens=(5, 5, 0)),
+        ]
+    )
+    complete = chat.token_count("hello there", include="complete")
+
+    assert new_only > 0
+    assert complete > new_only

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -773,3 +773,15 @@ def test_token_count_complete_includes_history_and_system():
 
     assert new_only > 0
     assert complete > new_only
+
+
+def test_token_count_invalid_include_raises():
+    chat = ChatOpenAICompletions(model="gpt-4o")
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "Expected `include` to be one of 'new' or 'complete', not 'bad_option'"
+        ),
+    ):
+        chat.token_count("hello", include="bad_option")  # type: ignore

--- a/tests/test_provider_anthropic.py
+++ b/tests/test_provider_anthropic.py
@@ -276,8 +276,11 @@ def test_anthropic_no_uploaded_omits_beta_header():
 
 def test_anthropic_token_count_args_keeps_beta_header():
     provider = AnthropicProvider(model="claude-sonnet-4-6")
+    turn = UserTurn(
+        [ContentUploaded(id="file_1", mime_type="application/pdf", provider="anthropic")]
+    )
     args = provider._token_count_args(
-        ContentUploaded(id="file_1", mime_type="application/pdf", provider="anthropic"),
+        [turn],
         tools={},
         data_model=None,
     )

--- a/tests/test_provider_anthropic.py
+++ b/tests/test_provider_anthropic.py
@@ -371,3 +371,19 @@ def test_anthropic_adaptive_effort_merges_with_structured_output():
     output_config = args["output_config"]
     assert output_config["effort"] == "high"
     assert output_config["format"]["type"] == "json_schema"
+
+
+@pytest.mark.vcr
+def test_anthropic_token_count_complete_exceeds_new():
+    chat = ChatAnthropic(system_prompt="You are a terse assistant.")
+    chat.set_turns(
+        [
+            UserTurn("an earlier question with some length to it"),
+            AssistantTurn("an earlier answer", tokens=(10, 5, 0)),
+        ]
+    )
+    new_only = chat.token_count("and one more question", include="new")
+    complete = chat.token_count("and one more question", include="complete")
+
+    assert new_only > 0
+    assert complete > new_only

--- a/tests/test_provider_openai.py
+++ b/tests/test_provider_openai.py
@@ -164,6 +164,22 @@ def test_openai_pdf():
     assert_pdf_local(ChatOpenAI)
 
 
+@pytest.mark.vcr
+def test_openai_token_count_uses_endpoint_and_counts_tools():
+    def get_weather(city: str) -> str:
+        "Get weather for a city."
+        return "sunny"
+
+    chat = ChatOpenAI()
+    without_tool = chat.token_count("What is the weather?")
+
+    chat.register_tool(get_weather)
+    with_tool = chat.token_count("What is the weather?")
+
+    assert isinstance(without_tool, int) and without_tool > 0
+    assert with_tool > without_tool
+
+
 def test_openai_custom_http_client():
     ChatOpenAI(kwargs={"http_client": httpx.AsyncClient()})
 

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -78,7 +78,7 @@ def test_tokens_method():
 @pytest.mark.vcr
 def test_token_count_method():
     chat = ChatOpenAI(model="gpt-4o-mini")
-    assert chat.token_count("What is 1 + 1?") == 32
+    assert chat.token_count("What is 1 + 1?") == 15
 
     chat = ChatAnthropic(model="claude-haiku-4-5-20251001")
     assert chat.token_count("What is 1 + 1?") == 16


### PR DESCRIPTION
`Chat.token_count()` had no way to distinguish "tokens for just this new input" from "tokens for the whole next request" (history + system prompt included), and `ChatOpenAI()` estimated tokens locally with `tiktoken` — an approximation that ignored registered tools and could drift from what OpenAI actually billed/enforced.

This is aligned with ellmer's [PR #1044](https://github.com/tidyverse/ellmer/pull/1044), which switched `Chat$token_count()` to provider token-counting endpoints (Claude, Google, OpenAI).

This PR:
- Adds `include=` to `Chat.token_count()`: `"new"` (default) counts only the supplied input plus registered tools where the provider supports it; `"complete"` estimates the total input tokens for the next request, including system prompt and history where the provider's counter supports it.
- Switches `ChatOpenAI().token_count()` to OpenAI's `responses.input_tokens.count()` endpoint for exact, tool-aware counts instead of the local `tiktoken` estimate.
- Documents provider-specific caveats (e.g. `ChatGoogle()` still counts message contents only, not tools/system prompt, due to a `google-genai` SDK limitation; Azure's endpoint behavior is called out separately).

**Breaking change:** `Provider.token_count()` / `token_count_async()` (both public, part of the `Provider` extension API) changed signature from `(*args: Content | str, ...)` to `(turns: list[Turn], *, ...)`. This will break any custom `Provider` subclass that overrides these methods. Noted in the CHANGELOG's "Changes" section.

## Test plan

- [x] `pytest` targeted suite (tokens, chat, and touched providers): 166 passed
- [x] `pyright` on all touched files: 0 errors