### PR TITLE
fix: Declare the httpx dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* chatlas now declares its dependency on `httpx`. (#387)
 * `ChatAnthropic()` citations backed by `document_index` (from `tool_web_fetch()` results and document/PDF attachments) now resolve to a source URL, instead of always coming back without one. Anthropic counts that index across every document-shaped block in the whole request, including ones from prior turns, which chatlas wasn't accounting for. (#382)
 * Token cost lookups (`.get_cost()`, `token_usage()`) no longer crash on models with no input price (e.g. output-only video generation models on Bedrock), and read ellmer's current pricing data format, which now wraps the price list in a versioned envelope rather than a bare array. (#382)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
-* chatlas now declares its dependency on `httpx`. (#387)
+* OpenAI-based providers now support the OpenAI 3 SDK and its native `httpx2`
+  clients. Custom clients are typed and documented as `httpx2`; legacy `httpx`
+  clients remain supported at runtime during migration. (#387)
 * `ChatAnthropic()` citations backed by `document_index` (from `tool_web_fetch()` results and document/PDF attachments) now resolve to a source URL, instead of always coming back without one. Anthropic counts that index across every document-shaped block in the whole request, including ones from prior turns, which chatlas wasn't accounting for. (#382)
 * Token cost lookups (`.get_cost()`, `token_usage()`) no longer crash on models with no input price (e.g. output-only video generation models on Bedrock), and read ellmer's current pricing data format, which now wraps the price list in a versioned envelope rather than a bare array. (#382)
 

--- a/chatlas/_provider_databricks.py
+++ b/chatlas/_provider_databricks.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, cast
+
+import httpx
+from openai import AsyncOpenAI
 
 from ._chat import Chat
 from ._logging import log_model_default
 from ._provider_openai_completions import OpenAICompletionsProvider
+from ._provider_openai_generic import create_openai_client
 
 if TYPE_CHECKING:
     from databricks.sdk import WorkspaceClient
@@ -103,9 +107,6 @@ class DatabricksProvider(OpenAICompletionsProvider):
                 "Install it with `pip install databricks-sdk`."
             )
 
-        import httpx
-        from openai import AsyncOpenAI
-
         super().__init__(
             name=name,
             model=model,
@@ -128,10 +129,16 @@ class DatabricksProvider(OpenAICompletionsProvider):
         # Note also there is a open PR to add async support that does essentially
         # the same thing:
         # https://github.com/databricks/databricks-sdk-py/pull/851
-        self._async_client = AsyncOpenAI(
-            base_url=client.base_url,
-            api_key="no-token",  # A placeholder to pass validations, this will not be used
-            http_client=httpx.AsyncClient(auth=client._client.auth),
+        # Databricks injects a legacy httpx client even though OpenAI types it as
+        # native httpx2. OpenAI 3 retains this as a runtime compatibility path.
+        legacy_auth = cast(httpx.Auth | None, client._client.auth)
+        self._async_client = create_openai_client(
+            AsyncOpenAI,
+            {
+                "base_url": client.base_url,
+                "api_key": "no-token",
+                "http_client": httpx.AsyncClient(auth=legacy_auth),
+            },
         )
 
     def list_models(self):

--- a/chatlas/_provider_openai_azure.py
+++ b/chatlas/_provider_openai_azure.py
@@ -9,6 +9,7 @@ from ._chat import Chat
 from ._provider import no_file_management
 from ._provider_openai import OpenAIProvider
 from ._provider_openai_completions import OpenAICompletionsProvider
+from ._provider_openai_generic import create_openai_client
 from ._utils import MISSING, MISSING_TYPE, is_testing, split_http_client_kwargs
 
 if TYPE_CHECKING:
@@ -157,8 +158,8 @@ class OpenAIAzureProvider(OpenAIProvider):
 
         sync_kwargs, async_kwargs = split_http_client_kwargs(kwargs_full)
 
-        self._client = AzureOpenAI(**sync_kwargs)  # type: ignore
-        self._async_client = AsyncAzureOpenAI(**async_kwargs)  # type: ignore
+        self._client = create_openai_client(AzureOpenAI, sync_kwargs)
+        self._async_client = create_openai_client(AsyncAzureOpenAI, async_kwargs)
 
 
 def ChatAzureOpenAICompletions(
@@ -226,5 +227,5 @@ class OpenAIAzureCompletionsProvider(OpenAICompletionsProvider):
 
         sync_kwargs, async_kwargs = split_http_client_kwargs(kwargs_full)
 
-        self._client = AzureOpenAI(**sync_kwargs)  # type: ignore
-        self._async_client = AsyncAzureOpenAI(**async_kwargs)  # type: ignore
+        self._client = create_openai_client(AzureOpenAI, sync_kwargs)
+        self._async_client = create_openai_client(AsyncAzureOpenAI, async_kwargs)

--- a/chatlas/_provider_openai_generic.py
+++ b/chatlas/_provider_openai_generic.py
@@ -6,7 +6,18 @@ import re
 import tempfile
 from abc import abstractmethod
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Generic, Iterable, Literal, Optional
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Generic,
+    Iterable,
+    Literal,
+    Mapping,
+    Optional,
+    TypeVar,
+    cast,
+)
 
 import orjson
 from openai import AsyncOpenAI, OpenAI
@@ -34,7 +45,20 @@ if TYPE_CHECKING:
     from .types.openai import ChatClientArgs
 
 
-def openai_models_to_info(models: Iterable["Model"], provider_name: str) -> list[ModelInfo]:
+OpenAIClientT = TypeVar("OpenAIClientT")
+
+
+def create_openai_client(
+    constructor: Callable[..., OpenAIClientT],
+    kwargs: Mapping[str, object],
+) -> OpenAIClientT:
+    # OpenAI supports legacy httpx clients at runtime but omits them from its types.
+    return constructor(**cast(Any, kwargs))
+
+
+def openai_models_to_info(
+    models: Iterable["Model"], provider_name: str
+) -> list[ModelInfo]:
     """Convert OpenAI SDK `Model` objects into chatlas `ModelInfo` dicts.
 
     Shared by `OpenAIAbstractProvider.list_models()` and by providers (like
@@ -122,9 +146,8 @@ class OpenAIAbstractProvider(
         # Avoid passing the wrong sync/async client to the OpenAI constructor.
         sync_kwargs, async_kwargs = split_http_client_kwargs(kwargs_full)
 
-        # TODO: worth bringing in AsyncOpenAI types?
-        self._client = OpenAI(**sync_kwargs)  # type: ignore
-        self._async_client = AsyncOpenAI(**async_kwargs)
+        self._client = create_openai_client(OpenAI, sync_kwargs)
+        self._async_client = create_openai_client(AsyncOpenAI, async_kwargs)
 
     def list_models(self):
         return openai_models_to_info(self._client.models.list(), self.name)

--- a/chatlas/_provider_posit.py
+++ b/chatlas/_provider_posit.py
@@ -10,7 +10,9 @@ from pathlib import Path
 from typing import Any, Callable, Literal, Optional
 
 import httpx
+import httpx2
 import requests
+from openai import AsyncOpenAI, OpenAI, OpenAIError
 from platformdirs import user_cache_dir
 
 from ._chat import Chat
@@ -204,7 +206,26 @@ class PositAuth(httpx.Auth):
         yield request
 
 
-def _make_posit_error_hook(error_cls: type[Exception]):
+class PositHttpx2Auth(httpx2.Auth):
+    def __init__(self, credentials: Callable[[], str]):
+        self._credentials = credentials
+
+    def _apply(self, request: httpx2.Request, token: str) -> None:
+        request.headers.pop("x-api-key", None)
+        request.headers["Authorization"] = f"Bearer {token}"
+
+    def sync_auth_flow(self, request: httpx2.Request):
+        token = self._credentials()
+        self._apply(request, token)
+        yield request
+
+    async def async_auth_flow(self, request: httpx2.Request):
+        token = await asyncio.to_thread(self._credentials)
+        self._apply(request, token)
+        yield request
+
+
+def make_posit_anthropic_error_hook(error_cls: type[Exception]):
     def hook(response: httpx.Response) -> None:
         if response.status_code < 400:
             return
@@ -216,8 +237,32 @@ def _make_posit_error_hook(error_cls: type[Exception]):
     return hook
 
 
-def _make_posit_error_hook_async(error_cls: type[Exception]):
+def make_posit_anthropic_error_hook_async(error_cls: type[Exception]):
     async def hook(response: httpx.Response) -> None:
+        if response.status_code < 400:
+            return
+        await response.aread()
+        message = _posit_error_message(response.status_code, _safe_json(response))
+        if message is not None:
+            raise error_cls(message)
+
+    return hook
+
+
+def make_posit_openai_error_hook(error_cls: type[Exception]):
+    def hook(response: httpx2.Response) -> None:
+        if response.status_code < 400:
+            return
+        response.read()
+        message = _posit_error_message(response.status_code, _safe_json(response))
+        if message is not None:
+            raise error_cls(message)
+
+    return hook
+
+
+def make_posit_openai_error_hook_async(error_cls: type[Exception]):
+    async def hook(response: httpx2.Response) -> None:
         if response.status_code < 400:
             return
         await response.aread()
@@ -294,7 +339,9 @@ class PositAnthropicProvider(AnthropicProvider):
             base_url=flavor_base_url,
             http_client=httpx.Client(
                 auth=auth,
-                event_hooks={"response": [_make_posit_error_hook(AnthropicError)]},
+                event_hooks={
+                    "response": [make_posit_anthropic_error_hook(AnthropicError)]
+                },
             ),
         )
         self._async_client = AsyncAnthropic(
@@ -303,7 +350,7 @@ class PositAnthropicProvider(AnthropicProvider):
             http_client=httpx.AsyncClient(
                 auth=auth,
                 event_hooks={
-                    "response": [_make_posit_error_hook_async(AnthropicError)]
+                    "response": [make_posit_anthropic_error_hook_async(AnthropicError)]
                 },
             ),
         )
@@ -323,28 +370,28 @@ class PositOpenAIProvider(OpenAICompletionsProvider):
     ):
         super().__init__(model=model, api_key="not-used", name=name)
 
-        from openai import AsyncOpenAI, OpenAI, OpenAIError
-
         self._gateway_base_url = base_url.rstrip("/")
         self._credentials = credentials
 
-        auth = PositAuth(credentials)
+        auth = PositHttpx2Auth(credentials)
         flavor_base_url = f"{self._gateway_base_url}/openai/v1"
 
         self._client = OpenAI(
             api_key="not-used",
             base_url=flavor_base_url,
-            http_client=httpx.Client(
+            http_client=httpx2.Client(
                 auth=auth,
-                event_hooks={"response": [_make_posit_error_hook(OpenAIError)]},
+                event_hooks={"response": [make_posit_openai_error_hook(OpenAIError)]},
             ),
         )
         self._async_client = AsyncOpenAI(
             api_key="not-used",
             base_url=flavor_base_url,
-            http_client=httpx.AsyncClient(
+            http_client=httpx2.AsyncClient(
                 auth=auth,
-                event_hooks={"response": [_make_posit_error_hook_async(OpenAIError)]},
+                event_hooks={
+                    "response": [make_posit_openai_error_hook_async(OpenAIError)]
+                },
             ),
         )
 

--- a/chatlas/_utils.py
+++ b/chatlas/_utils.py
@@ -8,6 +8,7 @@ import re
 from typing import Any, AsyncIterable, Awaitable, Callable, Iterable, TypeVar, cast
 
 import httpx
+import httpx2
 
 from ._typing_extensions import ParamSpec, TypedDict, TypeGuard
 
@@ -27,9 +28,9 @@ def split_http_client_kwargs(
     async_kwargs = kwargs.copy()
 
     http_client = kwargs.get("http_client")
-    if isinstance(http_client, httpx.AsyncClient):
+    if isinstance(http_client, (httpx.AsyncClient, httpx2.AsyncClient)):
         sync_kwargs.pop("http_client")
-    elif isinstance(http_client, httpx.Client):
+    elif isinstance(http_client, (httpx.Client, httpx2.Client)):
         async_kwargs.pop("http_client")
 
     return sync_kwargs, async_kwargs

--- a/chatlas/types/openai/_client.py
+++ b/chatlas/types/openai/_client.py
@@ -5,7 +5,7 @@
 
 from typing import Awaitable, Callable, Mapping, Optional, TypedDict, Union
 
-import httpx
+import httpx2
 import openai
 import openai._provider
 import openai.auth._workload
@@ -19,12 +19,12 @@ class ChatClientArgs(TypedDict, total=False):
     project: str | None
     webhook_secret: str | None
     provider: openai._provider._Provider | None
-    base_url: str | httpx.URL | None
-    websocket_base_url: str | httpx.URL | None
+    base_url: str | httpx2.URL | None
+    websocket_base_url: str | httpx2.URL | None
     timeout: float | openai.Timeout | None | openai.NotGiven
     max_retries: int
     default_headers: Optional[Mapping[str, str]]
     default_query: Optional[Mapping[str, object]]
-    http_client: httpx.AsyncClient | None
+    http_client: httpx2.AsyncClient | None
     _strict_response_validation: bool
     _enforce_credentials: bool

--- a/chatlas/types/openai/_client.py
+++ b/chatlas/types/openai/_client.py
@@ -25,6 +25,6 @@ class ChatClientArgs(TypedDict, total=False):
     max_retries: int
     default_headers: Optional[Mapping[str, str]]
     default_query: Optional[Mapping[str, object]]
-    http_client: httpx2.AsyncClient | None
+    http_client: httpx2.Client | httpx2.AsyncClient | None
     _strict_response_validation: bool
     _enforce_credentials: bool

--- a/chatlas/types/openai/_client_azure.py
+++ b/chatlas/types/openai/_client_azure.py
@@ -4,7 +4,7 @@
 
 from typing import Awaitable, Callable, Mapping, Optional, TypedDict, Union
 
-import httpx
+import httpx2
 import openai
 import openai.auth._workload
 
@@ -21,11 +21,11 @@ class ChatAzureClientArgs(TypedDict, total=False):
     project: str | None
     webhook_secret: str | None
     base_url: str | None
-    websocket_base_url: str | httpx.URL | None
+    websocket_base_url: str | httpx2.URL | None
     timeout: float | openai.Timeout | None | openai.NotGiven
     max_retries: int
     default_headers: Optional[Mapping[str, str]]
     default_query: Optional[Mapping[str, object]]
-    http_client: httpx.AsyncClient | None
+    http_client: httpx2.AsyncClient | None
     _strict_response_validation: bool
     _enforce_credentials: bool

--- a/chatlas/types/openai/_client_azure.py
+++ b/chatlas/types/openai/_client_azure.py
@@ -26,6 +26,6 @@ class ChatAzureClientArgs(TypedDict, total=False):
     max_retries: int
     default_headers: Optional[Mapping[str, str]]
     default_query: Optional[Mapping[str, object]]
-    http_client: httpx2.AsyncClient | None
+    http_client: httpx2.Client | httpx2.AsyncClient | None
     _strict_response_validation: bool
     _enforce_credentials: bool

--- a/chatlas/types/openai/_submit_responses.py
+++ b/chatlas/types/openai/_submit_responses.py
@@ -219,6 +219,9 @@ class SubmitInputArgs(TypedDict, total=False):
             "gpt-5-pro",
             "gpt-5-pro-2025-10-06",
             "gpt-5.1-codex-max",
+            "gpt-daybreak-blue-latest",
+            "gpt-daybreak-red-latest",
+            "gpt-5.6-cyber",
         ],
         openai.Omit,
     ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ requires-python = ">=3.10"
 dependencies = [
   "requests",
   "httpx",
+  "httpx2",
   "platformdirs",
   "pydantic>=2.0",
   "jinja2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
   "requests",
+  "httpx",
   "platformdirs",
   "pydantic>=2.0",
   "jinja2",

--- a/scripts/_generate_openai_types.py
+++ b/scripts/_generate_openai_types.py
@@ -1,9 +1,10 @@
 from pathlib import Path
 
-from _utils import generate_typeddict_code, write_code_to_file
 from openai import AsyncAzureOpenAI, AsyncOpenAI
 from openai.resources.chat import Completions
 from openai.resources.responses import Responses
+
+from _utils import generate_typeddict_code, write_code_to_file
 
 types_dir = Path(__file__).parent.parent / "chatlas" / "types"
 provider_dir = types_dir / "openai"
@@ -48,7 +49,14 @@ def fix_callable_types(text: str):
     return text.replace("Callable[Awaitable[str]]", "Callable[[], Awaitable[str]]")
 
 
-init_args = fix_callable_types(init_args)
+def widen_http_client_type(text: str) -> str:
+    return text.replace(
+        "http_client: httpx2.AsyncClient | None",
+        "http_client: httpx2.Client | httpx2.AsyncClient | None",
+    )
+
+
+init_args = widen_http_client_type(fix_callable_types(init_args))
 
 write_code_to_file(
     init_args,
@@ -65,7 +73,7 @@ init_args = generate_typeddict_code(
     },
 )
 
-init_args = fix_callable_types(init_args)
+init_args = widen_http_client_type(fix_callable_types(init_args))
 
 write_code_to_file(
     init_args,

--- a/tests/test_openai_httpx2.py
+++ b/tests/test_openai_httpx2.py
@@ -1,0 +1,158 @@
+import asyncio
+from typing import Any, cast, get_args, get_type_hints
+
+import httpx
+import httpx2
+import pytest
+from chatlas import ChatAzureOpenAI, ChatOpenAI, ChatOpenAICompletions
+from chatlas._provider_openai import OpenAIProvider
+from chatlas._provider_openai_azure import OpenAIAzureProvider
+from chatlas._provider_openai_completions import OpenAICompletionsProvider
+from chatlas.types.openai import ChatAzureClientArgs, ChatClientArgs
+
+
+def test_openai_client_args_use_native_httpx2_clients():
+    expected = {
+        type(None),
+        httpx2.Client,
+        httpx2.AsyncClient,
+    }
+
+    client_types = set(get_args(get_type_hints(ChatClientArgs)["http_client"]))
+    azure_client_types = set(
+        get_args(get_type_hints(ChatAzureClientArgs)["http_client"])
+    )
+
+    assert client_types == expected
+    assert azure_client_types == expected
+
+
+def test_openai_routes_legacy_sync_client():
+    assert_openai_client_routed(httpx.Client(), is_async=False)
+
+
+def test_openai_routes_legacy_async_client():
+    assert_openai_client_routed(httpx.AsyncClient(), is_async=True)
+
+
+def test_openai_routes_native_sync_client():
+    assert_openai_client_routed(httpx2.Client(), is_async=False)
+
+
+def test_openai_routes_native_async_client():
+    assert_openai_client_routed(httpx2.AsyncClient(), is_async=True)
+
+
+def test_openai_native_sync_client_performs_request():
+    requests: list[httpx2.Request] = []
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return make_chat_completion_response(request)
+
+    client = httpx2.Client(transport=httpx2.MockTransport(handler))
+    chat = ChatOpenAICompletions(
+        model="test-model",
+        api_key="test",
+        kwargs={"http_client": client},
+    )
+    provider = cast(OpenAICompletionsProvider, chat.provider)
+
+    try:
+        response = chat.chat("hello", stream=False, echo="none")
+        assert str(response) == "transport works"
+        assert [str(request.url) for request in requests] == [
+            "https://api.openai.com/v1/chat/completions"
+        ]
+    finally:
+        provider._client.close()
+        asyncio.run(provider._async_client.close())
+
+
+@pytest.mark.asyncio
+async def test_openai_native_async_client_performs_request():
+    requests: list[httpx2.Request] = []
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return make_chat_completion_response(request)
+
+    client = httpx2.AsyncClient(transport=httpx2.MockTransport(handler))
+    chat = ChatOpenAICompletions(
+        model="test-model",
+        api_key="test",
+        kwargs={"http_client": client},
+    )
+    provider = cast(OpenAICompletionsProvider, chat.provider)
+
+    try:
+        response = await chat.chat_async("hello", stream=False, echo="none")
+        assert await response.get_content() == "transport works"
+        assert [str(request.url) for request in requests] == [
+            "https://api.openai.com/v1/chat/completions"
+        ]
+    finally:
+        provider._client.close()
+        await provider._async_client.close()
+
+
+def test_azure_routes_native_async_client():
+    client = httpx2.AsyncClient()
+    chat = ChatAzureOpenAI(
+        endpoint="https://example.openai.azure.com",
+        deployment_id="test",
+        api_version="2025-03-01-preview",
+        kwargs={"http_client": client},
+    )
+    provider = cast(OpenAIAzureProvider, chat.provider)
+
+    try:
+        assert provider._async_client._client is client
+    finally:
+        provider._client.close()
+        asyncio.run(provider._async_client.close())
+
+
+def make_chat_completion_response(request: httpx2.Request) -> httpx2.Response:
+    return httpx2.Response(
+        200,
+        request=request,
+        json={
+            "id": "chatcmpl-test",
+            "object": "chat.completion",
+            "created": 0,
+            "model": "test-model",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "transport works",
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 1,
+                "completion_tokens": 2,
+                "total_tokens": 3,
+            },
+        },
+    )
+
+
+def assert_openai_client_routed(
+    client: httpx.Client | httpx.AsyncClient | httpx2.Client | httpx2.AsyncClient,
+    *,
+    is_async: bool,
+) -> None:
+    kwargs = cast(Any, {"http_client": client})
+    chat = ChatOpenAI(kwargs=kwargs)
+    provider = cast(OpenAIProvider, chat.provider)
+    target = provider._async_client if is_async else provider._client
+
+    try:
+        assert target._client is client
+    finally:
+        provider._client.close()
+        asyncio.run(provider._async_client.close())

--- a/tests/test_provider_databricks.py
+++ b/tests/test_provider_databricks.py
@@ -1,5 +1,12 @@
+import asyncio
+from types import SimpleNamespace
+from typing import Any, cast
+
+import httpx
 import pytest
 from chatlas import ChatDatabricks
+from chatlas._provider_databricks import DatabricksProvider
+from openai import OpenAI
 
 from .conftest import (
     assert_data_extraction,
@@ -107,3 +114,32 @@ def test_connect_without_openai_key(monkeypatch):
     # This should not raise an error
     chat = ChatDatabricks()
     assert chat is not None
+
+
+def test_databricks_async_client_preserves_legacy_httpx_auth():
+    auth = httpx.BasicAuth("user", "password")
+    sync_client = OpenAI(
+        api_key="no-token",
+        base_url="https://workspace.example.com/serving-endpoints",
+        http_client=cast(
+            Any,
+            httpx.Client(auth=auth),
+        ),
+    )
+    workspace_client = SimpleNamespace(
+        serving_endpoints=SimpleNamespace(
+            get_open_ai_client=lambda: sync_client,
+        )
+    )
+
+    provider = DatabricksProvider(
+        model="test",
+        workspace_client=cast(Any, workspace_client),
+    )
+
+    try:
+        assert isinstance(provider._async_client._client, httpx.AsyncClient)
+        assert provider._async_client._client.auth is auth
+    finally:
+        provider._client.close()
+        asyncio.run(provider._async_client.close())

--- a/tests/test_provider_posit.py
+++ b/tests/test_provider_posit.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 import httpx
+import httpx2
 import pytest
 import requests
 from chatlas._provider import ModelInfo
@@ -14,12 +15,16 @@ from chatlas._provider_posit import (
     PositAnthropicProvider,
     PositAuth,
     PositCredentials,
+    PositHttpx2Auth,
     PositOpenAIProvider,
-    _make_posit_error_hook,
-    _make_posit_error_hook_async,
     _posit_error_message,
     list_models_posit,
+    make_posit_anthropic_error_hook,
+    make_posit_anthropic_error_hook_async,
+    make_posit_openai_error_hook,
+    make_posit_openai_error_hook_async,
 )
+from openai import AsyncOpenAI, OpenAI, OpenAIError
 
 
 class _FakeResponse:
@@ -295,7 +300,7 @@ def test_anthropic_error_hook_propagates_through_client_send():
         http_client=httpx.Client(
             auth=PositAuth(lambda: "test-token"),
             transport=httpx.MockTransport(handler),
-            event_hooks={"response": [_make_posit_error_hook(AnthropicError)]},
+            event_hooks={"response": [make_posit_anthropic_error_hook(AnthropicError)]},
         ),
     )
 
@@ -322,7 +327,9 @@ async def test_anthropic_error_hook_propagates_through_async_client_send():
         http_client=httpx.AsyncClient(
             auth=PositAuth(lambda: "test-token"),
             transport=httpx.MockTransport(handler),
-            event_hooks={"response": [_make_posit_error_hook_async(AnthropicError)]},
+            event_hooks={
+                "response": [make_posit_anthropic_error_hook_async(AnthropicError)]
+            },
         ),
     )
 
@@ -334,26 +341,79 @@ async def test_anthropic_error_hook_propagates_through_async_client_send():
         )
 
 
-def test_openai_error_hook_propagates_through_client_send():
-    from openai import OpenAI, OpenAIError
+def test_posit_openai_provider_uses_httpx2_clients():
+    provider = PositOpenAIProvider(
+        base_url="https://gateway.posit.ai",
+        model="qwen3-8b",
+        credentials=lambda: "test-token",
+    )
 
-    def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(402, json={}, request=request)
+    try:
+        assert isinstance(provider._client._client, httpx2.Client)
+        assert isinstance(provider._async_client._client, httpx2.AsyncClient)
+    finally:
+        provider._client.close()
+        asyncio.run(provider._async_client.close())
+
+
+def test_posit_httpx2_auth_sets_bearer_token_and_strips_api_key():
+    auth = PositHttpx2Auth(lambda: "test-token")
+    request = httpx2.Request(
+        "GET", "https://gateway.posit.ai/openai/v1/chat/completions"
+    )
+    request.headers["x-api-key"] = "not-used"
+
+    sent_request = next(auth.sync_auth_flow(request))
+
+    assert sent_request.headers["Authorization"] == "Bearer test-token"
+    assert "x-api-key" not in sent_request.headers
+
+
+def test_openai_httpx2_error_hook_propagates_through_client_send():
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(402, json={}, request=request)
 
     client = OpenAI(
         api_key="not-used",
         base_url="https://gateway.posit.ai/openai/v1",
-        http_client=httpx.Client(
-            auth=PositAuth(lambda: "test-token"),
-            transport=httpx.MockTransport(handler),
-            event_hooks={"response": [_make_posit_error_hook(OpenAIError)]},
+        http_client=httpx2.Client(
+            auth=PositHttpx2Auth(lambda: "test-token"),
+            transport=httpx2.MockTransport(handler),
+            event_hooks={"response": [make_posit_openai_error_hook(OpenAIError)]},
         ),
     )
 
-    with pytest.raises(OpenAIError, match="credits are depleted"):
-        client.chat.completions.create(
-            model="qwen3-8b", messages=[{"role": "user", "content": "hi"}]
-        )
+    try:
+        with pytest.raises(OpenAIError, match="credits are depleted"):
+            client.chat.completions.create(
+                model="qwen3-8b", messages=[{"role": "user", "content": "hi"}]
+            )
+    finally:
+        client.close()
+
+
+@pytest.mark.asyncio
+async def test_openai_httpx2_error_hook_propagates_through_async_client_send():
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(402, json={}, request=request)
+
+    client = AsyncOpenAI(
+        api_key="not-used",
+        base_url="https://gateway.posit.ai/openai/v1",
+        http_client=httpx2.AsyncClient(
+            auth=PositHttpx2Auth(lambda: "test-token"),
+            transport=httpx2.MockTransport(handler),
+            event_hooks={"response": [make_posit_openai_error_hook_async(OpenAIError)]},
+        ),
+    )
+
+    try:
+        with pytest.raises(OpenAIError, match="credits are depleted"):
+            await client.chat.completions.create(
+                model="qwen3-8b", messages=[{"role": "user", "content": "hi"}]
+            )
+    finally:
+        await client.close()
 
 
 def test_unrecognized_gateway_error_passes_through_unchanged():
@@ -370,7 +430,7 @@ def test_unrecognized_gateway_error_passes_through_unchanged():
         http_client=httpx.Client(
             auth=PositAuth(lambda: "test-token"),
             transport=httpx.MockTransport(handler),
-            event_hooks={"response": [_make_posit_error_hook(AnthropicError)]},
+            event_hooks={"response": [make_posit_anthropic_error_hook(AnthropicError)]},
         ),
     )
 


### PR DESCRIPTION
Fixes #386.

## Problem

`import chatlas` fails with `ModuleNotFoundError: No module named 'httpx'` whenever `openai` resolves to 3.x:

```
File ".../chatlas/_utils.py", line 10, in <module>
    import httpx
ModuleNotFoundError: No module named 'httpx'
```

## Cause

chatlas imports `httpx` unconditionally but never declared it, relying on `openai` to supply it transitively. **`openai 3.0.0`** (released 2026-08-12) switched to the separate **`httpx2`** distribution (`httpx2<3,>=2.7.0`), so a fresh resolve installs `httpx2` and no `httpx`.

The import is not optional or lazy: `chatlas/__init__.py` → `types` → `_chat` → `_callbacks` → `_utils`, and `_utils.py` has a module-scope `import httpx` (used for the `httpx.Client` / `httpx.AsyncClient` isinstance checks). Nine other modules import it too, including `types/openai/_client.py`, `types/anthropic/_client.py`, and `_provider_posit.py`.

## Fix

Declare `httpx` in `dependencies`. Left unbounded, matching the surrounding entries — the APIs used (`Client`, `AsyncClient`, `URL`, `Proxy`, `Limits`, `Timeout`, `BaseTransport`) are long-stable.

## Verification

Control, released chatlas with openai 3.0.0:

```
$ uv pip install "chatlas==0.21.0" "openai==3.0.0" && python -c "import chatlas"
ModuleNotFoundError: No module named 'httpx'
```

This branch, same openai:

```
$ uv pip install "openai==3.0.0" ./chatlas && python -c "import chatlas"
chatlas 0.1.dev1+g9b94fa1cd  openai 3.0.0  httpx 0.28.1  httpx2 2.10.0
import chatlas OK
```

`httpx` now arrives on its own rather than by luck, and coexists fine with the `httpx2` that openai 3.x brings.

## Context

This broke py-shiny's CI (a Playwright test whose app imports chatlas) across every Python version and browser. Worked around downstream in posit-dev/py-shiny#2437, which can be reverted once this is released.
