### PR TITLE
fix(anthropic): support Claude 5 structured outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug fixes
 
 * `ChatOpenAI()` web-search citations no longer report the inline Markdown source link as `ContentCitation.grounded_span`; OpenAI's citation offsets identify that marker rather than the answer text it supports. (#388)
+* `ChatAnthropic()` now identifies Claude 5 and later models as supporting native structured output, so automatic mode does not fall back to tools. (#390)
 
 ## [0.21.1] - 2026-08-12
 

--- a/chatlas/_provider_anthropic.py
+++ b/chatlas/_provider_anthropic.py
@@ -119,7 +119,7 @@ def supports_structured_outputs(model: str) -> bool:
 
     https://platform.claude.com/docs/en/build-with-claude/structured-outputs
     """
-    return bool(re.match(r"^claude-\w+-4-[5-9](-|$)", model))
+    return bool(re.match(r"^claude-[a-z]+-(4-[5-9]|[5-9]|[1-9]\d)(-|$)", model))
 
 
 StructuredOutputMode = Literal["auto", "native", "tool"]

--- a/tests/test_provider_anthropic.py
+++ b/tests/test_provider_anthropic.py
@@ -37,6 +37,7 @@ from chatlas._provider_anthropic import (
     AnthropicProvider,
     anthropic_fetch_result,
     serving_model,
+    supports_structured_outputs,
 )
 from chatlas._provider_anthropic import (
     normalize_finish_reason as anthropic_normalize_finish_reason,
@@ -95,6 +96,19 @@ def test_normalize_finish_reason_passes_through_unknown():
 
 def test_normalize_finish_reason_handles_none():
     assert anthropic_normalize_finish_reason(None) is None
+
+
+@pytest.mark.parametrize(
+    ("model", "expected"),
+    [
+        ("claude-sonnet-4-5", True),
+        ("claude-opus-5", True),
+        ("claude-haiku-10", True),
+        ("claude-3-5-sonnet-20240620", False),
+    ],
+)
+def test_supports_structured_outputs_for_supported_model_names(model, expected):
+    assert supports_structured_outputs(model) is expected
 
 
 def chat_func(system_prompt: str = "", **kwargs):


### PR DESCRIPTION
Closes #390

## Why this matters
Claude 5 models now use Anthropic native structured outputs in auto mode instead of falling back to the legacy tool-based implementation.

## What changed
The model capability matcher recognizes Claude 5 and later major versions while continuing to exclude legacy version-first names.

## Verification
- `make check-tests`
- `make check-types`
- `make check-format`