### PR TITLE
fix(openai): correct web citation grounding metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -->
 
 
+## [Unreleased]
+
+### Bug fixes
+
+* `ChatOpenAI()` web-search citations no longer report the inline Markdown source link as `ContentCitation.grounded_span`; OpenAI's citation offsets identify that marker rather than the answer text it supports. (#388)
+
 ## [0.21.1] - 2026-08-12
 
 ### Bug fixes

--- a/chatlas/_provider_openai.py
+++ b/chatlas/_provider_openai.py
@@ -393,9 +393,8 @@ class OpenAIProvider(
                 return [
                     ContentCitation(
                         source=WebSource(url=ann["url"], title=ann.get("title")),
-                        # No grounded_span here: OpenAI streams the annotation
-                        # with start_index/end_index into text that hasn't fully
-                        # arrived yet, so the span is resolved on the final turn.
+                        # OpenAI's offsets delimit the inline citation marker,
+                        # not the answer text supported by the source.
                         extra=ann,
                     )
                 ]
@@ -499,11 +498,9 @@ class OpenAIProvider(
                         for a in x.annotations or []:
                             if not isinstance(a, AnnotationURLCitation):
                                 continue
-                            grounded = x.text[a.start_index : a.end_index] or None
                             contents.append(
                                 ContentCitation(
                                     source=WebSource(url=a.url, title=a.title),
-                                    grounded_span=grounded,
                                     extra=a.model_dump(),
                                 )
                             )

--- a/tests/test_provider_openai.py
+++ b/tests/test_provider_openai.py
@@ -270,17 +270,17 @@ def test_openai_web_search():
     assert cites, "expected ContentCitation items in turn contents"
     assert all(c.source and c.source.url for c in cites)
 
-    # grounded_span should be sliced from the answer text on each turn
-    found_grounded_span = False
     for turn in chat.get_turns():
         answer = "".join(c.text for c in turn.contents if isinstance(c, ContentText))
         for c in turn.contents:
             if not isinstance(c, ContentCitation):
                 continue
-            assert c.grounded_span is not None
-            assert c.grounded_span in answer
-            found_grounded_span = True
-    assert found_grounded_span, "expected at least one citation with grounded_span"
+            assert c.extra is not None
+            marker = answer[c.extra["start_index"] : c.extra["end_index"]]
+            assert marker.startswith("([")
+            assert c.source is not None
+            assert f"]({c.source.url})" in marker
+            assert c.grounded_span is None
 
 
 @pytest.mark.vcr
@@ -296,6 +296,8 @@ def test_openai_web_search_streaming():
     citations = [x for x in items if isinstance(x, ContentCitation)]
     assert citations
     assert all(c.source and c.source.url for c in citations)
+    assert all(c.grounded_span is None for c in citations)
+    assert all(c.extra is not None for c in citations)
     # interleaved: at least one citation arrives before the last item in the stream
     cite_idx = [i for i, x in enumerate(items) if isinstance(x, ContentCitation)]
     assert cite_idx and min(cite_idx) < len(items) - 1


### PR DESCRIPTION
## Why this matters
OpenAI web-search annotations locate inline URL citation markers, not the answer claims that the sources support. This change prevents chatlas from exposing a Markdown source link as `ContentCitation.grounded_span`.

## What changes
- Preserve OpenAI citation URLs, titles, and raw annotation metadata while leaving `grounded_span` unset in streaming and finalized turns.
- Strengthen VCR coverage around the actual marker offsets.

## Verification
- `uv run pytest tests/test_provider_openai.py -k web_search -q`
- `uv run ruff check chatlas/_provider_openai.py tests/test_provider_openai.py`