### PR TITLE
docs: add a Reasoning article to Get Started

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -94,6 +94,7 @@ website:
             - get-started/tools.qmd
             - get-started/stream.qmd
             - get-started/structured-data.qmd
+            - get-started/reasoning.qmd
             - get-started/async.qmd
             - get-started/chatbots.qmd
             - get-started/parameters.qmd

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -158,6 +158,7 @@ quartodoc:
         - ChatMistral
         - ChatOllama
         - ChatOpenAI
+        - ChatOpenAICompletions
         - ChatOpenRouter
         - ChatPerplexity
         - ChatPortkey

--- a/docs/_sidebar.yml
+++ b/docs/_sidebar.yml
@@ -18,6 +18,7 @@ website:
       - reference/ChatMistral.qmd
       - reference/ChatOllama.qmd
       - reference/ChatOpenAI.qmd
+      - reference/ChatOpenAICompletions.qmd
       - reference/ChatOpenRouter.qmd
       - reference/ChatPerplexity.qmd
       - reference/ChatPortkey.qmd

--- a/docs/get-started/models.qmd
+++ b/docs/get-started/models.qmd
@@ -59,7 +59,7 @@ In addition to choosing a model provider, you also need to choose a specific mod
 
 If you're using `chatlas` inside your organisation, you'll be limited to what your org allows, which is likely to be one provided by a big cloud provider (e.g. `ChatAzureOpenAI()` and `ChatBedrockAnthropic()`). If you're using `chatlas` for your own personal exploration, you have a lot more freedom so we have a few recommendations to help you get started:
 
-- `ChatOpenAI()` or `ChatAnthropic()` are both good places to start. `ChatOpenAI()` defaults to **GPT-5.4**, but you can use `model = "gpt-5.4-mini"` for a cheaper lower-quality model, or `model = "o3"` for more complex reasoning.  `ChatAnthropic()` is similarly good; it defaults to **Claude Sonnet 4.6** which we have found to be particularly good at writing code.
+- `ChatOpenAI()` or `ChatAnthropic()` are both good places to start. `ChatOpenAI()` defaults to **GPT-5.4**, but you can use `model = "gpt-5.4-mini"` for a cheaper lower-quality model, or `model = "o3"` for more complex [reasoning](reasoning.qmd).  `ChatAnthropic()` is similarly good; it defaults to **Claude Sonnet 4.6** which we have found to be particularly good at writing code.
 
 - `ChatGoogle()` is a strong model with generous free tier (with the downside that [your data is used](https://ai.google.dev/gemini-api/terms#unpaid-services) to improve the model), making it a great place to start if you don't want to spend any money.
 

--- a/docs/get-started/parameters.qmd
+++ b/docs/get-started/parameters.qmd
@@ -6,7 +6,7 @@ callout-appearance: simple
 There are a few different classes of custom parameters that you can set when using chatlas.
 
 The first, and most important, are [model parameters](#model-parameters) that are commonly used across providers. This includes parameters like `temperature`, `top_p`, and `max_tokens`.
-The second is [chat parameters](#chat-parameters), which are specific to the model provider you're using. This might include non-standard parameters like `thinking` or provider-specific built-in `tools`.
+The second is [chat parameters](#chat-parameters), which are specific to the model provider you're using. This might include non-standard parameters like `service_tier` or provider-specific built-in `tools`. (Note that some provider-specific features, like [reasoning](reasoning.qmd), are common enough to earn a dedicated parameter.)
 Finally, there are [HTTP parameters](#http-parameters), which are used to customize the behavior of the HTTP client make requests for the duration of the chat session.
 
 In any case, chatlas leverages typing and IDE autocomplete to help you discover and set these parameters in a type safe way.

--- a/docs/get-started/reasoning.qmd
+++ b/docs/get-started/reasoning.qmd
@@ -1,0 +1,115 @@
+---
+title: Reasoning
+callout-appearance: simple
+---
+
+Modern frontier models can "think" before they answer: they spend tokens working through a problem privately before committing to a response.
+This tends to produce better answers on hard problems (math, code, multi-step planning), at the cost of extra latency and output tokens.
+Providers expose this in different ways and under different names -- reasoning, thinking, thoughts -- but chatlas gives you one consistent interface to enable it, see it, and program against it.
+
+## Enabling reasoning
+
+Reasoning-capable providers accept a `reasoning` parameter when you construct the chat client.
+The simplest option is a string effort level, which works the same way across providers:
+
+```python
+import chatlas as ctl
+
+chat = ctl.ChatAnthropic(reasoning="medium")
+chat.chat("What's the average airspeed velocity of an unladen swallow?")
+```
+
+```python
+chat = ctl.ChatOpenAI(reasoning="medium")
+chat = ctl.ChatGoogle(reasoning="medium")
+```
+
+`"low"`, `"medium"`, and `"high"` are accepted everywhere; individual providers offer more (e.g., [`ChatAnthropic()`](../reference/ChatAnthropic.qmd) goes up to `"max"`, and [`ChatGoogle()`](../reference/ChatGoogle.qmd) down to `"minimal"`).
+Your IDE will autocomplete the levels available for the provider you're using, and each provider's reference page documents its full set.
+[`ChatAzureOpenAI()`](../reference/ChatAzureOpenAI.qmd) and [`ChatBedrockAnthropic()`](../reference/ChatBedrockAnthropic.qmd) take `reasoning` too (Bedrock accepts a token budget rather than an effort level).
+
+If you'd rather control the budget directly, `ChatAnthropic()` and `ChatGoogle()` also accept an integer number of tokens to allocate to reasoning:
+
+```python
+chat = ctl.ChatAnthropic(reasoning=2048)
+```
+
+And for full control, pass the provider's native configuration type:
+
+```python
+chat = ctl.ChatOpenAI(reasoning={"effort": "high", "summary": "detailed"})
+```
+
+::: callout-note
+## Open models think on their own
+
+Many open-weight models (e.g., DeepSeek R1, Qwen QwQ) decide for themselves when to think -- there's no parameter to set.
+[`ChatDeepSeek()`](../reference/ChatDeepSeek.qmd), [`ChatOllama()`](../reference/ChatOllama.qmd), and [`ChatOpenAICompletions()`](../reference/ChatOpenAICompletions.qmd) (LM Studio, vLLM, etc.) capture that reasoning automatically.
+:::
+
+## Seeing reasoning {#seeing-reasoning}
+
+When reasoning is enabled, [`.chat()`](../reference/Chat.qmd#chat) shows it to you as it streams.
+At the console, reasoning appears in a Thinking panel ahead of the response:
+
+```
+╭─ Thinking ───────────────────────────────────────────────╮
+│ Let me work through this. 2+2 is a basic addition        │
+│ problem, so the answer is 4.                             │
+╰──────────────────────────────────────────────────────────╯
+
+The answer is **4**.
+```
+
+Reasoning can get long, so the panel is capped: it keeps the most recent lines (10 by default) and the title notes how many earlier lines scrolled away (e.g., `Thinking (… 12 earlier lines)`).
+Tune this with [`.set_echo_options()`](../reference/Chat.qmd#set_echo_options) -- pass `thinking_max_lines=None` to keep it all.
+
+In a notebook, reasoning renders as a collapsible "Thinking" block instead: open while the model is thinking, collapsed once the response arrives, so it never crowds out the answer.
+
+How much you see is controlled by the `echo` parameter.
+The default (`echo="output"`) includes reasoning and [tool calls](tools.qmd); `echo="text"` shows just the model's answer; `echo="none"` shows nothing at all.
+
+## Accessing reasoning programmatically {#programmatic-access}
+
+For text, reasoning stays out of your way: `str()` on a [`.chat()`](chat.qmd) result and the chunks from [`.stream()`](stream.qmd) contain only the model's answer.
+To consume reasoning yourself -- say, to render it in a [chatbot](chatbots.qmd) UI -- set `content="all"` and the stream yields rich content objects as they're generated:
+
+```python
+stream = chat.stream("What is 2+2?", content="all")
+for chunk in stream:
+    print(type(chunk))
+```
+
+```
+<class 'chatlas._content.ContentThinkingDelta'>
+<class 'chatlas._content.ContentThinkingDelta'>
+<class 'str'>
+<class 'str'>
+```
+
+Each [`ContentThinkingDelta`](../reference/types.ContentThinkingDelta.qmd) carries a fragment of reasoning text (`.thinking`), plus a `.phase` (`"start"`, `"body"`, or `"end"`) marking where one thinking block begins and ends -- handy for opening and closing a collapsible region in your UI.
+This is the same pattern used for [displaying tool calls](../tool-calling/displays.qmd) in bespoke apps.
+
+Once the response completes, the reasoning is stored on the assistant turn as [`ContentThinking`](../reference/types.ContentThinking.qmd):
+
+```python
+turn = chat.get_last_turn()
+print([type(c).__name__ for c in turn.contents])
+```
+
+```
+['ContentThinking', 'ContentText']
+```
+
+## Reasoning across turns {#reasoning-across-turns}
+
+You generally don't need to think about what happens to reasoning on the *next* request -- chatlas handles each provider's requirements for you:
+
+- **Anthropic** returns its full thinking and requires it to be replayed (with cryptographic signatures) for subsequent requests, which chatlas does automatically.
+- **OpenAI** keeps raw reasoning private and returns only a summary.
+  chatlas also requests the *encrypted* reasoning and sends it back on your behalf, so multi-turn reasoning works without OpenAI-side state.
+- **OpenAI-compatible backends** vary: most expect prior reasoning to be dropped from the conversation, which is what [`ChatOpenAICompletions()`](../reference/ChatOpenAICompletions.qmd) does by default (the reasoning stays on the turn -- it's just not sent back).
+  Pass `preserve_thinking=True` for backends that want it replayed, as [`ChatDeepSeek()`](../reference/ChatDeepSeek.qmd) does.
+
+One thing to keep in mind: reasoning tokens are billed as *output* tokens, so higher effort levels cost more.
+See [monitoring](monitor.qmd) for keeping an eye on token usage and cost.

--- a/docs/get-started/stream.qmd
+++ b/docs/get-started/stream.qmd
@@ -52,6 +52,7 @@ len(chat.get_turns())
 To gain access to these, set the `content` parameter to `"all"`.
 If the response includes things like tool calls, the stream will yield the relevant content types as they are generated.
 As we'll learn later, this can be useful for [displaying tool calls](../tool-calling/displays.qmd) in something like a [chatbot](chatbots.qmd) app.
+The same goes for [reasoning](reasoning.qmd): when thinking is enabled, the stream yields `ContentThinkingDelta` chunks as the model thinks.
 
 ```python
 def get_current_weather(lat: float, lng: float):


### PR DESCRIPTION
Reasoning is now something chatlas users hit on their very first chat — default models think before answering, and (as of #362) that thinking is actually visible when echoing. But the docs barely acknowledged the feature: the only mention was a stale reference to `thinking` as a provider-specific kwarg, even though `reasoning` is a first-class constructor parameter on five providers.

This PR gives reasoning a proper home: a new **Reasoning** article in the Get Started section (between Structured data and Async) covering the full lifecycle:

- **Enabling it** — the unified `reasoning` parameter (string effort levels everywhere; token budgets for Anthropic/Google; provider-native config as the escape hatch), plus a callout that open models (DeepSeek, Ollama, LM Studio) think on their own.
- **Seeing it** — the bounded Thinking panel in the console and the collapsible block in notebooks, and how `echo` modes interact with it.
- **Programming against it** — `.stream(content="all")` yielding `ContentThinkingDelta` (with block-boundary phases) and `ContentThinking` on completed turns.
- **Multi-turn behavior** — what gets replayed per provider (Anthropic thinking blocks, OpenAI encrypted summaries, `preserve_thinking` for OpenAI-compatible backends) and the output-token cost note.

Supporting changes:

- `ChatOpenAICompletions` was missing from the reference index entirely (pre-existing gap — `models.qmd` already had a dead link to it), so it's now listed under Chat model providers.
- Cross-links from `parameters.qmd` (replacing the stale `thinking` example), `stream.qmd`, and `models.qmd`.

Every API claim in the article was checked against the source (effort-level literals, echo semantics, `thinking_max_lines` default, `ContentThinkingDelta.phase` values, `preserve_thinking` defaults). Full site render verified: sidebar placement, all links resolve.