### PR TITLE
Price refusal fallback at serving model's rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### New features
 
 * New `ChatBedrock()` reaches models on AWS's `bedrock-mantle` endpoint, including the GPT-5 family, Grok 4.3, Gemma 4, and Claude Mythos — none of which were previously available through chatlas. It picks the request format from the model name (`api="responses"` for the OpenAI Responses API, `api="messages"` for the Anthropic Messages API), or you can set `api` explicitly. Authentication uses your AWS credential chain (profiles, SSO, instance roles), or a Bedrock API key via the `AWS_BEARER_TOKEN_BEDROCK` environment variable.
+* `ChatAnthropic()` (and `ChatBedrockAnthropic()`) now correctly handle the `fallback` content block returned when a model's server-side refusal fallback (`server-side-fallback-2026-06-01`) is triggered, and price the turn at the serving model's rate rather than the requested model's, mirroring [ellmer's equivalent fix](https://github.com/tidyverse/ellmer/pull/1058).
 
 ### Improvements
 

--- a/chatlas/_provider_anthropic.py
+++ b/chatlas/_provider_anthropic.py
@@ -339,6 +339,26 @@ def normalize_finish_reason(reason: str | None) -> str | None:
     return _ANTHROPIC_FINISH_REASON_MAP.get(reason, reason)
 
 
+def serving_model(completion: Message) -> str:
+    """
+    The model that actually served the response.
+
+    A server-side refusal fallback
+    (https://platform.claude.com/docs/en/build-with-claude/refusals-and-fallback)
+    can route a request to a different model than the one requested.
+    `completion.model` is unreliable for a mid-response fallback in a stream
+    (it keeps the requested model named at `message_start`), so prefer the
+    last `fallback` content block's `to.model`.
+    """
+    served_model = None
+    for content in completion.content:
+        if getattr(content, "type", None) == "fallback":
+            to = getattr(content, "to", None)
+            if isinstance(to, dict) and "model" in to:
+                served_model = to["model"]
+    return served_model or completion.model
+
+
 class AnthropicProvider(
     Provider[Message, RawMessageStreamEvent, Message, "SubmitInputArgs"]
 ):
@@ -674,6 +694,25 @@ class AnthropicProvider(
             completion.usage.output_tokens,
             usage.cache_read_input_tokens if usage.cache_read_input_tokens else 0,
         )
+
+    def value_cost(
+        self,
+        completion,
+        tokens: tuple[int, int, int] | None = None,
+    ) -> float | None:
+        """
+        Compute the cost for a completion, pricing a refusal fallback at the
+        serving model's rate rather than the requested model's.
+        """
+        from ._tokens import get_token_cost
+
+        if tokens is None:
+            tokens = self.value_tokens(completion)
+        if tokens is None:
+            return None
+
+        model = serving_model(completion) if completion is not None else self.model
+        return get_token_cost(self.name, model, tokens)
 
     def token_count(
         self,
@@ -1057,6 +1096,9 @@ class AnthropicProvider(
                 contents.append(anthropic_search_result(content))
             elif content.type == "web_fetch_tool_result":
                 contents.append(anthropic_fetch_result(content))
+            elif content.type == "fallback":
+                # https://platform.claude.com/docs/en/build-with-claude/refusals-and-fallback
+                pass
 
         return AssistantTurn(
             contents,

--- a/chatlas/types/openai/_submit.py
+++ b/chatlas/types/openai/_submit.py
@@ -44,6 +44,7 @@ class SubmitInputArgs(TypedDict, total=False):
             "gpt-5.6-sol",
             "gpt-5.6-terra",
             "gpt-5.6-luna",
+            "gpt-5.5",
             "gpt-5.4",
             "gpt-5.4-mini",
             "gpt-5.4-nano",

--- a/chatlas/types/openai/_submit_responses.py
+++ b/chatlas/types/openai/_submit_responses.py
@@ -124,6 +124,7 @@ class SubmitInputArgs(TypedDict, total=False):
             "gpt-5.6-sol",
             "gpt-5.6-terra",
             "gpt-5.6-luna",
+            "gpt-5.5",
             "gpt-5.4",
             "gpt-5.4-mini",
             "gpt-5.4-nano",

--- a/tests/test_provider_anthropic.py
+++ b/tests/test_provider_anthropic.py
@@ -28,7 +28,11 @@ from chatlas._content import (
     ContentPDF,
     ContentUploaded,
 )
-from chatlas._provider_anthropic import _ANTHROPIC_FINISH_REASON_MAP, AnthropicProvider
+from chatlas._provider_anthropic import (
+    _ANTHROPIC_FINISH_REASON_MAP,
+    AnthropicProvider,
+    serving_model,
+)
 from chatlas._provider_anthropic import (
     normalize_finish_reason as anthropic_normalize_finish_reason,
 )
@@ -705,3 +709,65 @@ def test_anthropic_truncated_plain_text_still_returns_a_turn():
 
     assert turn.text == '{"comments": [{"body": "trunc'
     assert turn.finish_reason == "max_tokens"
+
+
+def fallback_message(
+    *, requested_model: str = "claude-fable-5", served_model: str = "claude-opus-4-8"
+) -> "Message":
+    """A response where a server-side refusal fallback swapped the serving model.
+
+    https://platform.claude.com/docs/en/build-with-claude/refusals-and-fallback
+    """
+    return Message.construct(
+        id="msg_1",
+        type="message",
+        role="assistant",
+        model=requested_model,
+        stop_reason="end_turn",
+        stop_sequence=None,
+        content=[
+            TextBlock.construct(
+                type="fallback",
+                from_={"model": requested_model},
+                to={"model": served_model},
+            ),
+            TextBlock(type="text", text="ok"),
+        ],
+        usage=Usage(input_tokens=1000, output_tokens=50),
+    )
+
+
+def test_anthropic_fallback_block_excluded_from_contents():
+    provider = cast(AnthropicProvider, chat_func().provider)
+
+    turn = provider._as_turn(fallback_message(), has_data_model=False)
+
+    assert turn.text == "ok"
+    assert len(turn.contents) == 1
+
+
+def test_serving_model_prefers_last_fallback_blocks_to_model():
+    assert serving_model(fallback_message()) == "claude-opus-4-8"
+
+    no_fallback = Message.construct(
+        id="msg_1",
+        type="message",
+        role="assistant",
+        model="claude-fable-5",
+        stop_reason="end_turn",
+        stop_sequence=None,
+        content=[TextBlock(type="text", text="hi")],
+        usage=Usage(input_tokens=10, output_tokens=5),
+    )
+    assert serving_model(no_fallback) == "claude-fable-5"
+
+
+def test_anthropic_value_cost_prices_fallback_at_serving_models_rate():
+    provider = AnthropicProvider(model="claude-fable-5")
+
+    completion = fallback_message()
+    tokens = provider.value_tokens(completion)
+    cost = provider.value_cost(completion, tokens)
+
+    # opus-4-8 rates ($5/$25 per 1M), not fable-5's ($10/$50).
+    assert cost == pytest.approx((1000 * 5 + 50 * 25) / 1e6)


### PR DESCRIPTION
## Summary

Anthropic's server-side refusal fallback (`server-side-fallback-2026-06-01`) can silently route a request to a different model than the one requested — e.g. a smaller model refuses, so a larger one finishes the response instead. Two problems follow from that: the response includes a `fallback` content block that chatlas didn't know about, and pricing used the requested model's rate even when a different, differently-priced model actually served the tokens.

This mirrors ellmer's fix: [tidyverse/ellmer#1058](https://github.com/tidyverse/ellmer/pull/1058).

- `AnthropicProvider` now recognizes the `fallback` content block and excludes it from turn contents (it's bookkeeping, not something to display).
- Cost is now computed from the model that actually served the response (the last `fallback` block's `to.model`, when present) instead of the requested model, via a `serving_model()` helper and an `AnthropicProvider.value_cost()` override (same pattern already used by `OpenAIProvider` for `service_tier`-aware pricing).

As with ellmer's PR, this doesn't yet do per-iteration cost accounting when the fallback happens mid-stream after some tokens were already billed at the original model's rate — it prices the whole turn at the serving model's rate, which is what the actual API response reflects for now.

## Test plan
- [x] `uv run pytest tests/test_provider_anthropic.py tests/test_tokens.py`
- [x] `uv run ruff check` / `uv run pyright` on changed files