### PR TITLE
Render thinking and bound long tool results when echoing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug fixes
 
 * `echo="all"` no longer displays tool results twice — once in full as part of the user turn they're attached to, and again on their own.
+* Tool names and argument names are now HTML-escaped in the notebook/shiny rendering of tool requests and results, closing an HTML-injection hole (both are model-controlled).
 
 ## [0.20.0] - 2026-07-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug fixes
 
 * `echo="all"` no longer displays tool results twice — once in full as part of the user turn they're attached to, and again on their own.
+* `Chat.set_echo_options(css_styles=)` now actually applies in notebooks: the styles were previously attached to a CSS sibling selector that could never match the wrapper they were meant to style.
 * Tool names and argument names are now HTML-escaped in the notebook/shiny rendering of tool requests and results, closing an HTML-injection hole (both are model-controlled).
 
 ## [0.20.0] - 2026-07-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Reasoning is now visible when echoing. Previously, thinking content was wrapped in literal `<thinking>` tags that a markdown renderer treated as an HTML block and dropped, so reasoning never appeared at all — even with `echo="all"`. It now renders in a "Thinking" panel in the console, and in a `<details>` block in notebooks that stays expanded while reasoning streams in and collapses once it's done. `echo="text"` continues to show only the assistant's answer. (#361)
 * Long tool results no longer dominate the display. In notebooks they render collapsed, with the same look shinychat uses, and scroll internally beyond a bounded height once expanded. In the console they're truncated with a count of the dropped lines. Either way a big tool result now costs a fixed amount of vertical space, and the full value remains on the turn. `Chat.set_echo_options()` gained `tool_result_max_lines` (console, default 20) and `tool_result_max_height` (notebook, default `"400px"`) to tune this. (#361)
+* Long reasoning is likewise bounded in the console, capped at `thinking_max_lines` (default 10). Unlike a tool result it's cropped from the *top*, keeping the newest reasoning — cropping the other way would pin the panel to text you've already read while new text streamed in unseen. The title reports how many earlier lines were dropped. The cap counts rendered (wrapped) lines rather than newlines, since reasoning is prose that wraps well past its own line count, so the dropped count stays correct at any console width.
+* All three echo size options (`tool_result_max_lines`, `tool_result_max_height`, `thinking_max_lines`) accept `None` to turn the bound off entirely.
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -->
 
 
+## [UNRELEASED]
+
+### Improvements
+
+* Reasoning is now visible when echoing. Previously, thinking content was wrapped in literal `<thinking>` tags that a markdown renderer treated as an HTML block and dropped, so reasoning never appeared at all — even with `echo="all"`. It now renders in a "Thinking" panel in the console, and in a `<details>` block in notebooks that stays expanded while reasoning streams in and collapses once it's done. `echo="text"` continues to show only the assistant's answer. (#361)
+* Long tool results no longer dominate the display. In notebooks they render collapsed, with the same look shinychat uses, and scroll internally beyond a bounded height once expanded. In the console they're truncated with a count of the dropped lines. Either way a big tool result now costs a fixed amount of vertical space, and the full value remains on the turn. `Chat.set_echo_options()` gained `tool_result_max_lines` (console, default 20) and `tool_result_max_height` (notebook, default `"400px"`) to tune this. (#361)
+
+### Bug fixes
+
+* `echo="all"` no longer displays tool results twice — once in full as part of the user turn they're attached to, and again on their own.
+
 ## [0.20.0] - 2026-07-29
 
 ### New features

--- a/chatlas/_chat.py
+++ b/chatlas/_chat.py
@@ -81,7 +81,13 @@ from ._turn import (
 )
 from ._turn_accumulator import TurnAccumulator
 from ._typing_extensions import TypedDict, TypeGuard
-from ._utils import MISSING, MISSING_TYPE, html_escape, wrap_async
+from ._utils import (
+    MISSING,
+    MISSING_TYPE,
+    default_if_missing,
+    html_escape,
+    wrap_async,
+)
 
 if TYPE_CHECKING:
     from inspect_ai.model import ChatMessage as InspectChatMessage
@@ -3317,6 +3323,9 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         """
         Set echo styling options for the chat.
 
+        Note that each call replaces *all* of the options: anything not passed
+        reverts to its default rather than keeping a previously set value.
+
         Parameters
         ----------
         rich_markdown
@@ -3535,18 +3544,6 @@ def emit_user_contents(
     emit(f"## 👤 User turn:\n\n{x.text}\n\n")
     emit_other_contents(x, emit)
     emit("\n\n## 🤖 Assistant turn:\n\n")
-
-
-def default_if_missing(value: "T | None | MISSING_TYPE", default: T) -> Optional[T]:
-    """
-    Resolve an echo size option, keeping `None` distinct from "not passed".
-
-    `None` is meaningful for these -- it turns the bound off -- so it can't
-    double as the "use the default" signal.
-    """
-    if isinstance(value, MISSING_TYPE):
-        return default
-    return value
 
 
 def emit_thinking_contents(

--- a/chatlas/_chat.py
+++ b/chatlas/_chat.py
@@ -47,6 +47,8 @@ from ._content import (
     ToolInfo,
 )
 from ._display import (
+    DEFAULT_TOOL_RESULT_MAX_HEIGHT,
+    DEFAULT_TOOL_RESULT_MAX_LINES,
     EchoDisplayOptions,
     IPyMarkdownDisplay,
     LiveMarkdownDisplay,
@@ -186,11 +188,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         self._on_tool_request_callbacks = CallbackManager()
         self._on_tool_result_callbacks = CallbackManager()
         self._current_display: Optional[MarkdownDisplay] = None
-        self._echo_options: EchoDisplayOptions = {
-            "rich_markdown": {},
-            "rich_console": {},
-            "css_styles": {},
-        }
+        self.set_echo_options()
         self._mcp_manager = MCPSessionManager()
 
         # Chat input parameters from `set_model_params()`
@@ -2322,7 +2320,9 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
 
         This is primarily useful if you want to add custom content to the
         display while the chat is running, but currently blocked by something
-        like a tool call.
+        like a tool call. Its `.echo()` method takes a markdown string, or a
+        [](`~chatlas.types.Content`) object to have it rendered the way the chat
+        itself would render it.
 
         Example
         -------
@@ -2362,7 +2362,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         """
         return self._current_display
 
-    def _echo_content(self, x: str):
+    def _echo_content(self, x: str | Content):
         if self._current_display:
             self._current_display.echo(x)
 
@@ -2693,13 +2693,13 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
                         if tool is not None:
                             x.tool = ToolInfo.from_tool(tool)
                         if echo == "output":
-                            self._echo_content(f"\n\n{x}\n\n")
+                            self._echo_content(x)
                         if content == "all":
                             yield x
                         results = self._invoke_tool(x, _otel_parent=agent_span)
                         for res in results:
                             if echo == "output":
-                                self._echo_content(f"\n\n{res}\n\n")
+                                self._echo_content(res)
                             if content == "all":
                                 yield res
                             all_results.append(res)
@@ -2784,13 +2784,13 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
                         if tool is not None:
                             x.tool = ToolInfo.from_tool(tool)
                         if echo == "output":
-                            self._echo_content(f"\n\n{x}\n\n")
+                            self._echo_content(x)
                         if content == "all":
                             yield x
                         results = self._invoke_tool_async(x, _otel_parent=agent_span)
                         async for res in results:
                             if echo == "output":
-                                self._echo_content(f"\n\n{res}\n\n")
+                                self._echo_content(res)
                             if content == "all":
                                 yield res
                             else:
@@ -2853,8 +2853,14 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         )
         try:
 
-            def emit(text: str | Content):
-                self._echo_content(str(text))
+            def emit(x: str | Content):
+                # `echo="text"` means just the assistant's answer, so reasoning is
+                # held back the same way tool content is.
+                if echo == "text" and isinstance(
+                    x, (ContentThinking, ContentThinkingDelta)
+                ):
+                    return
+                self._echo_content(x)
 
             emit("<br>\n\n")
 
@@ -2928,6 +2934,8 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
                 turn = self.provider.value_turn(
                     response, has_data_model=data_model is not None
                 )
+                emit_thinking_contents(turn, emit)
+
                 if turn.text:
                     emit(turn.text)
                     yield turn.text
@@ -2989,8 +2997,14 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         )
         try:
 
-            def emit(text: str | Content):
-                self._echo_content(str(text))
+            def emit(x: str | Content):
+                # `echo="text"` means just the assistant's answer, so reasoning is
+                # held back the same way tool content is.
+                if echo == "text" and isinstance(
+                    x, (ContentThinking, ContentThinkingDelta)
+                ):
+                    return
+                self._echo_content(x)
 
             emit("<br>\n\n")
 
@@ -3066,6 +3080,8 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
                 turn = self.provider.value_turn(
                     response, has_data_model=data_model is not None
                 )
+                emit_thinking_contents(turn, emit)
+
                 if turn.text:
                     emit(turn.text)
                     yield turn.text
@@ -3271,7 +3287,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         screen sizes.
         """
         if echo == "none":
-            return ChatMarkdownDisplay(MockMarkdownDisplay(), self)
+            return ChatMarkdownDisplay(MockMarkdownDisplay(self._echo_options), self)
 
         # rich does a lot to detect a notebook environment, but it doesn't
         # detect Quarto, or a Positron notebook
@@ -3293,6 +3309,8 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         rich_markdown: Optional[dict[str, Any]] = None,
         rich_console: Optional[dict[str, Any]] = None,
         css_styles: Optional[dict[str, str]] = None,
+        tool_result_max_lines: Optional[int] = None,
+        tool_result_max_height: Optional[str] = None,
     ):
         """
         Set echo styling options for the chat.
@@ -3308,11 +3326,27 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         css_styles
             A dictionary of CSS styles to apply to `IPython.display.Markdown()`.
             This is only relevant when outputing to the browser.
+        tool_result_max_lines
+            Truncate an echoed tool result to this many lines, noting how many
+            were dropped. The full value remains available on the turn. This is
+            only relevant when outputting to the console.
+        tool_result_max_height
+            A CSS length (e.g. `"400px"`) bounding the height of an echoed tool
+            result, which scrolls internally beyond it. This is only relevant
+            when outputting to the browser.
         """
         self._echo_options: EchoDisplayOptions = {
             "rich_markdown": rich_markdown or {},
             "rich_console": rich_console or {},
             "css_styles": css_styles or {},
+            "tool_result_max_lines": (
+                tool_result_max_lines
+                if tool_result_max_lines is not None
+                else DEFAULT_TOOL_RESULT_MAX_LINES
+            ),
+            "tool_result_max_height": (
+                tool_result_max_height or DEFAULT_TOOL_RESULT_MAX_HEIGHT
+            ),
         }
 
     def __str__(self):
@@ -3487,17 +3521,41 @@ def emit_user_contents(
 ):
     if x.role != "user":
         raise ValueError("Expected a user turn")
-    emit(f"## 👤 User turn:\n\n{str(x)}\n\n")
+    # Only the text: `emit_other_contents()` handles the rest, and routing those
+    # as objects rather than through `str(x)` is what lets the display bound them.
+    emit(f"## 👤 User turn:\n\n{x.text}\n\n")
     emit_other_contents(x, emit)
     emit("\n\n## 🤖 Assistant turn:\n\n")
+
+
+def emit_thinking_contents(
+    x: Turn,
+    emit: Callable[[Content | str], None],
+):
+    """
+    Emit a non-streamed turn's reasoning, ahead of its text.
+
+    The streaming path displays reasoning as it arrives; this is the non-streaming
+    equivalent. `emit()` decides whether the current echo mode wants it.
+    """
+    for content in x.contents:
+        if isinstance(content, ContentThinking):
+            emit(content)
 
 
 def emit_other_contents(
     x: Turn,
     emit: Callable[[Content | str], None],
 ):
+    """
+    Emit everything in the turn other than its text.
+
+    Reasoning is excluded: it's displayed as it arrives (streaming) or explicitly
+    before the text (non-streaming), so emitting it from the turn's contents too
+    would show it twice.
+    """
     # Gather other content to emit in _reverse_ order
-    to_emit: list[str] = []
+    to_emit: list[Content | str] = []
 
     if isinstance(x, AssistantTurn) and x.finish_reason:
         to_emit.append(f"\n\n<< 🤖 finish reason: {x.finish_reason} \\>\\>\n\n")
@@ -3507,9 +3565,11 @@ def emit_other_contents(
     for content in reversed(x.contents):
         if isinstance(content, ContentText):
             has_text = True
+        elif isinstance(content, (ContentThinking, ContentThinkingDelta)):
+            continue
         else:
             has_other = True
-            to_emit.append(str(content))
+            to_emit.append(content)
 
     if has_text and has_other:
         if isinstance(x, UserTurn):
@@ -3519,7 +3579,10 @@ def emit_other_contents(
 
     to_emit.reverse()
 
-    emit("\n\n".join(to_emit))
+    for i, content in enumerate(to_emit):
+        if i > 0:
+            emit("\n\n")
+        emit(content)
 
 
 # Helper/wrapper class to let Chat know about the currently active display

--- a/chatlas/_chat.py
+++ b/chatlas/_chat.py
@@ -47,6 +47,7 @@ from ._content import (
     ToolInfo,
 )
 from ._display import (
+    DEFAULT_THINKING_MAX_LINES,
     DEFAULT_TOOL_RESULT_MAX_HEIGHT,
     DEFAULT_TOOL_RESULT_MAX_LINES,
     EchoDisplayOptions,
@@ -3309,8 +3310,9 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         rich_markdown: Optional[dict[str, Any]] = None,
         rich_console: Optional[dict[str, Any]] = None,
         css_styles: Optional[dict[str, str]] = None,
-        tool_result_max_lines: Optional[int] = None,
-        tool_result_max_height: Optional[str] = None,
+        tool_result_max_lines: int | None | MISSING_TYPE = MISSING,
+        tool_result_max_height: str | None | MISSING_TYPE = MISSING,
+        thinking_max_lines: int | None | MISSING_TYPE = MISSING,
     ):
         """
         Set echo styling options for the chat.
@@ -3328,24 +3330,31 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
             This is only relevant when outputing to the browser.
         tool_result_max_lines
             Truncate an echoed tool result to this many lines, noting how many
-            were dropped. The full value remains available on the turn. This is
-            only relevant when outputting to the console.
+            were dropped. The full value remains available on the turn. Pass
+            `None` to echo it in full. This is only relevant when outputting to
+            the console.
         tool_result_max_height
             A CSS length (e.g. `"400px"`) bounding the height of an echoed tool
-            result, which scrolls internally beyond it. This is only relevant
-            when outputting to the browser.
+            result, which scrolls internally beyond it. Pass `None` to let it
+            grow. This is only relevant when outputting to the browser.
+        thinking_max_lines
+            Cap echoed reasoning at this many lines, keeping the most recent and
+            noting how many earlier ones were dropped. Pass `None` to echo it in
+            full. This is only relevant when outputting to the console; in the
+            browser, reasoning collapses on its own once it's complete.
         """
         self._echo_options: EchoDisplayOptions = {
             "rich_markdown": rich_markdown or {},
             "rich_console": rich_console or {},
             "css_styles": css_styles or {},
-            "tool_result_max_lines": (
-                tool_result_max_lines
-                if tool_result_max_lines is not None
-                else DEFAULT_TOOL_RESULT_MAX_LINES
+            "tool_result_max_lines": default_if_missing(
+                tool_result_max_lines, DEFAULT_TOOL_RESULT_MAX_LINES
             ),
-            "tool_result_max_height": (
-                tool_result_max_height or DEFAULT_TOOL_RESULT_MAX_HEIGHT
+            "tool_result_max_height": default_if_missing(
+                tool_result_max_height, DEFAULT_TOOL_RESULT_MAX_HEIGHT
+            ),
+            "thinking_max_lines": default_if_missing(
+                thinking_max_lines, DEFAULT_THINKING_MAX_LINES
             ),
         }
 
@@ -3526,6 +3535,18 @@ def emit_user_contents(
     emit(f"## 👤 User turn:\n\n{x.text}\n\n")
     emit_other_contents(x, emit)
     emit("\n\n## 🤖 Assistant turn:\n\n")
+
+
+def default_if_missing(value: "T | None | MISSING_TYPE", default: T) -> Optional[T]:
+    """
+    Resolve an echo size option, keeping `None` distinct from "not passed".
+
+    `None` is meaningful for these -- it turns the bound off -- so it can't
+    double as the "use the default" signal.
+    """
+    if isinstance(value, MISSING_TYPE):
+        return default
+    return value
 
 
 def emit_thinking_contents(

--- a/chatlas/_content.py
+++ b/chatlas/_content.py
@@ -360,7 +360,7 @@ class ContentToolRequest(Content):
                 "but htmltools is not installed. ",
             )
 
-        html = f"<p></p><span class='chatlas-tool-request'>🔧 Running tool: <code>{self.name}</code></span>"
+        html = f"<p></p><span class='chatlas-tool-request'>🔧 Running tool: <code>{html_escape(self.name, attr=False)}</code></span>"
 
         return TagList(
             HTML(html),
@@ -596,8 +596,13 @@ class ContentToolResult(Content):
         """
 
         # Helper function to format code blocks (optionally with labels for arguments).
+        # Labels are argument names, which come from the model's tool call, so they
+        # need escaping just like the values do.
         def pre_code(code: str, label: str | None = None) -> str:
-            lbl = f"<span class='input-parameter-label'>{label}</span>" if label else ""
+            if label:
+                lbl = f"<span class='input-parameter-label'>{html_escape(label, attr=False)}</span>"
+            else:
+                lbl = ""
             return f"<pre>{lbl}<code>{html_escape(code, attr=False)}</code></pre>"
 
         # Helper function to wrap content in a <details> block.
@@ -629,11 +634,13 @@ class ContentToolResult(Content):
         # Put both the result and parameters into a container
         result_div = f'<div class="chatlas-tool-result-content">{result}{params}</div>'
 
-        # Header for the top-level result details block.
+        # Header for the top-level result details block. The tool name is
+        # model-controlled, so it gets escaped too.
+        name = html_escape(self.name, attr=False)
         if not self.error:
-            header = f"Result from tool call: <code>{self.name}</code>"
+            header = f"Result from tool call: <code>{name}</code>"
         else:
-            header = f"❌ Failed to call tool <code>{self.name}</code>"
+            header = f"❌ Failed to call tool <code>{name}</code>"
 
         res = details_block(header, result_div, open_=False)
 

--- a/chatlas/_content.py
+++ b/chatlas/_content.py
@@ -17,6 +17,7 @@ from pydantic import (
 )
 
 from ._typing_extensions import TypedDict
+from ._utils import html_escape, truncate_lines
 
 if TYPE_CHECKING:
     from htmltools import Tagified
@@ -463,9 +464,23 @@ class ContentToolResult(Content):
         return self.request.arguments
 
     def __str__(self):
+        return self.to_display_markdown()
+
+    def to_display_markdown(self, max_lines: Optional[int] = None) -> str:
+        """
+        Render as a fenced code block, optionally capping the value's height.
+
+        Parameters
+        ----------
+        max_lines
+            Truncate the value to this many lines, replacing the remainder with a
+            count of what was dropped. `None` (the default) emits the full value.
+        """
         prefix = "✅ tool result" if not self.error else "❌ tool error"
         comment = f"# {prefix} ({self.id})"
         value = self._get_display_value()
+        if max_lines is not None:
+            value = truncate_lines(value, max_lines)
         return f"""```python\n{comment}\n{value}\n```"""
 
     # Format the value for display purposes
@@ -554,22 +569,36 @@ class ContentToolResult(Content):
         return orjson.dumps(value).decode("utf-8")
 
     def _repr_html_(self):
-        return str(self.tagify())
+        return self.to_html()
 
     def tagify(self) -> Tagified:
         "A method for rendering this object via htmltools/shiny."
         try:
-            from htmltools import HTML, html_escape
+            from htmltools import HTML, TagList, head_content, tags
         except ImportError:
             raise ImportError(
                 ".tagify() is only intended to be called by htmltools/shiny, ",
                 "but htmltools is not installed. ",
             )
 
+        return TagList(
+            HTML(self.to_html()),
+            head_content(tags.style(TOOL_CSS)),
+        ).tagify()
+
+    def to_html(self) -> str:
+        """
+        Render as an HTML string.
+
+        Shared by `.tagify()` (shinychat) and the notebook echo display, so the two
+        can't drift. Requires `TOOL_CSS` to be present on the page. The result is
+        collapsed; `TOOL_CSS` bounds its height once expanded.
+        """
+
         # Helper function to format code blocks (optionally with labels for arguments).
         def pre_code(code: str, label: str | None = None) -> str:
             lbl = f"<span class='input-parameter-label'>{label}</span>" if label else ""
-            return f"<pre>{lbl}<code>{html_escape(code)}</code></pre>"
+            return f"<pre>{lbl}<code>{html_escape(code, attr=False)}</code></pre>"
 
         # Helper function to wrap content in a <details> block.
         def details_block(summary: str, content: str, open_: bool = True) -> str:
@@ -608,7 +637,7 @@ class ContentToolResult(Content):
 
         res = details_block(header, result_div, open_=False)
 
-        return HTML(f'<div class="chatlas-tool-result">{res}</div>')
+        return f'<div class="chatlas-tool-result">{res}</div>'
 
     def _arguments_str(self) -> str:
         if isinstance(self.arguments, dict):
@@ -1117,6 +1146,14 @@ TOOL_CSS = """
 
 .chatlas-tool-result-content pre, .chatlas-tool-result-content code {
   background-color: var(--bs-body-bg, white) !important;
+}
+
+/* Bound a large result so it costs a fixed amount of vertical space.
+   Consumers override the height by setting the custom property on an ancestor
+   (chatlas' notebook display does this from set_echo_options()). */
+.chatlas-tool-result-content pre {
+  max-height: var(--chatlas-tool-result-max-height, 400px);
+  overflow-y: auto;
 }
 
 .chatlas-tool-result-content .input-parameter-label {

--- a/chatlas/_display.py
+++ b/chatlas/_display.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional, Union
 from uuid import uuid4
 
-from rich._loop import loop_last
 from rich.live import Live
 from rich.logging import RichHandler
 
@@ -241,7 +240,9 @@ class IPyMarkdownDisplay(MarkdownDisplay):
                 "Install it with `pip install ipython`."
             )
 
-        max_height = self._echo_options["tool_result_max_height"]
+        # `none` (the CSS keyword) rather than omitting the property, which
+        # would fall through to the 400px fallback baked into TOOL_CSS.
+        max_height = self._echo_options["tool_result_max_height"] or "none"
         wrapper_style = f"--chatlas-tool-result-max-height: {max_height}"
 
         if self._css_styles:
@@ -356,10 +357,10 @@ class ThinkingPanel:
                     kept.pop(0)
                     dropped += 1
                 segments: list[Segment] = []
-                for last, line in loop_last(kept):
-                    segments.extend(line)
-                    if not last:
+                for i, line in enumerate(kept):
+                    if i > 0:
                         segments.append(Segment.line())
+                    segments.extend(line)
                 body = Segments(segments)
                 plural = "" if dropped == 1 else "s"
                 title = f"Thinking (… {dropped} earlier line{plural})"

--- a/chatlas/_display.py
+++ b/chatlas/_display.py
@@ -1,44 +1,111 @@
 import logging
 from abc import ABC, abstractmethod
-from typing import Any
+from dataclasses import dataclass
+from typing import Any, Union
 from uuid import uuid4
 
 from rich.live import Live
 from rich.logging import RichHandler
 
+from ._content import (
+    TOOL_CSS,
+    Content,
+    ContentText,
+    ContentThinking,
+    ContentThinkingDelta,
+    ContentToolResult,
+)
 from ._live_render import LiveRender
 from ._logging import logger
 from ._typing_extensions import TypedDict
 
 
 class MarkdownDisplay(ABC):
-    """Base class for displaying markdown content in different environments."""
+    """
+    Base class for displaying markdown content in different environments.
+
+    Accumulates what it's told to display as a list of segments rather than one
+    string, so subclasses can render each content type on its own terms —
+    reasoning as a collapsible/dimmed aside, a large tool result inside a bounded
+    container, everything else as markdown.
+    """
+
+    def __init__(self, echo_options: "EchoDisplayOptions"):
+        self._echo_options = echo_options
+        self._segments: list["Segment"] = []
+
+    def echo(self, content: Union[str, Content]):
+        """
+        Display the provided content. This will append the content to the
+        current display.
+        """
+        self._append(content)
+        self._render()
 
     @abstractmethod
-    def echo(self, content: str):
-        """
-        Display the provided markdown string. This will append the content
-        to the current display.
-        """
-        pass
+    def _render(self) -> None:
+        """Repaint the accumulated segments."""
 
-    @abstractmethod
+    def _append(self, content: Union[str, Content]) -> None:
+        if isinstance(content, ContentThinking):
+            # A complete block, so there's nothing left to stream into it.
+            self._segments.append(
+                ThinkingSegment(thinking=content.thinking, is_open=False)
+            )
+            return
+
+        if isinstance(content, ContentThinkingDelta):
+            self._append_thinking_delta(content)
+            return
+
+        # Anything else means reasoning is over, even if the provider never sent
+        # a closing delta.
+        self._close_thinking()
+
+        if isinstance(content, ContentText):
+            content = content.text
+
+        if isinstance(content, str):
+            last = self._segments[-1] if self._segments else None
+            if isinstance(last, TextSegment):
+                last.text += content
+            else:
+                self._segments.append(TextSegment(text=content))
+        else:
+            self._segments.append(ContentSegment(content=content))
+
+    def _append_thinking_delta(self, content: ContentThinkingDelta) -> None:
+        last = self._segments[-1] if self._segments else None
+        segment = last if isinstance(last, ThinkingSegment) and last.is_open else None
+
+        if segment is None:
+            # A stray closing delta has nothing to close.
+            if content.phase == "end":
+                return
+            segment = ThinkingSegment()
+            self._segments.append(segment)
+
+        segment.thinking += content.thinking
+        if content.phase == "end":
+            segment.is_open = False
+
+    def _close_thinking(self) -> None:
+        last = self._segments[-1] if self._segments else None
+        if isinstance(last, ThinkingSegment):
+            last.is_open = False
+
     def __enter__(self) -> "MarkdownDisplay":
-        pass
-
-    @abstractmethod
-    def __exit__(self, exc_type, exc_value, traceback):
-        pass
-
-
-class MockMarkdownDisplay(MarkdownDisplay):
-    def echo(self, content: str):
-        pass
-
-    def __enter__(self):
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
+        self._segments = []
+
+
+class MockMarkdownDisplay(MarkdownDisplay):
+    def echo(self, content: Union[str, Content]):
+        pass
+
+    def _render(self) -> None:
         pass
 
 
@@ -50,7 +117,8 @@ class LiveMarkdownDisplay(MarkdownDisplay):
     def __init__(self, echo_options: "EchoDisplayOptions"):
         from rich.console import Console
 
-        self.content: str = ""
+        super().__init__(echo_options)
+
         live = Live(
             auto_refresh=False,
             console=Console(
@@ -69,17 +137,52 @@ class LiveMarkdownDisplay(MarkdownDisplay):
 
         self._markdown_options = echo_options["rich_markdown"]
 
-    def echo(self, content: str):
+    def _render(self) -> None:
+        from rich.console import Group
+        from rich.text import Text
+
+        # rich puts no space between the members of a Group, but the accumulated
+        # markdown this replaced had blank lines between blocks. Restore them so
+        # a panel or tool result doesn't abut the text around it.
+        spaced: list[Any] = []
+        for renderable in self._renderables():
+            if spaced:
+                spaced.append(Text(""))
+            spaced.append(renderable)
+
+        self.live.update(Group(*spaced), refresh=True)
+
+    def _renderables(self) -> list[Any]:
+        from rich.panel import Panel
+
+        out: list[Any] = []
+        for segment in self._segments:
+            if isinstance(segment, TextSegment):
+                out.append(self._markdown(segment.text))
+            elif isinstance(segment, ThinkingSegment):
+                out.append(
+                    Panel(
+                        self._markdown(segment.thinking),
+                        title="Thinking",
+                        title_align="left",
+                        border_style="dim",
+                    )
+                )
+            else:
+                out.append(self._markdown(self._content_markdown(segment.content)))
+        return out
+
+    def _content_markdown(self, content: Content) -> str:
+        if isinstance(content, ContentToolResult):
+            return content.to_display_markdown(
+                max_lines=self._echo_options["tool_result_max_lines"]
+            )
+        return str(content)
+
+    def _markdown(self, text: str) -> Any:
         from rich.markdown import Markdown
 
-        self.content += content
-        self.live.update(
-            Markdown(
-                self.content,
-                **self._markdown_options,
-            ),
-            refresh=True,
-        )
+        return Markdown(text, **self._markdown_options)
 
     def __enter__(self):
         self.live.__enter__()
@@ -95,7 +198,7 @@ class LiveMarkdownDisplay(MarkdownDisplay):
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        self.content = ""
+        super().__exit__(exc_type, exc_value, traceback)
         return self.live.__exit__(exc_type, exc_value, traceback)
 
 
@@ -104,18 +207,30 @@ class IPyMarkdownDisplay(MarkdownDisplay):
     Stream chunks of markdown into an IPython notebook.
     """
 
-    def __init__(self, echo_options: "EchoDisplayOptions"):
-        self.content: str = ""
-        self._css_styles = echo_options["css_styles"]
-
-    def echo(self, content: str):
+    def _render(self) -> None:
         from IPython.display import Markdown, update_display
 
-        self.content += content
         update_display(
-            Markdown(self.content),
+            Markdown(self._markdown()),
             display_id=self._ipy_display_id,
         )
+
+    def _markdown(self) -> str:
+        parts: list[str] = []
+        for segment in self._segments:
+            if isinstance(segment, TextSegment):
+                parts.append(segment.text)
+            elif isinstance(segment, ThinkingSegment):
+                parts.append(thinking_html(segment.thinking, is_open=segment.is_open))
+            else:
+                parts.append(self._content_markdown(segment.content))
+        return "".join(parts)
+
+    def _content_markdown(self, content: Content) -> str:
+        if isinstance(content, ContentToolResult):
+            # Already collapsed, and TOOL_CSS bounds its height once expanded.
+            return f"\n\n{content.to_html()}\n\n"
+        return f"\n\n{content}\n\n"
 
     def _init_display(self) -> str:
         try:
@@ -126,26 +241,43 @@ class IPyMarkdownDisplay(MarkdownDisplay):
                 "Install it with `pip install ipython`."
             )
 
+        max_height = self._echo_options["tool_result_max_height"]
+        wrapper_style = f"--chatlas-tool-result-max-height: {max_height}"
+
         if self._css_styles:
             id_ = uuid4().hex
             css = "".join(f"{k}: {v}; " for k, v in self._css_styles.items())
-            display(HTML(f"<style>#{id_} + .chatlas-markdown {{ {css} }}</style>"))
-            display(HTML(f"<div id='{id_}' class='chatlas-markdown'>"))
+            display(
+                HTML(
+                    f"<style>{TOOL_CSS}\n#{id_} + .chatlas-markdown {{ {css} }}</style>"
+                )
+            )
+            display(
+                HTML(
+                    f"<div id='{id_}' class='chatlas-markdown' style='{wrapper_style}'>"
+                )
+            )
         else:
+            display(HTML(f"<style>{TOOL_CSS}</style>"))
             # Unfortunately, there doesn't seem to be a proper way to wrap
             # Markdown() in a div?
-            display(HTML("<div class='chatlas-markdown'>"))
+            display(HTML(f"<div class='chatlas-markdown' style='{wrapper_style}'>"))
 
         handle = display(Markdown(""), display_id=True)
         if handle is None:
             raise ValueError("Failed to create display handle")
         return handle.display_id
 
+    @property
+    def _css_styles(self) -> dict[str, str]:
+        return self._echo_options["css_styles"]
+
     def __enter__(self):
         self._ipy_display_id = self._init_display()
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
+        super().__exit__(exc_type, exc_value, traceback)
         self._ipy_display_id = None
 
 
@@ -153,3 +285,43 @@ class EchoDisplayOptions(TypedDict):
     rich_markdown: dict[str, Any]
     rich_console: dict[str, Any]
     css_styles: dict[str, str]
+    tool_result_max_lines: int
+    tool_result_max_height: str
+
+
+DEFAULT_TOOL_RESULT_MAX_LINES = 20
+DEFAULT_TOOL_RESULT_MAX_HEIGHT = "400px"
+
+
+def thinking_html(thinking: str, is_open: bool) -> str:
+    """
+    Wrap reasoning in a `<details>` block.
+
+    The blank lines matter: they end the opening HTML block so the body is still
+    markdown-rendered (CommonMark html block type 6), which is the same thing
+    `Chat.export()` relies on for its system prompt block.
+    """
+    open_attr = " open" if is_open else ""
+    return (
+        f"\n\n<details{open_attr}><summary>Thinking</summary>"
+        f"\n\n{thinking}\n\n</details>\n\n"
+    )
+
+
+@dataclass
+class TextSegment:
+    text: str = ""
+
+
+@dataclass
+class ThinkingSegment:
+    thinking: str = ""
+    is_open: bool = True
+
+
+@dataclass
+class ContentSegment:
+    content: Content
+
+
+Segment = Union[TextSegment, ThinkingSegment, ContentSegment]

--- a/chatlas/_display.py
+++ b/chatlas/_display.py
@@ -248,10 +248,10 @@ class IPyMarkdownDisplay(MarkdownDisplay):
         if self._css_styles:
             id_ = uuid4().hex
             css = "".join(f"{k}: {v}; " for k, v in self._css_styles.items())
+            # A compound selector (no combinator): id and class are on the same
+            # element, the wrapper div displayed just below.
             display(
-                HTML(
-                    f"<style>{TOOL_CSS}\n#{id_} + .chatlas-markdown {{ {css} }}</style>"
-                )
+                HTML(f"<style>{TOOL_CSS}\n#{id_}.chatlas-markdown {{ {css} }}</style>")
             )
             display(
                 HTML(

--- a/chatlas/_display.py
+++ b/chatlas/_display.py
@@ -1,11 +1,15 @@
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 from uuid import uuid4
 
+from rich._loop import loop_last
 from rich.live import Live
 from rich.logging import RichHandler
+
+if TYPE_CHECKING:
+    from rich.console import Console, ConsoleOptions
 
 from ._content import (
     TOOL_CSS,
@@ -32,7 +36,7 @@ class MarkdownDisplay(ABC):
 
     def __init__(self, echo_options: "EchoDisplayOptions"):
         self._echo_options = echo_options
-        self._segments: list["Segment"] = []
+        self._segments: list["DisplaySegment"] = []
 
     def echo(self, content: Union[str, Content]):
         """
@@ -153,19 +157,15 @@ class LiveMarkdownDisplay(MarkdownDisplay):
         self.live.update(Group(*spaced), refresh=True)
 
     def _renderables(self) -> list[Any]:
-        from rich.panel import Panel
-
         out: list[Any] = []
         for segment in self._segments:
             if isinstance(segment, TextSegment):
                 out.append(self._markdown(segment.text))
             elif isinstance(segment, ThinkingSegment):
                 out.append(
-                    Panel(
+                    ThinkingPanel(
                         self._markdown(segment.thinking),
-                        title="Thinking",
-                        title_align="left",
-                        border_style="dim",
+                        max_lines=self._echo_options["thinking_max_lines"],
                     )
                 )
             else:
@@ -285,12 +285,16 @@ class EchoDisplayOptions(TypedDict):
     rich_markdown: dict[str, Any]
     rich_console: dict[str, Any]
     css_styles: dict[str, str]
-    tool_result_max_lines: int
-    tool_result_max_height: str
+    tool_result_max_lines: Optional[int]
+    tool_result_max_height: Optional[str]
+    thinking_max_lines: Optional[int]
 
 
 DEFAULT_TOOL_RESULT_MAX_LINES = 20
 DEFAULT_TOOL_RESULT_MAX_HEIGHT = "400px"
+# Lower than the tool-result cap on purpose: reasoning is an aside, so it should
+# take up less room than the answer it precedes.
+DEFAULT_THINKING_MAX_LINES = 10
 
 
 def thinking_html(thinking: str, is_open: bool) -> str:
@@ -306,6 +310,61 @@ def thinking_html(thinking: str, is_open: bool) -> str:
         f"\n\n<details{open_attr}><summary>Thinking</summary>"
         f"\n\n{thinking}\n\n</details>\n\n"
     )
+
+
+class ThinkingPanel:
+    """
+    A panel of reasoning, capped at `max_lines` by dropping the *oldest* lines.
+
+    Two things make this different from truncating a tool result:
+
+    - It counts *wrapped* lines, not source lines. Reasoning is prose, so it
+      wraps well past its own newline count (a real Anthropic sample: 35
+      newlines, 44 rendered lines at width 70) and some providers send no
+      newlines at all. So the cap has to render first and crop the result,
+      which also can't break the markdown the way slicing the source could
+      (e.g. halving a code fence).
+    - It keeps the tail rather than the head. The newest reasoning is what's
+      streaming in; cropping the other way would pin the panel to text the
+      reader has already finished, and look like a hang.
+    """
+
+    def __init__(self, body: Any, max_lines: Optional[int]):
+        self.body = body
+        self.max_lines = max_lines
+
+    def __rich_console__(self, console: "Console", options: "ConsoleOptions"):
+        from rich.panel import Panel
+        from rich.segment import Segment, Segments
+
+        title = "Thinking"
+        body = self.body
+
+        if self.max_lines is not None:
+            # Clamped to >=1 because `lines[-0:]` is the whole list, so a cap of 0
+            # would keep everything while the title claimed it all got dropped.
+            keep = max(1, self.max_lines)
+            # Panel spends two columns on borders and two on padding.
+            inner = options.update_width(max(options.max_width - 4, 1))
+            lines = console.render_lines(self.body, inner, pad=False)
+            dropped = len(lines) - keep
+            if dropped > 0:
+                kept = lines[-keep:]
+                # The crop often lands on a paragraph break, which would spend
+                # the first row of a hard-won budget on nothing.
+                while kept and not any(seg.text.strip() for seg in kept[0]):
+                    kept.pop(0)
+                    dropped += 1
+                segments: list[Segment] = []
+                for last, line in loop_last(kept):
+                    segments.extend(line)
+                    if not last:
+                        segments.append(Segment.line())
+                body = Segments(segments)
+                plural = "" if dropped == 1 else "s"
+                title = f"Thinking (… {dropped} earlier line{plural})"
+
+        yield Panel(body, title=title, title_align="left", border_style="dim")
 
 
 @dataclass
@@ -324,4 +383,4 @@ class ContentSegment:
     content: Content
 
 
-Segment = Union[TextSegment, ThinkingSegment, ContentSegment]
+DisplaySegment = Union[TextSegment, ThinkingSegment, ContentSegment]

--- a/chatlas/_turn_accumulator.py
+++ b/chatlas/_turn_accumulator.py
@@ -20,7 +20,7 @@ class TurnAccumulator:
     1. ``begin_turn(user_turn)`` — insert user + partial assistant into turns
     2. ``process_content(content, ...)`` — append content, handle thinking
        phase boundaries, emit display text, and return items to yield
-    3. ``flush_thinking(...)`` — emit closing thinking tags after the loop
+    3. ``flush_thinking(...)`` — close an unterminated thinking block after the loop
     4. ``complete_turn(turn)`` — replace partial with the full turn (skipped if cancelled)
     5. ``finalize_turn()`` — called from ``finally``; stamps the cancellation
        reason if the turn is still partial
@@ -55,24 +55,24 @@ class TurnAccumulator:
         items: list[str | Content] = []
 
         if isinstance(content, ContentThinkingDelta) and not self._inside_thinking:
-            content = ContentThinkingDelta(
-                thinking=content.thinking, phase="start"
-            )
-            emit("<thinking>\n")
+            content = ContentThinkingDelta(thinking=content.thinking, phase="start")
             self._inside_thinking = True
         elif not isinstance(content, ContentThinkingDelta) and self._inside_thinking:
-            emit("\n</thinking>\n\n")
+            end = ContentThinkingDelta(thinking="", phase="end")
+            emit(end)
             if content_mode == "all":
-                items.append(ContentThinkingDelta(thinking="", phase="end"))
+                items.append(end)
             self._inside_thinking = False
 
-        if text:
-            emit(text)
-
+        # Reasoning goes to the display as the content object itself: the display
+        # needs the `phase` to know where the block starts and ends, and each
+        # backend renders reasoning differently from ordinary text.
         if isinstance(content, ContentThinkingDelta):
+            emit(content)
             if content_mode == "all":
                 items.append(content)
         elif text:
+            emit(text)
             items.append(text)
 
         if content_mode == "all" and isinstance(content, PROVIDER_ANNOTATION_TYPES):
@@ -85,13 +85,14 @@ class TurnAccumulator:
         content_mode: Literal["text", "all"],
         emit: Callable[[str | Content], None],
     ) -> Sequence[str | Content]:
-        """Emit closing thinking tags if the stream ended mid-thinking."""
+        """Close the thinking block if the stream ended mid-thinking."""
         if not self._inside_thinking:
             return []
         self._inside_thinking = False
-        emit("\n</thinking>\n\n")
+        end = ContentThinkingDelta(thinking="", phase="end")
+        emit(end)
         if content_mode == "all":
-            return [ContentThinkingDelta(thinking="", phase="end")]
+            return [end]
         return []
 
     def complete_turn(self, turn: AssistantTurn) -> None:

--- a/chatlas/_utils.py
+++ b/chatlas/_utils.py
@@ -165,6 +165,21 @@ HTML_ATTRS_ESCAPE_TABLE = {
 }
 
 
+def truncate_lines(text: str, max_lines: int) -> str:
+    """
+    Cap `text` at `max_lines`, noting how many lines were dropped.
+
+    A terminal can't scroll inside a region the way a browser can, so the count is
+    what stands in for a scrollbar: it tells you the output was cut and by how much.
+    """
+    lines = text.splitlines()
+    if len(lines) <= max_lines:
+        return text
+    n_dropped = len(lines) - max_lines
+    plural = "" if n_dropped == 1 else "s"
+    return "\n".join([*lines[:max_lines], f"# … {n_dropped} more line{plural}"])
+
+
 def html_escape(text: str, attr: bool = True) -> str:
     table = HTML_ATTRS_ESCAPE_TABLE if attr else HTML_ESCAPE_TABLE
     if not re.search("|".join(table), text):

--- a/chatlas/_utils.py
+++ b/chatlas/_utils.py
@@ -145,6 +145,18 @@ class MISSING_TYPE:
 MISSING = MISSING_TYPE()
 
 
+def default_if_missing(value: T | None | MISSING_TYPE, default: T) -> T | None:
+    """
+    Resolve an option, keeping `None` distinct from "not passed".
+
+    For use where `None` is itself meaningful (e.g. it turns a bound off), so it
+    can't double as the "use the default" signal.
+    """
+    if isinstance(value, MISSING_TYPE):
+        return default
+    return value
+
+
 # --------------------------------------------------------------------
 # html_escape was copied from htmltools/_utils.py
 # --------------------------------------------------------------------

--- a/tests/__snapshots__/test_echo_display.ambr
+++ b/tests/__snapshots__/test_echo_display.ambr
@@ -1,0 +1,29 @@
+# serializer version: 1
+# name: test_echo_renders_markdown
+  '''
+                            Heading
+  
+  Some bold and code, then a list:
+  
+   • one
+   • two
+  
+  
+   x = 1
+  '''
+# ---
+# name: test_echo_renders_thinking
+  '''
+  👤 User turn:
+  
+  what is 2+2?
+  
+  🤖 Assistant turn:
+  
+  ╭─ Thinking ───────────────────────────────────────────────╮
+  │ Let me think. 2+2 is 4.                                  │
+  ╰──────────────────────────────────────────────────────────╯
+  
+  The answer is 4.
+  '''
+# ---

--- a/tests/test_content_html.py
+++ b/tests/test_content_html.py
@@ -138,6 +138,29 @@ class TestContentToolResultHTML:
         assert "<script>" not in html_str
         assert "<img" not in html_str
 
+    def test_html_escaping_of_tool_name_and_argument_keys(self):
+        """Tool names and argument keys are model-controlled, so escape them too."""
+
+        request = ContentToolRequest(
+            id="test-id",
+            name="<img src=x onerror=alert(1)>",
+            arguments={"<b>key</b>": "value"},
+        )
+
+        result = ContentToolResult(value="result", request=request)
+        html_str = result.to_html()
+        assert "<img" not in html_str
+        assert "&lt;img src=x" in html_str
+        assert "<b>" not in html_str
+        assert "&lt;b&gt;key&lt;/b&gt;" in html_str
+
+        error_result = ContentToolResult(
+            value=None, error=ValueError("boom"), request=request
+        )
+        html_str = error_result.to_html()
+        assert "<img" not in html_str
+        assert "&lt;img src=x" in html_str
+
     def test_get_display_value_always_returns_string(self):
         """Test that _get_display_value always returns a string."""
         # Test with various value types

--- a/tests/test_echo_display.py
+++ b/tests/test_echo_display.py
@@ -9,6 +9,7 @@ assertions deterministic and free of ANSI escapes.
 """
 
 import logging
+import re
 from collections.abc import Sequence
 from io import StringIO
 from typing import Any, Callable, Literal, Optional, overload
@@ -29,6 +30,7 @@ from chatlas._live_render import LiveRender
 from chatlas._logging import _rich_handler
 from chatlas._provider import AnyTypeDict, Provider
 from chatlas._turn import AssistantTurn
+from chatlas._utils import MISSING, MISSING_TYPE
 from rich.console import Console
 from rich.text import Text
 
@@ -234,6 +236,159 @@ def test_echo_thinking_then_tool_request():
     assert "I need the temperature." in res
     # The request renders after the panel closes.
     assert "🔧 tool request" in res.rsplit("╰", 1)[-1]
+
+
+def test_echo_caps_long_reasoning_keeping_the_NEWEST_lines():
+    """
+    Reasoning is cropped from the top, unlike a tool result. The newest text is
+    what's still streaming, so cropping the other way would pin the panel to
+    lines the reader already finished and look like a hang.
+    """
+    chat = make_chat([long_reasoning_chunks()])
+    output = capture_echo(chat, width=70, thinking_max_lines=6)
+    chat.chat("q", echo="output")
+    res = output()
+
+    assert "step 39" in res  # newest reasoning kept
+    assert "step 00" not in res  # oldest dropped
+    assert "earlier line" in res
+    assert "The answer is 4." in res
+
+
+def test_reasoning_cap_counts_WRAPPED_lines():
+    """
+    Reasoning arrives as one long paragraph with no newlines, so a
+    `splitlines()`-style cap (what tool results use) would do nothing at all
+    here. The panel body must be bounded by *rendered* line count.
+    """
+    chunks = long_reasoning_chunks()
+    assert "\n" not in "".join(
+        c.thinking for c in chunks if isinstance(c, ContentThinkingDelta)
+    ), "fixture must be newline-free for this test to mean anything"
+
+    chat = make_chat([chunks])
+    output = capture_echo(chat, width=70, thinking_max_lines=6)
+    chat.chat("q", echo="output")
+    res = output()
+
+    # 6 body lines + 2 border lines is the whole panel.
+    panel = [ln for ln in res.splitlines() if ln.startswith(("╭", "│", "╰"))]
+    assert len(panel) == 8, panel
+
+
+def test_reasoning_cap_reports_how_many_lines_were_dropped():
+    chat = make_chat([long_reasoning_chunks()])
+    output = capture_echo(chat, width=70, thinking_max_lines=6)
+    chat.chat("q", echo="output")
+
+    match = re.search(r"… (\d+) earlier lines?", output())
+    assert match is not None
+    dropped = int(match.group(1))
+
+    # Re-render uncapped to learn the true height, then check the count adds up.
+    uncapped_chat = make_chat([long_reasoning_chunks()])
+    uncapped = capture_echo(uncapped_chat, width=70, thinking_max_lines=None)
+    uncapped_chat.chat("q", echo="output")
+    total_body = len([ln for ln in uncapped().splitlines() if ln.startswith("│")])
+    assert dropped == total_body - 6
+
+
+def test_reasoning_cap_can_be_disabled_with_None():
+    chat = make_chat([long_reasoning_chunks()])
+    output = capture_echo(chat, width=70, thinking_max_lines=None)
+    chat.chat("q", echo="output")
+    res = output()
+    assert "step 00" in res
+    assert "step 39" in res
+    assert "earlier line" not in res
+
+
+def test_short_reasoning_is_left_alone():
+    chat = make_chat([thinking_chunks()])
+    output = capture_echo(chat, width=70, thinking_max_lines=6)
+    chat.chat("what is 2+2?", echo="output")
+    res = output()
+    assert "2+2 is 4." in res
+    assert "earlier line" not in res
+
+
+def test_reasoning_cap_defaults_to_ten_lines():
+    chat = make_chat([long_reasoning_chunks()])
+    output = capture_echo(chat, width=70)
+    chat.chat("q", echo="output")
+    body = [ln for ln in output().splitlines() if ln.startswith("│")]
+    assert len(body) == 10, body
+
+
+def test_reasoning_cap_does_not_open_with_a_blank_row():
+    """
+    Real reasoning has paragraph breaks, so the crop often lands on one. Spending
+    the first row of the budget on a blank line is a waste, and it reads as a
+    rendering wart.
+    """
+    paragraphs = "\n\n".join(
+        f"Paragraph {i}: reasoning about possibility {i} at some length here."
+        for i in range(20)
+    )
+    chunks: list[Content] = [
+        ContentThinkingDelta(thinking=paragraphs[i : i + 60])
+        for i in range(0, len(paragraphs), 60)
+    ]
+    chunks.append(text("Done."))
+
+    chat = make_chat([chunks])
+    output = capture_echo(chat, width=70, thinking_max_lines=8)
+    chat.chat("q", echo="output")
+
+    body = [ln for ln in output().splitlines() if ln.startswith("│")]
+    assert body, "expected a panel"
+    assert body[0].strip("│ ") != "", f"panel opens with a blank row: {body[0]!r}"
+    assert len(body) <= 8
+
+
+def test_reasoning_cap_counts_stripped_blanks_as_dropped():
+    """Whatever the panel drops -- cropped or blank -- the title has to own it."""
+    paragraphs = "\n\n".join(f"Paragraph {i} of reasoning." for i in range(20))
+    chunks: list[Content] = [
+        ContentThinkingDelta(thinking=paragraphs[i : i + 60])
+        for i in range(0, len(paragraphs), 60)
+    ]
+    chunks.append(text("Done."))
+
+    def body_lines(cap: "int | None") -> tuple[int, str]:
+        chat = make_chat([list(chunks)])
+        out = capture_echo(chat, width=70, thinking_max_lines=cap)
+        chat.chat("q", echo="output")
+        res = out()
+        return len([ln for ln in res.splitlines() if ln.startswith("│")]), res
+
+    kept, capped = body_lines(8)
+    total, _ = body_lines(None)
+
+    match = re.search(r"… (\d+) earlier lines?", capped)
+    assert match is not None
+    assert int(match.group(1)) == total - kept
+
+
+def test_reasoning_cap_of_zero_does_not_silently_keep_everything():
+    """`lines[-0:]` is the whole list, so a cap of 0 has to be clamped."""
+    chat = make_chat([long_reasoning_chunks()])
+    output = capture_echo(chat, width=70, thinking_max_lines=0)
+    chat.chat("q", echo="output")
+    res = output()
+    assert "step 00" not in res
+    body = [ln for ln in res.splitlines() if ln.startswith("│")]
+    assert len(body) == 1, body
+
+
+def test_tool_result_truncation_can_be_disabled_with_None():
+    chat = make_chat([[tool_request(name="big_tool", arguments={})], [text("Done.")]])
+    chat.register_tool(big_tool)
+    output = capture_echo(chat, width=80, tool_result_max_lines=None)
+    chat.chat("go", echo="output")
+    res = output()
+    assert "'row-29'" in res
+    assert "more line" not in res
 
 
 def test_echo_truncates_a_long_tool_result():
@@ -614,7 +769,10 @@ def capture_echo(
     force_terminal: bool = False,
     normalize: bool = True,
     rich_markdown: Optional[dict[str, object]] = None,
-    tool_result_max_lines: Optional[int] = None,
+    # MISSING, not None: `None` means "don't bound this", so it can't double as
+    # "the test didn't ask for anything".
+    tool_result_max_lines: "int | None | MISSING_TYPE" = MISSING,
+    thinking_max_lines: "int | None | MISSING_TYPE" = MISSING,
     height: Optional[int] = None,
 ) -> Callable[[], str]:
     """
@@ -638,6 +796,7 @@ def capture_echo(
         rich_console=console,
         rich_markdown=rich_markdown,
         tool_result_max_lines=tool_result_max_lines,
+        thinking_max_lines=thinking_max_lines,
     )
 
     def get() -> str:
@@ -685,6 +844,24 @@ def capture_ipy_html(monkeypatch: pytest.MonkeyPatch) -> list[str]:
     monkeypatch.setattr(IPython.display, "display", fake_display)
     monkeypatch.setattr(IPython.display, "update_display", lambda md, display_id: None)
     return html
+
+
+def long_reasoning_chunks() -> list[Content]:
+    """
+    Reasoning long enough to need capping, streamed in provider-sized chunks.
+
+    Deliberately newline-free: that's how reasoning actually arrives, and it's
+    what makes source-line counting useless.
+    """
+    reasoning = "".join(
+        f"step {i:02d}: considering possibility {i} in some detail. " for i in range(40)
+    )
+    chunks: list[Content] = [
+        ContentThinkingDelta(thinking=reasoning[i : i + 80])
+        for i in range(0, len(reasoning), 80)
+    ]
+    chunks.append(text("The answer is **4**."))
+    return chunks
 
 
 def thinking_chunks() -> list[Content]:

--- a/tests/test_echo_display.py
+++ b/tests/test_echo_display.py
@@ -1,0 +1,887 @@
+"""
+Tests for `echo=` output, as rendered by the rich-based live console display.
+
+`LiveMarkdownDisplay` writes to a `rich.console.Console` built from
+`Chat.set_echo_options(rich_console=)`, so pointing that at a `StringIO` lets us
+assert on what a user would actually see. On a non-terminal console, `rich.Live`
+skips incremental refreshes and prints only the final frame, which keeps these
+assertions deterministic and free of ANSI escapes.
+"""
+
+import logging
+from collections.abc import Sequence
+from io import StringIO
+from typing import Any, Callable, Literal, Optional, overload
+
+import pytest
+from chatlas import Chat
+from chatlas._content import (
+    Content,
+    ContentImageRemote,
+    ContentText,
+    ContentThinking,
+    ContentThinkingDelta,
+    ContentToolRequest,
+    ContentToolResult,
+)
+from chatlas._display import IPyMarkdownDisplay, LiveMarkdownDisplay
+from chatlas._live_render import LiveRender
+from chatlas._logging import _rich_handler
+from chatlas._provider import AnyTypeDict, Provider
+from chatlas._turn import AssistantTurn
+from rich.console import Console
+from rich.text import Text
+
+
+def test_echo_none_writes_nothing():
+    chat = make_chat([[text("Hello there")]])
+    output = capture_echo(chat)
+    chat.chat("hi", echo="none")
+    assert output() == ""
+
+
+def test_echo_text_renders_assistant_text():
+    chat = make_chat([[text("Hello **there**")]])
+    output = capture_echo(chat)
+    chat.chat("hi", echo="text")
+    assert output() == "Hello there"
+
+
+def test_echo_text_omits_user_turn():
+    chat = make_chat([[text("Hello there")]])
+    output = capture_echo(chat)
+    chat.chat("what is 2+2?", echo="text")
+    assert "what is 2+2?" not in output()
+    assert "User turn" not in output()
+
+
+def test_echo_all_includes_user_turn_and_headers():
+    chat = make_chat([[text("Hello there")]])
+    output = capture_echo(chat)
+    chat.chat("what is 2+2?", echo="all")
+    res = output()
+    assert "👤 User turn:" in res
+    assert "what is 2+2?" in res
+    assert "🤖 Assistant turn:" in res
+    assert "Hello there" in res
+
+
+def test_echo_renders_markdown(snapshot):
+    chunks = [
+        text("# Heading\n\n"),
+        text("Some **bold** and `code`, then a list:\n\n"),
+        text("- one\n- two\n\n"),
+        text("```python\nx = 1\n```\n"),
+    ]
+    chat = make_chat([chunks])
+    output = capture_echo(chat)
+    chat.chat("hi", echo="output")
+    assert snapshot == output()
+
+
+def test_echo_output_includes_tool_request_and_result():
+    chat = make_chat([[tool_request()], [text("It is 30°F.")]])
+    chat.register_tool(get_temperature)
+    output = capture_echo(chat)
+    chat.chat("temp in Duluth?", echo="output")
+    res = output()
+    assert "🔧 tool request" in res
+    assert 'get_temperature(city="Duluth")' in res
+    assert "✅ tool result" in res
+    assert "30" in res
+    assert "It is 30°F." in res
+
+
+def test_echo_text_omits_tool_content():
+    chat = make_chat([[tool_request()], [text("It is 30°F.")]])
+    chat.register_tool(get_temperature)
+    output = capture_echo(chat)
+    chat.chat("temp in Duluth?", echo="text")
+    res = output()
+    assert "tool request" not in res
+    assert "tool result" not in res
+    assert "It is 30°F." in res
+
+
+def test_echo_non_streaming():
+    chat = make_chat([[text("Hello **there**")]])
+    output = capture_echo(chat)
+    chat.chat("hi", echo="output", stream=False)
+    assert output() == "Hello there"
+
+
+def test_echo_stream_generator_renders_incrementally():
+    chat = make_chat([[text("Hello "), text("there")]])
+    output = capture_echo(chat)
+    for _ in chat.stream("hi", echo="output"):
+        pass
+    assert output() == "Hello there"
+
+
+@pytest.mark.asyncio
+async def test_echo_all_async_matches_sync():
+    chunks = [text("Hello **there**")]
+    sync_chat = make_chat([list(chunks)])
+    sync_output = capture_echo(sync_chat)
+    sync_chat.chat("what is 2+2?", echo="all")
+
+    async_chat = make_chat([list(chunks)])
+    async_output = capture_echo(async_chat)
+    await async_chat.chat_async("what is 2+2?", echo="all")
+
+    assert async_output() == sync_output()
+    assert "👤 User turn:" in async_output()
+
+
+@pytest.mark.asyncio
+async def test_echo_output_async_includes_tool_content():
+    chat = make_chat([[tool_request()], [text("It is 30°F.")]])
+    chat.register_tool(get_temperature)
+    output = capture_echo(chat)
+    await chat.chat_async("temp in Duluth?", echo="output")
+    res = output()
+    assert "🔧 tool request" in res
+    assert "✅ tool result" in res
+    assert "It is 30°F." in res
+
+
+@pytest.mark.asyncio
+async def test_echo_none_async_writes_nothing():
+    chat = make_chat([[text("Hello there")]])
+    output = capture_echo(chat)
+    await chat.chat_async("hi", echo="none")
+    assert output() == ""
+
+
+def test_echo_renders_thinking(snapshot):
+    chat = make_chat([thinking_chunks()])
+    output = capture_echo(chat)
+    chat.chat("what is 2+2?", echo="all")
+    res = output()
+    assert "2+2 is 4." in res
+    assert "Thinking" in res
+    assert snapshot == res
+
+
+def test_echo_renders_thinking_in_a_panel():
+    """Reasoning is boxed, so it reads as an aside rather than as the answer."""
+    chat = make_chat([thinking_chunks()])
+    output = capture_echo(chat)
+    chat.chat("what is 2+2?", echo="output")
+    res = output()
+    # Panel corners, with the title on the top border.
+    assert "╭─ Thinking" in res
+    assert "╰" in res
+    # The answer sits outside the panel.
+    assert "The answer is 4." in res.rsplit("╰", 1)[-1]
+
+
+def test_echo_text_omits_thinking():
+    chat = make_chat([thinking_chunks()])
+    output = capture_echo(chat)
+    chat.chat("what is 2+2?", echo="text")
+    res = output()
+    assert "2+2 is 4." not in res
+    assert "Thinking" not in res
+    assert res == "The answer is 4."
+
+
+def test_echo_all_renders_thinking_exactly_once():
+    """
+    The completed turn also carries a `ContentThinking`, so reasoning is
+    reachable twice: once streamed, once via `emit_other_contents`.
+    """
+    chat = make_chat([thinking_chunks()])
+    output = capture_echo(chat)
+    chat.chat("what is 2+2?", echo="all")
+    res = output()
+    assert res.count("2+2 is 4.") == 1
+    assert res.count("Thinking") == 1
+    # ...and the turn really does hold it, i.e. the assertion above isn't vacuous.
+    turn = chat.get_last_turn()
+    assert turn is not None
+    assert any(isinstance(c, ContentThinking) for c in turn.contents)
+
+
+@pytest.mark.parametrize("echo", ["output", "all"])
+def test_echo_non_streaming_renders_thinking(echo: Literal["output", "all"]):
+    chat = make_chat([thinking_chunks()])
+    output = capture_echo(chat)
+    chat.chat("what is 2+2?", echo=echo, stream=False)
+    res = output()
+    assert res.count("2+2 is 4.") == 1
+    assert "Thinking" in res
+
+
+def test_echo_text_non_streaming_omits_thinking():
+    chat = make_chat([thinking_chunks()])
+    output = capture_echo(chat)
+    chat.chat("what is 2+2?", echo="text", stream=False)
+    assert output() == "The answer is 4."
+
+
+def test_echo_thinking_then_tool_request():
+    """A tool request has to close the thinking block, not land inside it."""
+    chunks = [
+        ContentThinkingDelta(thinking="I need the temperature."),
+        tool_request(),
+    ]
+    chat = make_chat([chunks, [text("It is 30°F.")]])
+    chat.register_tool(get_temperature)
+    output = capture_echo(chat)
+    chat.chat("temp in Duluth?", echo="output")
+    res = output()
+    assert "I need the temperature." in res
+    # The request renders after the panel closes.
+    assert "🔧 tool request" in res.rsplit("╰", 1)[-1]
+
+
+def test_echo_truncates_a_long_tool_result():
+    chat = make_chat([[tool_request(name="big_tool", arguments={})], [text("Done.")]])
+    chat.register_tool(big_tool)
+    output = capture_echo(chat, width=80, tool_result_max_lines=5)
+    chat.chat("go", echo="output")
+    res = output()
+
+    assert "'row-0'" in res
+    assert "'row-4'" in res
+    # 30 rows over 5 kept lines, and pformat puts one row per line.
+    assert "'row-29'" not in res
+    assert "… 25 more lines" in res
+
+    # The full value is untouched on the turn -- only the display is bounded.
+    turn = chat.get_last_turn(role="user")
+    assert turn is not None
+    result = turn.contents[0]
+    assert isinstance(result, ContentToolResult)
+    assert isinstance(result.value, list)
+    assert len(result.value) == 30
+
+
+def test_echo_all_truncates_a_long_tool_result_exactly_once():
+    """
+    `echo="all"` reaches a tool result twice: the user turn it's attached to is
+    echoed as a whole, and `emit_other_contents` echoes its non-text contents.
+    Both have to go through the display, or the bounded copy sits next to an
+    unbounded one.
+    """
+    chat = make_chat([[tool_request(name="big_tool", arguments={})], [text("Done.")]])
+    chat.register_tool(big_tool)
+    output = capture_echo(chat, width=80, tool_result_max_lines=5)
+    chat.chat("go", echo="all")
+    res = output()
+
+    assert res.count("✅ tool result") == 1
+    assert res.count("… 25 more lines") == 1
+    assert "'row-29'" not in res
+
+
+def test_echo_all_still_shows_the_user_prompt():
+    """`emit_user_contents` emits `turn.text` rather than `str(turn)` now."""
+    chat = make_chat([[text("Hi")]])
+    output = capture_echo(chat)
+    chat.chat("what is 2+2?", echo="all")
+    res = output()
+    assert "👤 User turn:" in res
+    assert "what is 2+2?" in res
+
+
+def test_echo_does_not_truncate_a_short_tool_result():
+    chat = make_chat([[tool_request()], [text("It is 30°F.")]])
+    chat.register_tool(get_temperature)
+    output = capture_echo(chat, tool_result_max_lines=5)
+    chat.chat("temp in Duluth?", echo="output")
+    res = output()
+    assert "30" in res
+    assert "more line" not in res
+
+
+def test_tool_result_max_lines_defaults_to_twenty():
+    chat = make_chat([[tool_request(name="big_tool", arguments={})], [text("Done.")]])
+    chat.register_tool(big_tool)
+    output = capture_echo(chat, width=80)
+    chat.chat("go", echo="output")
+    assert "… 10 more lines" in output()
+
+
+def test_truncated_tool_result_reports_a_single_dropped_line():
+    result = ContentToolResult(
+        value="\n".join(f"line {i}" for i in range(6)),
+        request=tool_request(),
+    )
+    assert "… 1 more line" in result.to_display_markdown(max_lines=5)
+    assert "more lines" not in result.to_display_markdown(max_lines=5)
+
+
+def test_tool_result_str_is_never_truncated():
+    """
+    `str()` feeds `export()` and `Chat.__str__`, which are not display-bounded.
+    """
+    result = ContentToolResult(
+        value="\n".join(f"line {i}" for i in range(50)),
+        request=tool_request(),
+    )
+    assert "line 49" in str(result)
+    assert "more line" not in str(result)
+
+
+def test_current_display_echo_from_tool():
+    def noisy_tool() -> str:
+        "A tool that writes to the active display."
+        assert chat.current_display is not None
+        chat.current_display.echo("\n\nMy custom tool display!!!\n\n")
+        return "done"
+
+    chat = make_chat([[tool_request(name="noisy_tool", arguments={})], [text("Bye")]])
+    chat.register_tool(noisy_tool)
+    output = capture_echo(chat)
+    chat.chat("go", echo="output")
+    assert "My custom tool display!!!" in output()
+
+
+def test_current_display_is_none_outside_of_echo():
+    chat = make_chat([[text("Hello")]])
+    assert chat.current_display is None
+    chat.chat("hi", echo="output")
+    assert chat.current_display is None
+
+
+def test_set_echo_options_passes_rich_markdown_options():
+    chat = make_chat([[text("See [the docs](https://example.com)")]])
+    output = capture_echo(chat, rich_markdown={"hyperlinks": False})
+    chat.chat("hi", echo="output")
+    assert "https://example.com" in output()
+
+
+def test_logs_are_routed_into_the_live_console():
+    """
+    `LiveMarkdownDisplay.__enter__` repoints any `RichHandler` at the live
+    console so log records aren't swallowed while the display is active.
+    """
+    # Only handlers on the root logger and on chatlas' own logger get
+    # repointed, so attach to the latter rather than a child of it.
+    log = logging.getLogger("chatlas")
+    original_level = log.level
+    log.setLevel(logging.INFO)
+    handler = _rich_handler()
+    log.addHandler(handler)
+
+    chat = make_chat([[tool_request(name="logging_tool", arguments={})], [text("Hi")]])
+    chat.register_tool(logging_tool(log))
+    output = capture_echo(chat, width=100)
+    try:
+        chat.chat("go", echo="output")
+    finally:
+        log.removeHandler(handler)
+        log.setLevel(original_level)
+
+    assert "a log inside the live console" in output()
+
+
+def test_notebook_environments_use_the_ipy_display(monkeypatch):
+    chat = make_chat([[text("Hello")]])
+    assert isinstance(chat._markdown_display("output")._display, LiveMarkdownDisplay)
+
+    monkeypatch.setenv("QUARTO_PYTHON", "/usr/bin/python3")
+    assert isinstance(chat._markdown_display("output")._display, IPyMarkdownDisplay)
+
+
+def test_ipy_display_receives_markdown(monkeypatch):
+    updates = capture_ipy(monkeypatch)
+    chat = make_chat([[text("Hello "), text("there")]])
+    chat.chat("hi", echo="output")
+    assert updates[-1].endswith("Hello there")
+
+
+def test_ipy_thinking_is_open_while_streaming_then_collapses(monkeypatch):
+    updates = capture_ipy(monkeypatch)
+
+    chat = make_chat([thinking_chunks()])
+    chat.chat("what is 2+2?", echo="output")
+
+    # While reasoning streams, the block is expanded so you can watch it arrive.
+    mid = next(u for u in updates if "Let me think." in u)
+    assert "<details open><summary>Thinking</summary>" in mid
+
+    # Once it's done it folds away, so it costs almost no vertical space.
+    assert "<details><summary>Thinking</summary>" in updates[-1]
+    assert "<details open>" not in updates[-1]
+    assert "2+2 is 4." in updates[-1]
+    assert updates[-1].count("<summary>Thinking</summary>") == 1
+
+
+def test_ipy_thinking_body_stays_markdown(monkeypatch):
+    """
+    Blank lines around the body end the opening HTML block, so a notebook still
+    markdown-renders the reasoning rather than dumping it as raw text.
+    """
+    updates = capture_ipy(monkeypatch)
+    chat = make_chat([[ContentThinkingDelta(thinking="- a\n- b"), text("Done.")]])
+    chat.chat("hi", echo="output")
+    assert "<summary>Thinking</summary>\n\n- a\n- b\n\n</details>" in updates[-1]
+
+
+def test_ipy_text_only_response_has_no_thinking_block(monkeypatch):
+    updates = capture_ipy(monkeypatch)
+    chat = make_chat([[text("Hello there")]])
+    chat.chat("hi", echo="output")
+    assert "<details" not in updates[-1]
+    assert updates[-1].endswith("Hello there")
+
+
+def test_ipy_tool_result_renders_collapsed_html(monkeypatch):
+    updates = capture_ipy(monkeypatch)
+
+    chat = make_chat([[tool_request()], [text("It is 30°F.")]])
+    chat.register_tool(get_temperature)
+    chat.chat("temp in Duluth?", echo="output")
+
+    res = updates[-1]
+    # The shinychat markup, reused so the two can't drift.
+    assert '<div class="chatlas-tool-result">' in res
+    assert "Result from tool call: <code>get_temperature</code>" in res
+    # Collapsed: the outer <details> has no `open` attribute.
+    assert "<details><summary>Result from tool call" in res
+    assert "It is 30°F." in res
+
+
+def test_ipy_display_injects_tool_css_and_max_height(monkeypatch):
+    html = capture_ipy_html(monkeypatch)
+    chat = make_chat([[text("Hello")]])
+    chat.chat("hi", echo="output")
+
+    styles = [h for h in html if h.startswith("<style>")]
+    assert len(styles) == 1
+    assert ".chatlas-tool-result" in styles[0]
+    assert "--chatlas-tool-result-max-height, 400px" in styles[0]
+
+    wrapper = next(h for h in html if "chatlas-markdown" in h)
+    assert "--chatlas-tool-result-max-height: 400px" in wrapper
+
+
+def test_ipy_display_honors_max_height_option(monkeypatch):
+    html = capture_ipy_html(monkeypatch)
+    chat = make_chat([[text("Hello")]])
+    chat.set_echo_options(tool_result_max_height="12rem")
+    chat.chat("hi", echo="output")
+
+    wrapper = next(h for h in html if "chatlas-markdown" in h)
+    assert "--chatlas-tool-result-max-height: 12rem" in wrapper
+
+
+def test_ipy_display_keeps_css_styles_option(monkeypatch):
+    html = capture_ipy_html(monkeypatch)
+    chat = make_chat([[text("Hello")]])
+    chat.set_echo_options(css_styles={"max-height": "300px"})
+    chat.chat("hi", echo="output")
+
+    styles = [h for h in html if h.startswith("<style>")]
+    assert len(styles) == 1
+    assert "max-height: 300px;" in styles[0]
+    assert ".chatlas-tool-result" in styles[0]
+
+
+def test_live_terminal_output_contains_final_frame():
+    """
+    On a real terminal, `Live` repaints on every chunk. Assert the escape
+    sequences show up and that the last frame still holds the whole response
+    (i.e. the `crop_above` LiveRender patch didn't eat it).
+    """
+    chat = make_chat([[text("# Title\n\n"), text("body text")]])
+    output = capture_echo(chat, force_terminal=True, normalize=False)
+    chat.chat("hi", echo="output")
+    res = output()
+    assert "\x1b[2K" in res  # erase-line, i.e. a repaint happened
+    assert res.count("Title") > 1  # repainted at least once
+    assert "body text" in res.rsplit("Title", 1)[-1]
+
+
+def test_echo_all_shows_finish_reason_and_other_content_markers():
+    chat = make_chat(
+        [[text("Here you go"), ContentImageRemote(url="https://example.com/a.png")]],
+        finish_reason="stop",
+    )
+    output = capture_echo(chat, width=100)
+    chat.chat("hi", echo="all")
+    res = output()
+    assert "🤖 other content" in res
+    assert "finish reason: stop" in res
+
+
+def test_display_is_restored_when_the_provider_raises():
+    """
+    `chat()` runs the display as a context manager, so a mid-stream failure must
+    still stop `Live` -- otherwise the user's cursor stays hidden and their
+    terminal is left wedged.
+    """
+    chat = make_raising_chat([[text("partial "), text("answer")]])
+    output = capture_echo(chat, force_terminal=True, normalize=False)
+
+    with pytest.raises(RuntimeError, match="blew up mid-stream"):
+        chat.chat("hi", echo="output")
+
+    assert chat.current_display is None
+    assert SHOW_CURSOR in output()
+
+
+def test_display_is_restored_when_a_stream_is_abandoned():
+    """
+    `stream()` keeps the display open inside a generator, so it only unwinds
+    when that generator is closed. Bailing out of the loop early is the common
+    way users hit this.
+    """
+    chat = make_chat([[text("one "), text("two "), text("three")]])
+    output = capture_echo(chat, force_terminal=True, normalize=False)
+
+    stream = chat.stream("hi", echo="output")
+    next(stream)
+    stream.close()  # what garbage collection does after a `break`
+
+    assert chat.current_display is None
+    assert SHOW_CURSOR in output()
+
+
+def test_consecutive_turns_do_not_replay_the_previous_one():
+    """
+    The display accumulates segments, so a second `chat()` must start from an
+    empty list rather than repainting the first response above the second.
+    """
+    chat = make_chat([[text("first answer")], [text("second answer")]])
+
+    first = capture_echo(chat)
+    chat.chat("one", echo="output")
+    assert first() == "first answer"
+
+    second = capture_echo(chat)
+    chat.chat("two", echo="output")
+    assert second() == "second answer"
+
+
+def test_consecutive_turns_do_not_replay_thinking(monkeypatch):
+    """Same invariant for the notebook display, whose thinking segment is mutable."""
+    updates = capture_ipy(monkeypatch)
+    chat = make_chat([thinking_chunks(), [text("second answer")]])
+
+    chat.chat("one", echo="output")
+    chat.chat("two", echo="output")
+
+    assert "2+2 is 4." not in updates[-1]
+    assert "<details" not in updates[-1]
+    assert updates[-1].endswith("second answer")
+
+
+@pytest.mark.parametrize(
+    "overflow, kept, dropped",
+    [
+        ("crop_above", "line-10", "line-01"),
+        ("crop", "line-01", "line-10"),
+    ],
+)
+def test_live_render_vertical_overflow(overflow: str, kept: str, dropped: str):
+    """
+    Unit-tests the vendored `LiveRender` patch, which exists solely to add
+    `crop_above` (upstream rich only crops the tail). This is copied from rich
+    internals, so it's the piece most likely to break on a rich upgrade.
+
+    Driving it through `Live` doesn't work here: a `StringIO` console's height
+    never reaches `options.size`, so the overflow branch is unreachable from the
+    `Chat` API.
+    """
+    console = Console(file=StringIO(), width=30, height=5)
+    body = Text("\n".join(f"line-{i:02d}" for i in range(1, 11)))
+
+    lines = console.render_lines(
+        LiveRender(body, vertical_overflow=overflow),  # pyright: ignore[reportArgumentType]
+        console.options,
+    )
+    rendered = "".join(seg.text for line in lines for seg in line)
+
+    assert kept in rendered
+    assert dropped not in rendered
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+SHOW_CURSOR = "\x1b[?25h"
+
+
+def capture_echo(
+    chat: Chat,
+    *,
+    width: int = 60,
+    force_terminal: bool = False,
+    normalize: bool = True,
+    rich_markdown: Optional[dict[str, object]] = None,
+    tool_result_max_lines: Optional[int] = None,
+    height: Optional[int] = None,
+) -> Callable[[], str]:
+    """
+    Point `chat`'s echo console at a buffer. Returns a getter for its contents.
+
+    By default the text is normalized: rich pads every line out to the console
+    width, which would otherwise make assertions and snapshots whitespace-noisy.
+
+    `height` bounds the console viewport, which is what triggers `Live`'s
+    vertical-overflow handling.
+    """
+    buf = StringIO()
+    console: dict[str, Any] = {
+        "file": buf,
+        "width": width,
+        "force_terminal": force_terminal,
+    }
+    if height is not None:
+        console["height"] = height
+    chat.set_echo_options(
+        rich_console=console,
+        rich_markdown=rich_markdown,
+        tool_result_max_lines=tool_result_max_lines,
+    )
+
+    def get() -> str:
+        res = buf.getvalue()
+        if not normalize:
+            return res
+        return "\n".join(line.rstrip() for line in res.splitlines()).strip("\n")
+
+    return get
+
+
+def capture_ipy(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """
+    Route `chat` at the notebook display and collect every markdown update.
+
+    Returns the (growing) list, so assertions can look at intermediate frames as
+    well as the final one.
+    """
+    import IPython.display
+
+    updates: list[str] = []
+    monkeypatch.setenv("QUARTO_PYTHON", "/usr/bin/python3")
+    monkeypatch.setattr(IPython.display, "display", lambda *a, **kw: FakeHandle())
+    monkeypatch.setattr(
+        IPython.display,
+        "update_display",
+        lambda md, display_id: updates.append(md.data),
+    )
+    return updates
+
+
+def capture_ipy_html(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Collect the raw HTML the notebook display emits when setting itself up."""
+    import IPython.display
+
+    html: list[str] = []
+
+    def fake_display(*args: Any, **kwargs: Any) -> FakeHandle:
+        for arg in args:
+            if isinstance(arg, IPython.display.HTML):
+                html.append(str(arg.data))
+        return FakeHandle()
+
+    monkeypatch.setenv("QUARTO_PYTHON", "/usr/bin/python3")
+    monkeypatch.setattr(IPython.display, "display", fake_display)
+    monkeypatch.setattr(IPython.display, "update_display", lambda md, display_id: None)
+    return html
+
+
+def thinking_chunks() -> list[Content]:
+    return [
+        ContentThinkingDelta(thinking="Let me think. "),
+        ContentThinkingDelta(thinking="2+2 is 4."),
+        text("The answer is **4**."),
+    ]
+
+
+def text(value: str) -> ContentText:
+    return ContentText.model_construct(text=value)
+
+
+def tool_request(
+    name: str = "get_temperature",
+    arguments: Optional[dict[str, object]] = None,
+) -> ContentToolRequest:
+    if arguments is None:
+        arguments = {"city": "Duluth"}
+    return ContentToolRequest(id="call_1", name=name, arguments=arguments)
+
+
+def get_temperature(city: str) -> int:
+    "Get the current temperature in a city."
+    return 30
+
+
+def big_tool() -> list[dict[str, object]]:
+    "A tool whose result is far too tall to show in full."
+    return [{"i": i, "value": f"row-{i}"} for i in range(30)]
+
+
+def logging_tool(log: logging.Logger) -> Callable[[], str]:
+    def logging_tool() -> str:
+        "A tool that logs."
+        log.info("a log inside the live console")
+        return "done"
+
+    return logging_tool
+
+
+class FakeHandle:
+    display_id = "abc123"
+
+
+class FakeChunk:
+    def __init__(self, content: Optional[Content]):
+        self.content = content
+
+
+class EchoCompletion:
+    def __init__(self, contents: list[Content]):
+        self.contents = contents
+
+
+class EchoProvider(Provider[EchoCompletion, FakeChunk, dict[str, Any], AnyTypeDict]):
+    """
+    Yields one canned sequence of content chunks per `chat_perform()` call, so a
+    tool loop can be driven by handing it several sequences.
+    """
+
+    def __init__(
+        self,
+        responses: Sequence[Sequence[Content]],
+        *,
+        finish_reason: Optional[str] = None,
+    ):
+        super().__init__(name="echo", model="echo-model")
+        self._responses = list(responses)
+        self._current: list[Content] = []
+        self._finish_reason = finish_reason
+
+    def list_models(self) -> list[Any]:
+        return []
+
+    def _next_response(self) -> list[Content]:
+        self._current = list(self._responses.pop(0))
+        return self._current
+
+    @overload
+    def chat_perform(
+        self, *, stream: Literal[False], turns, tools, data_model, kwargs
+    ): ...
+
+    @overload
+    def chat_perform(
+        self, *, stream: Literal[True], turns, tools, data_model, kwargs
+    ): ...
+
+    def chat_perform(self, *, stream, turns, tools, data_model, kwargs):
+        contents = self._next_response()
+        if stream:
+            return iter([FakeChunk(c) for c in contents])
+        return EchoCompletion(contents)
+
+    @overload
+    async def chat_perform_async(
+        self, *, stream: Literal[False], turns, tools, data_model, kwargs
+    ): ...
+
+    @overload
+    async def chat_perform_async(
+        self, *, stream: Literal[True], turns, tools, data_model, kwargs
+    ): ...
+
+    async def chat_perform_async(self, *, stream, turns, tools, data_model, kwargs):
+        contents = self._next_response()
+
+        async def gen():
+            for c in contents:
+                yield FakeChunk(c)
+
+        if stream:
+            return gen()
+        return EchoCompletion(contents)
+
+    def stream_content(self, chunk: FakeChunk, completion) -> list[Content]:
+        return [chunk.content] if chunk.content is not None else []
+
+    def stream_merge_chunks(self, completion, chunk):
+        return completion or {}
+
+    def stream_turn(self, completion, has_data_model):
+        return self._turn_from_current()
+
+    def value_turn(self, completion, has_data_model):
+        return self._turn_from_current()
+
+    def _turn_from_current(self) -> AssistantTurn:
+        """
+        Build the completed turn the way a real provider does.
+
+        Text chunks merge into one `ContentText`, thinking deltas merge into one
+        `ContentThinking` (Anthropic/OpenAI both do this), tool requests pass
+        through. Reasoning has to be present here or the display's
+        no-double-echo guard wouldn't be exercised.
+        """
+        contents: list[Content] = []
+        merged = ""
+        thinking = ""
+        for c in self._current:
+            if isinstance(c, ContentText):
+                merged += c.text
+            elif isinstance(c, ContentThinkingDelta):
+                thinking += c.thinking
+            else:
+                contents.append(c)
+        if merged:
+            contents.insert(0, text(merged))
+        if thinking:
+            contents.insert(0, ContentThinking(thinking=thinking))
+        return AssistantTurn(
+            contents=contents,
+            tokens=None,
+            completion=None,
+            finish_reason=self._finish_reason,
+        )
+
+    def value_tokens(self, completion):
+        return None
+
+    def value_cost(self, completion, tokens=None):
+        return None
+
+    def token_count(self, *args, **kwargs):
+        return 0
+
+    async def token_count_async(self, *args, **kwargs):
+        return 0
+
+    def translate_model_params(self, *args, **kwargs) -> AnyTypeDict:
+        return AnyTypeDict()
+
+    def supported_model_params(self):
+        return set()
+
+
+class RaisingProvider(EchoProvider):
+    """Fails partway through the stream, after some content has been echoed."""
+
+    _calls = 0
+
+    def stream_content(self, chunk: FakeChunk, completion) -> list[Content]:
+        self._calls += 1
+        if self._calls > 1:
+            raise RuntimeError("provider blew up mid-stream")
+        return super().stream_content(chunk, completion)
+
+
+def make_chat(
+    responses: Sequence[Sequence[Content]],
+    *,
+    finish_reason: Optional[str] = None,
+) -> Chat:
+    return Chat(provider=EchoProvider(responses, finish_reason=finish_reason))
+
+
+def make_raising_chat(responses: Sequence[Sequence[Content]]) -> Chat:
+    return Chat(provider=RaisingProvider(responses))

--- a/tests/test_echo_display.py
+++ b/tests/test_echo_display.py
@@ -656,6 +656,14 @@ def test_ipy_display_keeps_css_styles_option(monkeypatch):
     assert "max-height: 300px;" in styles[0]
     assert ".chatlas-tool-result" in styles[0]
 
+    # The styles must target the wrapper div itself: its id and the
+    # `chatlas-markdown` class are on the same element, so a sibling
+    # selector (`#id + .chatlas-markdown`) would never match anything.
+    wrapper = next(h for h in html if h.startswith("<div"))
+    match = re.search(r"id='([^']+)'", wrapper)
+    assert match
+    assert f"#{match.group(1)}.chatlas-markdown {{" in styles[0]
+
 
 def test_live_terminal_output_contains_final_frame():
     """

--- a/tests/test_echo_display.py
+++ b/tests/test_echo_display.py
@@ -508,6 +508,14 @@ def test_set_echo_options_passes_rich_markdown_options():
     assert "https://example.com" in output()
 
 
+def test_set_echo_options_replaces_all_options():
+    """Each call replaces the full set: unspecified options revert to defaults."""
+    chat = make_chat([[text("Hello")]])
+    chat.set_echo_options(thinking_max_lines=None)
+    chat.set_echo_options(rich_markdown={"hyperlinks": False})
+    assert chat._echo_options["thinking_max_lines"] == 10
+
+
 def test_logs_are_routed_into_the_live_console():
     """
     `LiveMarkdownDisplay.__enter__` repoints any `RichHandler` at the live
@@ -622,6 +630,19 @@ def test_ipy_display_honors_max_height_option(monkeypatch):
 
     wrapper = next(h for h in html if "chatlas-markdown" in h)
     assert "--chatlas-tool-result-max-height: 12rem" in wrapper
+
+
+def test_ipy_display_max_height_None_means_unbounded(monkeypatch):
+    html = capture_ipy_html(monkeypatch)
+    chat = make_chat([[text("Hello")]])
+    chat.set_echo_options(tool_result_max_height=None)
+    chat.chat("hi", echo="output")
+
+    wrapper = next(h for h in html if "chatlas-markdown" in h)
+    # `none` is CSS for "no max-height"; it must not fall through to the
+    # 400px fallback in TOOL_CSS (or worse, a stringified Python None).
+    assert "--chatlas-tool-result-max-height: none" in wrapper
+    assert "None" not in wrapper
 
 
 def test_ipy_display_keeps_css_styles_option(monkeypatch):


### PR DESCRIPTION
Closes #361.

## Why this matters

**You can finally see the model think.** Reasoning was invisible in the console in *every* echo mode — not truncated, not styled oddly, just gone. `TurnAccumulator` wrapped it in literal `<thinking>` tags, and rich's `Markdown` treats those as an HTML block and silently drops them. So with a thinking-capable model you'd watch reasoning stream past the network and never see a character of it.

It now renders in a `Thinking` panel in the console, and in notebooks as a `<details>` block that stays **expanded while reasoning arrives** and **collapses once it's done** — so you can watch it happen without it permanently eating the cell.

```
╭─ Thinking ───────────────────────────────────────────────╮
│ Let me work through this. 2+2 is a basic addition        │
│ problem, so the answer is 4.                             │
╰──────────────────────────────────────────────────────────╯

The answer is 4.
```

**A big tool result no longer buries the answer.** A tool returning a large payload used to render as one unbounded code block. In a notebook that meant scrolling past hundreds of lines of JSON to find what the assistant actually said. Now a 30-row result costs one line until you ask for it:

```
▸ Result from tool call: query_db

The assistant's answer starts here, immediately.
```

Expanded, it scrolls inside a bounded container rather than growing the page. In the console it truncates with an honest count (`# … 25 more lines`), since a terminal can't scroll inside a region. Either way the full value stays on the turn — only the *display* is bounded.

**Long reasoning is bounded too** — but from the *other end*. A tool result arrives whole, so keeping its first N lines is fine. Reasoning streams, so keeping the head would pin the panel to text you'd already finished while new text arrived in a region you couldn't see; it reads as a hang. So the Thinking panel drops its **oldest** lines and reports how many:

```
╭─ Thinking (… 24 earlier lines) ────────────────────────────────────╮
│ Let me verify: (1020 + 1428 + 714)/31 = 3162/31 = 102 ✓ Converting │
│ to decimals for the final answer: Bob pays approximately $32.90,   │
│ Alice pays approximately $46.06, and Carol pays approximately      │
│ $23.03. These decimal values sum to exactly $102.                  │
╰────────────────────────────────────────────────────────────────────╯
```

That's real Anthropic reasoning at the default cap of 10 lines — you land on the conclusion, which is the part worth reading.

The cap counts **rendered** lines, not newlines. Reasoning is prose that wraps well past its own line count (that sample: 35 newlines, 44 rendered lines at width 70) and some providers send none at all, so reusing `truncate_lines()` would undercount the height or do nothing at all. `ThinkingPanel` renders via `console.render_lines()` and crops the result, which also can't break markdown the way slicing the source could. Since the wrapped count depends on console width, the panel computes its own title at render time — verified that the dropped count stays exact at widths 40/70/120 and at three different caps.

All three limits are tunable, and all three accept `None` to switch the bound off:

```python
chat.set_echo_options(
    tool_result_max_lines=20,       # console;  None = full
    tool_result_max_height="400px", # notebook; None = unbounded
    thinking_max_lines=10,          # console;  None = full
)
```

`None` is meaningful here, so it can't double as "not passed" — these use the `MISSING` sentinel that `set_model_params()` already establishes.

## Two bugs this surfaced

- **Reasoning was reachable twice** — once from the stream, once from the completed turn's `ContentThinking` via `emit_other_contents`. Both were invisible, so nobody noticed; making reasoning visible would have doubled it.
- **`echo="all"` showed every tool result twice** — in full as part of the user turn it's attached to, and again on its own. Pre-existing, and it would have left a bounded copy sitting next to an unbounded one.

`stream=False` also shows reasoning now, which it never has.

## What changed underneath

The root cause was that the display received *pre-stringified stream text*: `Chat._echo_content(x: str)` and `MarkdownDisplay.echo(content: str)` only ever saw strings, even though the call site still held the `Content` object and threw the type away. Both signatures widen to `str | Content` (widen, not replace — the documented `chat.current_display.echo("...")` keeps working), and `MarkdownDisplay` now accumulates a list of segments instead of one string, so each backend renders each content type on its own terms.

`ContentToolResult.tagify()`'s HTML moved into an htmltools-free `to_html()` that the notebook display reuses, so the notebook and shinychat can't drift apart.

The `<thinking>` tags were safe to remove: despite what #361 assumed, they were never a stream contract. They only ever reached the display — `content="text"` suppresses reasoning from the stream entirely, and `content="all"` yields `ContentThinkingDelta` objects carrying `phase`, which is what shinychat keys off.

## Verification

- `tagify()` / `_repr_html_()` output is **byte-identical** before and after, across dict/string/error/no-argument results with HTML metacharacters in both arguments and values — so shinychat is unaffected by the `html_escape` swap.
- Console output diffed against `main` to confirm block spacing is preserved; the pre-existing `test_echo_renders_markdown` snapshot is unchanged.
- Notebook markdown rendered through markdown-it and screenshotted in Chromium to confirm the expand/collapse and the bounded scroll actually behave in a browser.
- Stream-facing tests (`test_stream_thinking.py`, `test_provider_stream_contract.py`) pass untouched — that's the check that the stream contract didn't move.
- Reasoning capping was checked against **live Anthropic reasoning**, not just fixtures: the dropped count is exact, the panel never opens on a blank row, and the answer still follows immediately.
- 58 tests in `tests/test_echo_display.py`; `ruff` and `pyright` clean.

This branch also carries new characterization coverage for the display layer written in parallel (display teardown on provider errors and abandoned streams, plus a unit test for the vendored `crop_above` `LiveRender` patch). It's bundled here because it covers the same subsystem and the same file.
