### PR TITLE
Preserve semantic rich tool results in chat history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* Rich tool results containing images or PDFs remain semantic `ContentToolResult` objects in saved chat history, so restoring a conversation no longer exposes provider-only XML and media as user-authored content.
 * `ChatOpenAI()` web-search citations no longer report the inline Markdown source link as `ContentCitation.grounded_span`; OpenAI's citation offsets identify that marker rather than the answer text it supports. (#388)
 * `ChatAnthropic()` now identifies Claude 5 and later models as supporting native structured output, so automatic mode does not fall back to tools. (#390)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Rich tool results containing images or PDFs remain semantic `ContentToolResult` objects in saved chat history, so restoring a conversation no longer exposes provider-only XML and media as user-authored content.
 * `ChatOpenAI()` web-search citations no longer report the inline Markdown source link as `ContentCitation.grounded_span`; OpenAI's citation offsets identify that marker rather than the answer text it supports. (#388)
+* `ChatOpenAI()` no longer crashes while streaming web-search citations with current OpenAI SDKs, which emit annotations as model objects rather than dictionaries.
 * `ChatAnthropic()` now identifies Claude 5 and later models as supporting native structured output, so automatic mode does not fall back to tools. (#390)
 
 ## [0.21.1] - 2026-08-12

--- a/chatlas/_batch_job.py
+++ b/chatlas/_batch_job.py
@@ -14,7 +14,7 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 from ._chat import Chat
 from ._content import Content
 from ._provider import BatchStatus
-from ._turn import AssistantTurn, Turn, user_turn
+from ._turn import AssistantTurn, Turn, normalize_turns_for_provider, user_turn
 from ._typing_extensions import TypedDict
 
 BatchStage = Literal["submitting", "waiting", "retrieving", "done"]
@@ -155,7 +155,7 @@ class BatchJob:
 
         conversations = []
         for turn in self.user_turns:
-            conversation = existing_turns + [turn]
+            conversation = normalize_turns_for_provider(existing_turns + [turn])
             conversations.append(conversation)
 
         self.batch = self.provider.batch_submit(conversations, self.data_model)

--- a/chatlas/_chat.py
+++ b/chatlas/_chat.py
@@ -81,6 +81,7 @@ from ._turn import (
     Turn,
     UserTurn,
     check_finish_reason,
+    normalize_turns_for_provider,
     user_turn,
 )
 from ._turn_accumulator import TurnAccumulator
@@ -334,7 +335,10 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
             if x.role != final_turns[-1].role:
                 final_turns.append(x)
             else:
-                final_turns[-1].contents.extend(x.contents)
+                previous = final_turns[-1]
+                final_turns[-1] = previous.model_copy(
+                    update={"contents": [*previous.contents, *x.contents]}
+                )
 
         return final_turns
 
@@ -820,8 +824,10 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
             )
         new_turn = user_turn(*args)
         if include == "complete":
-            return self.get_turns(include_system_prompt=True) + [new_turn]
-        return [new_turn]
+            turns = self.get_turns(include_system_prompt=True) + [new_turn]
+        else:
+            turns = [new_turn]
+        return normalize_turns_for_provider(turns)
 
     def app(
         self,
@@ -2871,6 +2877,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
             raise ValueError("Cannot use async tools in a synchronous chat")
 
         request_turns = [*self._turns, user_turn]
+        provider_turns = normalize_turns_for_provider(request_turns)
         chat_span = start_chat_span(self.provider, request_turns, _otel_parent)
         try:
 
@@ -2906,7 +2913,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
                 with activate_span(chat_span):
                     response = self.provider.chat_perform(
                         stream=True,
-                        turns=request_turns,
+                        turns=provider_turns,
                         tools=self._tools,
                         data_model=data_model,
                         kwargs=all_kwargs,
@@ -2928,7 +2935,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
                             break
                         result = self.provider.stream_merge_chunks(result, chunk)
                         for content in self.provider.stream_content(
-                            chunk, result, turns=request_turns
+                            chunk, result, turns=provider_turns
                         ):
                             yield from acc.process_content(
                                 content, display_text(content), content_mode, emit
@@ -2940,7 +2947,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
                         turn = self.provider.stream_turn(
                             result,
                             has_data_model=data_model is not None,
-                            turns=request_turns,
+                            turns=provider_turns,
                         )
                         emit_image_contents(turn, emit)
                         if echo == "all":
@@ -2956,7 +2963,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
                 with activate_span(chat_span):
                     response = self.provider.chat_perform(
                         stream=False,
-                        turns=request_turns,
+                        turns=provider_turns,
                         tools=self._tools,
                         data_model=data_model,
                         kwargs=all_kwargs,
@@ -2965,7 +2972,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
                 turn = self.provider.value_turn(
                     response,
                     has_data_model=data_model is not None,
-                    turns=request_turns,
+                    turns=provider_turns,
                 )
                 emit_thinking_contents(turn, emit)
                 emit_web_contents(turn, emit)
@@ -3028,6 +3035,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         controller: StreamController,
     ) -> AsyncGenerator[str | Content, None]:
         request_turns = [*self._turns, user_turn]
+        provider_turns = normalize_turns_for_provider(request_turns)
         chat_span = start_chat_span(self.provider, request_turns, _otel_parent)
         try:
 
@@ -3063,7 +3071,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
                 with activate_span(chat_span):
                     response = await self.provider.chat_perform_async(
                         stream=True,
-                        turns=request_turns,
+                        turns=provider_turns,
                         tools=self._tools,
                         data_model=data_model,
                         kwargs=all_kwargs,
@@ -3085,7 +3093,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
                             break
                         result = self.provider.stream_merge_chunks(result, chunk)
                         for content in self.provider.stream_content(
-                            chunk, result, turns=request_turns
+                            chunk, result, turns=provider_turns
                         ):
                             for item in acc.process_content(
                                 content, display_text(content), content_mode, emit
@@ -3099,7 +3107,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
                         turn = self.provider.stream_turn(
                             result,
                             has_data_model=data_model is not None,
-                            turns=request_turns,
+                            turns=provider_turns,
                         )
                         emit_image_contents(turn, emit)
                         if echo == "all":
@@ -3115,7 +3123,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
                 with activate_span(chat_span):
                     response = await self.provider.chat_perform_async(
                         stream=False,
-                        turns=request_turns,
+                        turns=provider_turns,
                         tools=self._tools,
                         data_model=data_model,
                         kwargs=all_kwargs,
@@ -3124,7 +3132,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
                 turn = self.provider.value_turn(
                     response,
                     has_data_model=data_model is not None,
-                    turns=request_turns,
+                    turns=provider_turns,
                 )
                 emit_thinking_contents(turn, emit)
                 emit_web_contents(turn, emit)

--- a/chatlas/_content.py
+++ b/chatlas/_content.py
@@ -11,6 +11,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    SerializationInfo,
     SerializeAsAny,
     field_serializer,
     field_validator,
@@ -226,6 +227,8 @@ ContentTypeEnum = Literal[
 """
 A discriminated union of all content types.
 """
+
+CONTENT_VALUE_SENTINEL = "__chatlas_content__"
 
 
 class Content(BaseModel):
@@ -494,6 +497,15 @@ class ContentToolResult(Content):
     # "private"
     request: Optional[ContentToolRequest] = None
     content_type: ContentTypeEnum = "tool_result"
+
+    @field_validator("value", mode="before")
+    @classmethod
+    def _validate_value(cls, v: Any) -> Any:
+        return restore_content_value(v)
+
+    @field_serializer("value")
+    def _serialize_value(self, v: Any, info: SerializationInfo) -> Any:
+        return serialize_content_value(v, mode=info.mode)
 
     @field_serializer("error")
     @classmethod
@@ -1262,6 +1274,38 @@ def create_content(data: dict[str, Any]) -> ContentUnion:
         return ContentCitation.model_validate(data)
     else:
         raise ValueError(f"Unknown content type: {ct}")
+
+
+def serialize_content_value(value: Any, *, mode: str) -> Any:
+    """Tag Content objects nested in an arbitrary tool result value."""
+    if isinstance(value, Content):
+        return {CONTENT_VALUE_SENTINEL: value.model_dump(mode=mode)}
+    if isinstance(value, list):
+        return [serialize_content_value(item, mode=mode) for item in value]
+    if isinstance(value, tuple):
+        return tuple(serialize_content_value(item, mode=mode) for item in value)
+    if isinstance(value, dict):
+        return {
+            key: serialize_content_value(item, mode=mode)
+            for key, item in value.items()
+        }
+    return value
+
+
+def restore_content_value(value: Any) -> Any:
+    """Restore tagged Content objects nested in a serialized tool result value."""
+    if isinstance(value, list):
+        return [restore_content_value(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(restore_content_value(item) for item in value)
+    if isinstance(value, dict):
+        if set(value) == {CONTENT_VALUE_SENTINEL}:
+            content = value[CONTENT_VALUE_SENTINEL]
+            if not isinstance(content, dict):
+                raise ValueError("Serialized Content value must be a dictionary.")
+            return create_content(content)
+        return {key: restore_content_value(item) for key, item in value.items()}
+    return value
 
 
 TOOL_CSS = """

--- a/chatlas/_content.py
+++ b/chatlas/_content.py
@@ -1301,9 +1301,11 @@ def restore_content_value(value: Any) -> Any:
     if isinstance(value, dict):
         if set(value) == {CONTENT_VALUE_SENTINEL}:
             content = value[CONTENT_VALUE_SENTINEL]
-            if not isinstance(content, dict):
-                raise ValueError("Serialized Content value must be a dictionary.")
-            return create_content(content)
+            if (
+                isinstance(content, dict)
+                and content.get("content_type") in get_args(ContentTypeEnum)
+            ):
+                return create_content(content)
         return {key: restore_content_value(item) for key, item in value.items()}
     return value
 

--- a/chatlas/_provider_anthropic.py
+++ b/chatlas/_provider_anthropic.py
@@ -83,8 +83,8 @@ if TYPE_CHECKING:
         WebFetchToolResultBlock,
         WebSearchToolResultBlock,
     )
-    from anthropic.types.beta.file_metadata import (
-        FileMetadata as AnthropicFileMetadata,
+    from anthropic.types.beta.beta_file_metadata import (
+        BetaFileMetadata as AnthropicFileMetadata,
     )
     from anthropic.types.cache_control_ephemeral_param import CacheControlEphemeralParam
     from anthropic.types.document_block_param import DocumentBlockParam

--- a/chatlas/_provider_openai.py
+++ b/chatlas/_provider_openai.py
@@ -14,7 +14,12 @@ from openai.types.responses.response_function_web_search import (
     ActionOpenPage,
     ResponseFunctionWebSearch,
 )
-from openai.types.responses.response_output_text import AnnotationURLCitation
+from openai.types.responses.response_output_text import (
+    AnnotationURLCitation as ResponseAnnotationURLCitation,
+)
+from openai.types.responses.response_output_text_annotation_added_event import (
+    AnnotationURLCitation as StreamAnnotationURLCitation,
+)
 from pydantic import BaseModel
 
 from ._chat import Chat
@@ -387,8 +392,11 @@ class OpenAIProvider(
             return [ContentText.model_construct(text=chunk.delta)]
         if chunk.type == "response.output_text.annotation.added":
             # https://platform.openai.com/docs/api-reference/responses-streaming/response/output_text/annotation_added
-            # annotation is a plain dict at runtime (SDK types it as `object`)
-            ann: dict = chunk.annotation  # type: ignore[assignment]
+            ann = chunk.annotation
+            if isinstance(ann, StreamAnnotationURLCitation):
+                ann = ann.model_dump()
+            if not isinstance(ann, dict):
+                return []
             if ann.get("type") == "url_citation":
                 return [
                     ContentCitation(
@@ -496,7 +504,7 @@ class OpenAIProvider(
                     else:
                         contents.append(ContentText(text=x.text))
                         for a in x.annotations or []:
-                            if not isinstance(a, AnnotationURLCitation):
+                            if not isinstance(a, ResponseAnnotationURLCitation):
                                 continue
                             contents.append(
                                 ContentCitation(

--- a/chatlas/_turn.py
+++ b/chatlas/_turn.py
@@ -6,7 +6,7 @@ import os
 import warnings
 from typing import Any, Generic, Literal, Optional, Sequence, TypeVar, cast
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from ._content import (
     Content,
@@ -266,17 +266,23 @@ class UserTurn(Turn):
     ):
         super().__init__(contents, **kwargs)
 
-    @model_validator(mode="after")
-    def expand_tool_contents(self):
-        contents: list[ContentUnion] = []
-        for x in merge_tool_results(self.contents):
-            if isinstance(x, ContentToolResult):
-                contents.extend(expand_tool_result(x))
-            else:
-                contents.append(x)
 
-        self.contents = tool_results_first(contents)
-        return self
+def normalize_turn_for_provider(turn: Turn) -> Turn:
+    if not isinstance(turn, UserTurn):
+        return turn
+
+    contents: list[ContentUnion] = []
+    for content in merge_tool_results(turn.contents):
+        if isinstance(content, ContentToolResult):
+            contents.extend(expand_tool_result(content))
+        else:
+            contents.append(content)
+
+    return turn.model_copy(update={"contents": tool_results_first(contents)})
+
+
+def normalize_turns_for_provider(turns: Sequence[Turn]) -> list[Turn]:
+    return [normalize_turn_for_provider(turn) for turn in turns]
 
 
 class SystemTurn(Turn):

--- a/chatlas/data/prices.json
+++ b/chatlas/data/prices.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "min_ellmer_version": "0.5.0",
-  "updated_at": "2026-08-10T07:17:57Z",
+  "updated_at": "2026-08-17T06:39:03Z",
   "data": [
     {
       "provider": "AWS/Bedrock",
@@ -1740,6 +1740,14 @@
     },
     {
       "provider": "AWS/Bedrock",
+      "model": "openai.gpt-5.6-luna",
+      "variant": "above_272k_tokens",
+      "input": 0.44,
+      "output": 1.98,
+      "cached_input": 0.044
+    },
+    {
+      "provider": "AWS/Bedrock",
       "model": "openai.gpt-5.6-sol",
       "variant": "",
       "input": 5.5,
@@ -1748,11 +1756,27 @@
     },
     {
       "provider": "AWS/Bedrock",
+      "model": "openai.gpt-5.6-sol",
+      "variant": "above_272k_tokens",
+      "input": 11,
+      "output": 49.5,
+      "cached_input": 1.1
+    },
+    {
+      "provider": "AWS/Bedrock",
       "model": "openai.gpt-5.6-terra",
       "variant": "",
       "input": 2.2,
       "output": 13.2,
       "cached_input": 0.22
+    },
+    {
+      "provider": "AWS/Bedrock",
+      "model": "openai.gpt-5.6-terra",
+      "variant": "above_272k_tokens",
+      "input": 4.4,
+      "output": 19.8,
+      "cached_input": 0.44
     },
     {
       "provider": "AWS/Bedrock",
@@ -2848,6 +2872,22 @@
       "input": 1,
       "output": 5,
       "cached_input": 0.1
+    },
+    {
+      "provider": "Anthropic",
+      "model": "claude-mythos-5",
+      "variant": "",
+      "input": 10,
+      "output": 50,
+      "cached_input": 1
+    },
+    {
+      "provider": "Anthropic",
+      "model": "claude-mythos-preview",
+      "variant": "",
+      "input": 10,
+      "output": 50,
+      "cached_input": 1
     },
     {
       "provider": "Anthropic",
@@ -5389,6 +5429,13 @@
     },
     {
       "provider": "Google/Gemini",
+      "model": "gemini-3.1-flash-tts-preview",
+      "variant": "",
+      "input": 1,
+      "output": 20
+    },
+    {
+      "provider": "Google/Gemini",
       "model": "gemini-3.1-pro-preview",
       "variant": "",
       "input": 2,
@@ -5545,6 +5592,37 @@
     },
     {
       "provider": "Google/Gemini",
+      "model": "gemini-3.7-flash",
+      "variant": "",
+      "input": 0.75,
+      "output": 3.75,
+      "cached_input": 0.075
+    },
+    {
+      "provider": "Google/Gemini",
+      "model": "gemini-3.7-flash",
+      "variant": "batches",
+      "input": 0.375,
+      "output": 1.875
+    },
+    {
+      "provider": "Google/Gemini",
+      "model": "gemini-3.7-flash",
+      "variant": "flex",
+      "input": 0.375,
+      "output": 1.875,
+      "cached_input": 0.0375
+    },
+    {
+      "provider": "Google/Gemini",
+      "model": "gemini-3.7-flash",
+      "variant": "priority",
+      "input": 1.35,
+      "output": 6.75,
+      "cached_input": 0.135
+    },
+    {
+      "provider": "Google/Gemini",
       "model": "gemini-embedding-001",
       "variant": "",
       "input": 0.15,
@@ -5655,6 +5733,13 @@
       "input": 2,
       "output": 10,
       "cached_input": 0.2
+    },
+    {
+      "provider": "Google/Gemini",
+      "model": "gemini-robotics-er-2-streaming-preview",
+      "variant": "",
+      "input": 2,
+      "output": 10
     },
     {
       "provider": "Google/Vertex",
@@ -6074,6 +6159,37 @@
     },
     {
       "provider": "Google/Vertex",
+      "model": "gemini-3.7-flash",
+      "variant": "",
+      "input": 0.75,
+      "output": 3.75,
+      "cached_input": 0.075
+    },
+    {
+      "provider": "Google/Vertex",
+      "model": "gemini-3.7-flash",
+      "variant": "batches",
+      "input": 0.375,
+      "output": 1.875
+    },
+    {
+      "provider": "Google/Vertex",
+      "model": "gemini-3.7-flash",
+      "variant": "flex",
+      "input": 0.375,
+      "output": 1.875,
+      "cached_input": 0.0375
+    },
+    {
+      "provider": "Google/Vertex",
+      "model": "gemini-3.7-flash",
+      "variant": "priority",
+      "input": 1.35,
+      "output": 6.75,
+      "cached_input": 0.135
+    },
+    {
+      "provider": "Google/Vertex",
       "model": "gemini-live-2.5-flash-preview-native-audio-09-2025",
       "variant": "",
       "input": 0.3,
@@ -6273,6 +6389,20 @@
     },
     {
       "provider": "Groq",
+      "model": "meta-llama/llama-prompt-guard-2-22m",
+      "variant": "",
+      "input": 0.03,
+      "output": 0.03
+    },
+    {
+      "provider": "Groq",
+      "model": "meta-llama/llama-prompt-guard-2-86m",
+      "variant": "",
+      "input": 0.04,
+      "output": 0.04
+    },
+    {
+      "provider": "Groq",
       "model": "moonshotai/kimi-k2-instruct-0905",
       "variant": "",
       "input": 1,
@@ -6309,6 +6439,13 @@
       "variant": "",
       "input": 0.29,
       "output": 0.59
+    },
+    {
+      "provider": "Groq",
+      "model": "qwen/qwen3.6-27b",
+      "variant": "",
+      "input": 0.6,
+      "output": 3
     },
     {
       "provider": "Mistral",
@@ -6600,6 +6737,13 @@
       "variant": "",
       "input": 0.1,
       "output": 0.3
+    },
+    {
+      "provider": "Mistral",
+      "model": "mistral-small-2603",
+      "variant": "",
+      "input": 0.15,
+      "output": 0.6
     },
     {
       "provider": "Mistral",
@@ -9233,6 +9377,13 @@
       "input": 0.6,
       "output": 3,
       "cached_input": 0.1
+    },
+    {
+      "provider": "OpenRouter",
+      "model": "nvidia/nemotron-3.5-lightning",
+      "variant": "",
+      "input": 0.05,
+      "output": 0.2
     },
     {
       "provider": "OpenRouter",

--- a/chatlas/types/anthropic/_submit.py
+++ b/chatlas/types/anthropic/_submit.py
@@ -6,11 +6,14 @@
 from typing import Iterable, Literal, Mapping, Optional, Sequence, TypedDict, Union
 
 import anthropic
+import anthropic.types.browser_toolset_20260801_param
 import anthropic.types.cache_control_ephemeral_param
 import anthropic.types.code_execution_tool_20250522_param
 import anthropic.types.code_execution_tool_20250825_param
 import anthropic.types.code_execution_tool_20260120_param
 import anthropic.types.code_execution_tool_20260521_param
+import anthropic.types.computer_toolset_20260801_param
+import anthropic.types.container_params
 import anthropic.types.memory_tool_20250818_param
 import anthropic.types.message_param
 import anthropic.types.output_config_param
@@ -66,7 +69,9 @@ class SubmitInputArgs(TypedDict, total=False):
         None,
         anthropic.Omit,
     ]
-    container: Union[str, None, anthropic.Omit]
+    container: Union[
+        anthropic.types.container_params.ContainerParams, str, None, anthropic.Omit
+    ]
     inference_geo: Union[str, None, anthropic.Omit]
     output_config: (
         anthropic.types.output_config_param.OutputConfigParam | anthropic.Omit
@@ -100,7 +105,9 @@ class SubmitInputArgs(TypedDict, total=False):
                 anthropic.types.code_execution_tool_20250825_param.CodeExecutionTool20250825Param,
                 anthropic.types.code_execution_tool_20260120_param.CodeExecutionTool20260120Param,
                 anthropic.types.code_execution_tool_20260521_param.CodeExecutionTool20260521Param,
+                anthropic.types.browser_toolset_20260801_param.BrowserToolset20260801Param,
                 anthropic.types.memory_tool_20250818_param.MemoryTool20250818Param,
+                anthropic.types.computer_toolset_20260801_param.ComputerToolset20260801Param,
                 anthropic.types.tool_text_editor_20250124_param.ToolTextEditor20250124Param,
                 anthropic.types.tool_text_editor_20250429_param.ToolTextEditor20250429Param,
                 anthropic.types.tool_text_editor_20250728_param.ToolTextEditor20250728Param,

--- a/chatlas/types/openai/_client.py
+++ b/chatlas/types/openai/_client.py
@@ -3,7 +3,7 @@
 # ---------------------------------------------------------
 
 
-from typing import Awaitable, Callable, Mapping, Optional, TypedDict, Union
+from typing import Awaitable, Callable, Literal, Mapping, Optional, TypedDict, Union
 
 import httpx2
 import openai
@@ -14,12 +14,17 @@ import openai.auth._workload
 class ChatClientArgs(TypedDict, total=False):
     api_key: Union[str, Callable[[], Awaitable[str]], None]
     admin_api_key: str | None
-    workload_identity: openai.auth._workload.WorkloadIdentity | None
+    workload_identity: (
+        openai.auth._workload.WorkloadIdentity
+        | openai.auth._workload.X509WorkloadIdentity
+        | None
+    )
     organization: str | None
     project: str | None
     webhook_secret: str | None
     provider: openai._provider._Provider | None
-    base_url: str | httpx2.URL | None
+    base_url: str | httpx2.URL | None | openai.NotGiven
+    data_residency: Optional[Literal["global", "us", "eu", "ae"]]
     websocket_base_url: str | httpx2.URL | None
     timeout: float | openai.Timeout | None | openai.NotGiven
     max_retries: int

--- a/chatlas/types/openai/_client_azure.py
+++ b/chatlas/types/openai/_client_azure.py
@@ -15,7 +15,11 @@ class ChatAzureClientArgs(TypedDict, total=False):
     api_version: str | None
     api_key: Union[str, Callable[[], Awaitable[str]], None]
     admin_api_key: str | None
-    workload_identity: openai.auth._workload.WorkloadIdentity | None
+    workload_identity: (
+        openai.auth._workload.WorkloadIdentity
+        | openai.auth._workload.X509WorkloadIdentity
+        | None
+    )
     azure_ad_token: str | None
     organization: str | None
     project: str | None

--- a/chatlas/types/openai/_submit.py
+++ b/chatlas/types/openai/_submit.py
@@ -45,6 +45,7 @@ class SubmitInputArgs(TypedDict, total=False):
             "gpt-5.6-terra",
             "gpt-5.6-luna",
             "gpt-5.5",
+            "gpt-5.5-2026-04-23",
             "gpt-5.4",
             "gpt-5.4-mini",
             "gpt-5.4-nano",

--- a/chatlas/types/openai/_submit_responses.py
+++ b/chatlas/types/openai/_submit_responses.py
@@ -125,6 +125,7 @@ class SubmitInputArgs(TypedDict, total=False):
             "gpt-5.6-terra",
             "gpt-5.6-luna",
             "gpt-5.5",
+            "gpt-5.5-2026-04-23",
             "gpt-5.4",
             "gpt-5.4-mini",
             "gpt-5.4-nano",
@@ -215,6 +216,8 @@ class SubmitInputArgs(TypedDict, total=False):
             "o4-mini-deep-research-2025-06-26",
             "computer-use-preview",
             "computer-use-preview-2025-03-11",
+            "gpt-5.5-pro",
+            "gpt-5.5-pro-2026-04-23",
             "gpt-5-codex",
             "gpt-5-pro",
             "gpt-5-pro-2025-10-06",
@@ -243,7 +246,7 @@ class SubmitInputArgs(TypedDict, total=False):
     reasoning: Union[openai.types.shared_params.reasoning.Reasoning, None, openai.Omit]
     safety_identifier: Union[str, None, openai.Omit]
     service_tier: Union[
-        Literal["auto", "default", "flex", "scale", "priority", "fast"],
+        Literal["auto", "default", "flex", "scale", "priority", "fast", "ultrafast"],
         None,
         openai.Omit,
     ]

--- a/tests/test_batch_chat.py
+++ b/tests/test_batch_chat.py
@@ -8,6 +8,9 @@ from chatlas import (
     ChatGroq,
     ChatOpenAI,
     ChatVertex,
+    ContentToolRequest,
+    ContentToolResult,
+    UserTurn,
 )
 from chatlas._batch_chat import (
     BatchJob,
@@ -17,6 +20,8 @@ from chatlas._batch_chat import (
     batch_chat_text,
 )
 from chatlas._provider import BatchStatus
+from chatlas._turn import Turn
+from chatlas.types import ContentImageInline
 from pydantic import BaseModel
 
 from .conftest import VCR_MATCH_ON_WITHOUT_BODY, make_vcr_config
@@ -135,6 +140,40 @@ def test_can_submit_anthropic_batch():
         assert job.stage == "submitting"
         job.step()
         assert job.stage == "waiting"
+
+
+def test_batch_normalizes_rich_tool_results_for_provider():
+    request = ContentToolRequest(id="plot-1", name="plot", arguments={})
+    image = ContentImageInline(data="aGVsbG8=", image_content_type="image/png")
+    result = ContentToolResult(value=image, model_format="as_is", request=request)
+    chat = ChatAnthropic(model="claude-sonnet-4-5", api_key="dummy")
+    chat.set_turns(
+        [
+            UserTurn("plot the data"),
+            AssistantTurn([request]),
+            UserTurn([result]),
+            AssistantTurn("The chart is ready."),
+        ]
+    )
+    provider_conversations: list[list[Turn]] | None = None
+
+    def batch_submit_mock(
+        conversations: list[list[Turn]], _data_model: type[BaseModel] | None = None
+    ) -> dict[str, str]:
+        nonlocal provider_conversations
+        provider_conversations = conversations
+        return {"id": "123"}
+
+    with tempfile.NamedTemporaryFile() as temp_file:
+        job = BatchJob(chat, ["What does it show?"], temp_file.name, wait=False)
+        job.provider.batch_submit = batch_submit_mock
+        job.step()
+
+    assert provider_conversations is not None
+    provider_result_turn = provider_conversations[0][2]
+    assert isinstance(provider_result_turn, UserTurn)
+    assert any(isinstance(x, ContentImageInline) for x in provider_result_turn.contents)
+    assert chat.get_turns()[2].contents == [result]
 
 
 def test_groq_batch_support_via_inheritance():

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -5,6 +5,7 @@ import warnings
 import pytest
 from chatlas import (
     AssistantTurn,
+    ChatAnthropic,
     ChatOpenAI,
     ChatOpenAICompletions,
     ContentToolRequest,
@@ -14,7 +15,37 @@ from chatlas import (
     UserTurn,
 )
 from chatlas._chat import ToolFailureWarning, finalize_assistant_turn
+from chatlas.types import ContentImageInline, ContentText
 from pydantic import BaseModel
+
+
+def rich_tool_history() -> tuple[list[Turn], ContentToolResult]:
+    request = ContentToolRequest(id="plot-1", name="plot", arguments={})
+    image = ContentImageInline(data="aGVsbG8=", image_content_type="image/png")
+    result = ContentToolResult(
+        value=[ContentText(text="Chart displayed."), image],
+        model_format="as_is",
+        request=request,
+    )
+    return (
+        [
+            UserTurn("plot the data"),
+            AssistantTurn([request]),
+            UserTurn([result]),
+            AssistantTurn("The chart is ready."),
+        ],
+        result,
+    )
+
+
+def assert_rich_tool_result_expanded(turns: list[Turn]) -> None:
+    result_turn = turns[2]
+    assert isinstance(result_turn, UserTurn)
+    assert any(isinstance(x, ContentImageInline) for x in result_turn.contents)
+    assert any(
+        isinstance(x, ContentText) and x.text == '<tool-contents call-id="plot-1">'
+        for x in result_turn.contents
+    )
 
 
 @pytest.mark.vcr
@@ -288,6 +319,71 @@ def test_json_serialize():
     else:
         turns_for_comparison.append(turns[1])
     assert turns_for_comparison == turns_restored
+
+
+def test_chat_normalizes_rich_tool_results_only_for_provider(monkeypatch):
+    history, result = rich_tool_history()
+    chat = ChatAnthropic(model="claude-sonnet-4-5", api_key="dummy")
+    chat.set_turns(history)
+    provider_turns: list[Turn] | None = None
+
+    def chat_perform_mock(*, turns: list[Turn], **_kwargs: object) -> object:
+        nonlocal provider_turns
+        provider_turns = turns
+        return object()
+
+    def value_turn_mock(
+        _completion: object, has_data_model: bool, turns: list[Turn]
+    ) -> AssistantTurn:
+        assert has_data_model is False
+        assert turns is provider_turns
+        return AssistantTurn("done")
+
+    monkeypatch.setattr(chat.provider, "chat_perform", chat_perform_mock)
+    monkeypatch.setattr(chat.provider, "value_turn", value_turn_mock)
+
+    chat.chat("What does it show?", stream=False, echo="none")
+
+    assert provider_turns is not None
+    assert_rich_tool_result_expanded(provider_turns)
+
+    stored_result_turn = chat.get_turns()[2]
+    assert isinstance(stored_result_turn, UserTurn)
+    assert stored_result_turn.contents == [result]
+
+
+@pytest.mark.asyncio
+async def test_chat_async_normalizes_rich_tool_results_only_for_provider(monkeypatch):
+    history, result = rich_tool_history()
+    chat = ChatAnthropic(model="claude-sonnet-4-5", api_key="dummy")
+    chat.set_turns(history)
+    provider_turns: list[Turn] | None = None
+
+    async def chat_perform_async_mock(
+        *, turns: list[Turn], **_kwargs: object
+    ) -> object:
+        nonlocal provider_turns
+        provider_turns = turns
+        return object()
+
+    def value_turn_mock(
+        _completion: object, has_data_model: bool, turns: list[Turn]
+    ) -> AssistantTurn:
+        assert has_data_model is False
+        assert turns is provider_turns
+        return AssistantTurn("done")
+
+    monkeypatch.setattr(chat.provider, "chat_perform_async", chat_perform_async_mock)
+    monkeypatch.setattr(chat.provider, "value_turn", value_turn_mock)
+
+    await chat.chat_async("What does it show?", stream=False, echo="none")
+
+    assert provider_turns is not None
+    assert_rich_tool_result_expanded(provider_turns)
+
+    stored_result_turn = chat.get_turns()[2]
+    assert isinstance(stored_result_turn, UserTurn)
+    assert stored_result_turn.contents == [result]
 
 
 # Chat can be deepcopied/forked
@@ -776,6 +872,47 @@ def test_token_count_complete_includes_history_and_system():
 
     assert new_only > 0
     assert complete > new_only
+
+
+def test_token_count_normalizes_rich_tool_results_for_provider(monkeypatch):
+    history, result = rich_tool_history()
+    chat = ChatAnthropic(model="claude-sonnet-4-5", api_key="dummy")
+    chat.set_turns(history)
+    provider_turns: list[Turn] | None = None
+
+    def token_count_mock(turns: list[Turn], **_kwargs: object) -> int:
+        nonlocal provider_turns
+        provider_turns = turns
+        return 1
+
+    monkeypatch.setattr(chat.provider, "token_count", token_count_mock)
+
+    assert chat.token_count("What does it show?", include="complete") == 1
+    assert provider_turns is not None
+    assert_rich_tool_result_expanded(provider_turns)
+    assert chat.get_turns()[2].contents == [result]
+
+
+@pytest.mark.asyncio
+async def test_token_count_async_normalizes_rich_tool_results_for_provider(
+    monkeypatch,
+):
+    history, result = rich_tool_history()
+    chat = ChatAnthropic(model="claude-sonnet-4-5", api_key="dummy")
+    chat.set_turns(history)
+    provider_turns: list[Turn] | None = None
+
+    async def token_count_async_mock(turns: list[Turn], **_kwargs: object) -> int:
+        nonlocal provider_turns
+        provider_turns = turns
+        return 1
+
+    monkeypatch.setattr(chat.provider, "token_count_async", token_count_async_mock)
+
+    assert await chat.token_count_async("What does it show?", include="complete") == 1
+    assert provider_turns is not None
+    assert_rich_tool_result_expanded(provider_turns)
+    assert chat.get_turns()[2].contents == [result]
 
 
 def test_token_count_invalid_include_raises():

--- a/tests/test_provider_openai.py
+++ b/tests/test_provider_openai.py
@@ -9,6 +9,7 @@ from chatlas._content import (
     ContentImageInline,
     ContentPDF,
     ContentUploaded,
+    WebSource,
 )
 from chatlas._provider_openai import OpenAIProvider, as_input_param
 from chatlas._provider_openai import (
@@ -17,8 +18,12 @@ from chatlas._provider_openai import (
 from chatlas.types import ContentCitation, ContentText, ContentToolRequestSearch
 from openai.types.responses import (
     Response,
+    ResponseOutputTextAnnotationAddedEvent,
     ResponseOutputMessage,
     ResponseOutputText,
+)
+from openai.types.responses.response_output_text_annotation_added_event import (
+    AnnotationURLCitation,
 )
 
 from .conftest import (
@@ -77,6 +82,35 @@ def test_normalize_finish_reason_passes_through_unknown_status():
 
 def test_normalize_finish_reason_handles_none():
     assert openai_normalize_finish_reason(None) is None
+
+
+def test_stream_content_handles_url_citation_model():
+    provider = OpenAIProvider(api_key="test", model="gpt-4.1")
+    annotation = AnnotationURLCitation(
+        type="url_citation",
+        url="https://example.com",
+        title="Example",
+        start_index=0,
+        end_index=1,
+    )
+    chunk = ResponseOutputTextAnnotationAddedEvent(
+        type="response.output_text.annotation.added",
+        annotation=annotation,
+        annotation_index=0,
+        content_index=0,
+        item_id="msg_123",
+        output_index=0,
+        sequence_number=1,
+    )
+
+    contents = provider.stream_content(chunk, completion=None)
+
+    assert len(contents) == 1
+    citation = contents[0]
+    assert isinstance(citation, ContentCitation)
+    assert isinstance(citation.source, WebSource)
+    assert citation.source.url == "https://example.com"
+    assert citation.extra == annotation.model_dump()
 
 
 def test_openai_uploaded_serializes_to_input_file():

--- a/tests/test_provider_stream_contract.py
+++ b/tests/test_provider_stream_contract.py
@@ -11,12 +11,15 @@ import pytest
 from chatlas import Chat
 from chatlas._content import (
     Content,
+    ContentImageInline,
     ContentText,
     ContentThinkingDelta,
+    ContentToolRequest,
+    ContentToolResult,
     ContentToolRequestSearch,
 )
 from chatlas._provider import Provider
-from chatlas._turn import AssistantTurn
+from chatlas._turn import AssistantTurn, Turn, UserTurn
 
 
 class Chunk:
@@ -38,6 +41,8 @@ class AccumulatingProvider(Provider):
         self._chunks = chunks
         self.seen_completions: list[Optional[dict]] = []
         self.seen_turns: list[list[tuple[str, str]]] = []
+        self.seen_raw_turns: list[list[Turn]] = []
+        self.perform_turns: list[Turn] | None = None
 
     def stream_merge_chunks(self, completion, chunk) -> dict:
         merged = dict(completion or {"text": ""})
@@ -47,6 +52,7 @@ class AccumulatingProvider(Provider):
     def stream_content(self, chunk, completion, turns=()) -> list[Content]:
         self.seen_completions.append(completion)
         self.seen_turns.append([(turn.role, turn.text) for turn in turns])
+        self.seen_raw_turns.append(turns)
         out: list[Content] = []
         if chunk.text:
             out.append(ContentText.model_construct(text=chunk.text))
@@ -57,11 +63,13 @@ class AccumulatingProvider(Provider):
 
     def chat_perform(self, *, stream, turns, tools, data_model, kwargs):
         if stream:
+            self.perform_turns = turns
             return iter(self._chunks)
         raise NotImplementedError
 
     async def chat_perform_async(self, *, stream, turns, tools, data_model, kwargs):
         if stream:
+            self.perform_turns = turns
 
             async def gen():
                 for c in self._chunks:
@@ -72,6 +80,7 @@ class AccumulatingProvider(Provider):
 
     def stream_turn(self, completion, has_data_model, turns=()):
         self.seen_turns.append([(turn.role, turn.text) for turn in turns])
+        self.seen_raw_turns.append(turns)
         return AssistantTurn(
             contents=[ContentText.model_construct(text=completion["text"])],
             tokens=None,
@@ -141,6 +150,19 @@ def test_stream_content_receives_exact_request_turns():
     assert provider.seen_turns == [[("user", "hi")]] * 3
 
 
+def test_stream_provider_hooks_receive_normalized_rich_tool_results():
+    provider = AccumulatingProvider([Chunk("done")])
+    chat = Chat(provider=provider)
+    result = set_rich_tool_history(chat)
+
+    assert "".join(chat.stream("What does it show?")) == "done"
+
+    assert provider.perform_turns is not None
+    assert_rich_tool_result_expanded(provider.perform_turns)
+    assert all(turns is provider.perform_turns for turns in provider.seen_raw_turns)
+    assert chat.get_turns()[2].contents == [result]
+
+
 def test_multiple_contents_from_one_chunk_are_all_processed():
     provider = AccumulatingProvider([])
     chat = Chat(provider=provider)
@@ -178,3 +200,39 @@ async def test_stream_content_receives_exact_request_turns_async():
 
     assert "".join(out) == "ab"
     assert provider.seen_turns == [[("user", "hi")]] * 3
+
+
+@pytest.mark.asyncio
+async def test_stream_provider_hooks_receive_normalized_rich_tool_results_async():
+    provider = AccumulatingProvider([Chunk("done")])
+    chat = Chat(provider=provider)
+    result = set_rich_tool_history(chat)
+
+    out = [x async for x in await chat.stream_async("What does it show?")]
+
+    assert "".join(out) == "done"
+    assert provider.perform_turns is not None
+    assert_rich_tool_result_expanded(provider.perform_turns)
+    assert all(turns is provider.perform_turns for turns in provider.seen_raw_turns)
+    assert chat.get_turns()[2].contents == [result]
+
+
+def set_rich_tool_history(chat: Chat) -> ContentToolResult:
+    request = ContentToolRequest(id="plot-1", name="plot", arguments={})
+    image = ContentImageInline(data="aGVsbG8=", image_content_type="image/png")
+    result = ContentToolResult(value=image, model_format="as_is", request=request)
+    chat.set_turns(
+        [
+            UserTurn("plot the data"),
+            AssistantTurn([request]),
+            UserTurn([result]),
+            AssistantTurn("The chart is ready."),
+        ]
+    )
+    return result
+
+
+def assert_rich_tool_result_expanded(turns: list[Turn]) -> None:
+    result_turn = turns[2]
+    assert isinstance(result_turn, UserTurn)
+    assert any(isinstance(x, ContentImageInline) for x in result_turn.contents)

--- a/tests/test_tool_multi_results.py
+++ b/tests/test_tool_multi_results.py
@@ -19,7 +19,12 @@ from chatlas._provider_anthropic import AnthropicProvider
 from chatlas._provider_google import GoogleProvider
 from chatlas._provider_openai import OpenAIProvider
 from chatlas._provider_openai_completions import OpenAICompletionsProvider
-from chatlas._turn import AssistantTurn, Turn, UserTurn
+from chatlas._turn import (
+    AssistantTurn,
+    Turn,
+    UserTurn,
+    normalize_turns_for_provider,
+)
 from chatlas.types import ContentImageInline, ContentJson, ContentToolResult
 
 CALL_ID = "call_abc123"
@@ -41,7 +46,9 @@ def tool_turns(func: Any, name: str) -> list[Turn]:
         tool=ToolInfo.from_tool(chat._tools[name]),
     )
     results = list(chat._invoke_tool(request))
-    return [UserTurn("go"), AssistantTurn([request]), UserTurn(results)]
+    return normalize_turns_for_provider(
+        [UserTurn("go"), AssistantTurn([request]), UserTurn(results)]
+    )
 
 
 def anthropic_blocks(turns: list[Turn]) -> list[dict[str, Any]]:
@@ -248,17 +255,19 @@ def test_distinct_requests_are_not_merged(result_ids):
     """Combining must key on the request id, not lump all results together."""
     req_a = ContentToolRequest(id="call_a", name="repl", arguments={})
     req_b = ContentToolRequest(id="call_b", name="repl", arguments={})
-    turns = [
-        UserTurn("go"),
-        AssistantTurn([req_a, req_b]),
-        UserTurn(
-            [
-                ContentToolResult(value="a1", request=req_a),
-                ContentToolResult(value="a2", request=req_a),
-                ContentToolResult(value="b1", request=req_b),
-            ]
-        ),
-    ]
+    turns = normalize_turns_for_provider(
+        [
+            UserTurn("go"),
+            AssistantTurn([req_a, req_b]),
+            UserTurn(
+                [
+                    ContentToolResult(value="a1", request=req_a),
+                    ContentToolResult(value="a2", request=req_a),
+                    ContentToolResult(value="b1", request=req_b),
+                ]
+            ),
+        ]
+    )
 
     assert sorted(result_ids(turns)) == ["call_a", "call_b"]
 

--- a/tests/test_turn_expand.py
+++ b/tests/test_turn_expand.py
@@ -1,10 +1,11 @@
 """Tests for turn content expansion with images and PDFs in tool results."""
 
 import base64
-from typing import Any, cast
+from typing import Any, Sequence, cast
 
 from chatlas import UserTurn
 from chatlas._content import (
+    Content,
     ContentImageInline,
     ContentImageRemote,
     ContentPDF,
@@ -14,12 +15,22 @@ from chatlas._content import (
     ToolInfo,
 )
 from chatlas._provider_anthropic import AnthropicProvider
-from chatlas._turn import AssistantTurn
+from chatlas._turn import (
+    AssistantTurn,
+    normalize_turn_for_provider,
+    normalize_turns_for_provider,
+)
+
+
+def provider_turn(contents: str | Sequence[Content | str]) -> UserTurn:
+    turn = normalize_turn_for_provider(UserTurn(contents))
+    assert isinstance(turn, UserTurn)
+    return turn
 
 
 def test_expand_turn_no_tool_results():
     """Test that turns without tool results are unchanged."""
-    turn = UserTurn([ContentText(text="Hello")])
+    turn = provider_turn([ContentText(text="Hello")])
 
     assert len(turn.contents) == 1
     assert isinstance(turn.contents[0], ContentText)
@@ -36,7 +47,7 @@ def test_expand_turn_tool_result_without_images():
     )
 
     result = ContentToolResult(value="test result", request=request)
-    turn = UserTurn([result])
+    turn = provider_turn([result])
 
     assert len(turn.contents) == 1
     assert isinstance(turn.contents[0], ContentToolResult)
@@ -59,7 +70,7 @@ def test_expand_turn_tool_result_with_single_image():
     )
 
     result = ContentToolResult(value=image, request=request)
-    turn = UserTurn([result])
+    turn = provider_turn([result])
 
     # Should have 4 items: result with placeholder, open tag, image, close tag
     assert len(turn.contents) == 4
@@ -93,7 +104,7 @@ def test_expand_turn_tool_result_with_remote_image():
     image = ContentImageRemote(url="https://example.com/image.png")
 
     result = ContentToolResult(value=image, request=request)
-    turn = UserTurn([result])
+    turn = provider_turn([result])
 
     assert len(turn.contents) == 4
     assert isinstance(turn.contents[0], ContentToolResult)
@@ -113,7 +124,7 @@ def test_expand_turn_tool_result_with_pdf():
     pdf = ContentPDF(data=b"fake pdf data", filename="test.pdf")
 
     result = ContentToolResult(value=pdf, request=request)
-    turn = UserTurn([result])
+    turn = provider_turn([result])
 
     assert len(turn.contents) == 4
     assert isinstance(turn.contents[0], ContentToolResult)
@@ -141,7 +152,7 @@ def test_expand_turn_tool_result_with_list_of_images():
     )
 
     result = ContentToolResult(value=[image1, image2], request=request)
-    turn = UserTurn([result])
+    turn = provider_turn([result])
 
     # Should have: result, open wrapper, (open tag, image1, close tag),
     # (open tag, image2, close tag), close wrapper = 9 items
@@ -199,7 +210,7 @@ def test_expand_turn_multiple_tool_results():
     )
     result2 = ContentToolResult(value=image, request=request2)
 
-    turn = UserTurn([result1, result2])
+    turn = provider_turn([result1, result2])
 
     # First result unchanged (1 item)
     # Second result expanded (4 items)
@@ -233,7 +244,7 @@ def test_expand_turn_preserves_other_content():
     result = ContentToolResult(value=image, request=request)
     text2 = ContentText(text="After")
 
-    turn = UserTurn([text1, result, text2])
+    turn = provider_turn([text1, result, text2])
 
     # Tool result is expanded to 4 items (result, open tag, image, close tag)
     # Only the ContentToolResult itself is reordered to the front
@@ -255,7 +266,7 @@ def test_expand_turn_preserves_other_content():
 
 def test_expand_turn_empty_contents():
     """Test that turns with empty contents are handled gracefully."""
-    turn = UserTurn([])
+    turn = provider_turn([])
 
     assert len(turn.contents) == 0
 
@@ -272,7 +283,7 @@ def tool_request(id: str = "call_1", name: str = "repl") -> ContentToolRequest:
 def test_merge_joins_multiple_text_results():
     """Several text parts for one call arrive as one newline-joined result."""
     request = tool_request()
-    turn = UserTurn(
+    turn = provider_turn(
         [
             ContentToolResult(value="first", request=request),
             ContentToolResult(value="second", request=request),
@@ -288,7 +299,7 @@ def test_merge_leaves_single_result_untouched():
     request = tool_request()
     result = ContentToolResult(value="only", request=request)
 
-    turn = UserTurn([result])
+    turn = provider_turn([result])
 
     assert len(turn.contents) == 1
     assert turn.contents[0] is result
@@ -297,7 +308,7 @@ def test_merge_leaves_single_result_untouched():
 def test_merge_keeps_distinct_requests_separate():
     req_a = tool_request(id="call_a")
     req_b = tool_request(id="call_b")
-    turn = UserTurn(
+    turn = provider_turn(
         [
             ContentToolResult(value="a1", request=req_a),
             ContentToolResult(value="b1", request=req_b),
@@ -317,7 +328,7 @@ def test_merge_keeps_distinct_requests_separate():
 def test_merge_propagates_error_from_any_part():
     """A failure anywhere in the group must not be masked by sibling output."""
     request = tool_request()
-    turn = UserTurn(
+    turn = provider_turn(
         [
             ContentToolResult(value="partial output", request=request),
             ContentToolResult(value=None, error=RuntimeError("boom"), request=request),
@@ -338,7 +349,7 @@ def test_merge_mixed_text_and_image_is_expanded():
         data=base64.b64encode(b"png").decode("utf-8"),
         image_content_type="image/png",
     )
-    turn = UserTurn(
+    turn = provider_turn(
         [
             ContentToolResult(value="stdout", request=request),
             ContentToolResult(value=image, request=request),
@@ -356,7 +367,7 @@ def test_merge_mixed_text_and_image_is_expanded():
 
 def test_merge_keeps_non_result_content_in_relative_order():
     request = tool_request()
-    turn = UserTurn(
+    turn = provider_turn(
         [
             ContentText(text="Before"),
             ContentToolResult(value="one", request=request),
@@ -376,7 +387,7 @@ def test_merge_keeps_non_result_content_in_relative_order():
 
 def test_merge_ignores_results_without_a_request():
     """A result with no request has no id to group on, so it passes through."""
-    turn = UserTurn(
+    turn = provider_turn(
         [
             ContentToolResult(value="orphan a"),
             ContentToolResult(value="orphan b"),
@@ -397,7 +408,7 @@ def test_expanded_content_does_not_push_a_later_result_out_of_position():
         image_content_type="image/png",
     )
 
-    turn = UserTurn(
+    turn = provider_turn(
         [
             ContentToolResult(value=image, request=request_a),
             ContentToolResult(value="text b", request=request_b),
@@ -417,7 +428,7 @@ def test_tool_results_precede_user_authored_content():
         image_content_type="image/png",
     )
 
-    turn = UserTurn(
+    turn = provider_turn(
         [
             ContentText(text="Before"),
             ContentToolResult(value=image, request=request),
@@ -432,7 +443,7 @@ def test_tool_results_precede_user_authored_content():
 
 
 def test_ordering_is_untouched_when_there_are_no_tool_results():
-    turn = UserTurn([ContentText(text="one"), ContentText(text="two")])
+    turn = provider_turn([ContentText(text="one"), ContentText(text="two")])
 
     assert [c.text for c in turn.contents if isinstance(c, ContentText)] == [
         "one",
@@ -449,16 +460,18 @@ def test_anthropic_puts_every_tool_result_block_first():
         image_content_type="image/png",
     )
 
-    turns = [
-        UserTurn("go"),
-        AssistantTurn([request_a, request_b]),
-        UserTurn(
-            [
-                ContentToolResult(value=image, request=request_a),
-                ContentToolResult(value="text b", request=request_b),
-            ]
-        ),
-    ]
+    turns = normalize_turns_for_provider(
+        [
+            UserTurn("go"),
+            AssistantTurn([request_a, request_b]),
+            UserTurn(
+                [
+                    ContentToolResult(value=image, request=request_a),
+                    ContentToolResult(value="text b", request=request_b),
+                ]
+            ),
+        ]
+    )
 
     messages = AnthropicProvider(
         model="claude-sonnet-4-5", api_key="dummy", kwargs=None
@@ -485,20 +498,22 @@ def test_merge_expand_and_reorder_together():
         image_content_type="image/png",
     )
 
-    turns = [
-        UserTurn("go"),
-        AssistantTurn([request_a, request_b]),
-        UserTurn(
-            [
-                ContentText(text="Before"),
-                ContentToolResult(value="here is the plot", request=request_a),
-                ContentToolResult(value=image, request=request_a),
-                ContentText(text="Between"),
-                ContentToolResult(value="text b", request=request_b),
-                ContentText(text="After"),
-            ]
-        ),
-    ]
+    turns = normalize_turns_for_provider(
+        [
+            UserTurn("go"),
+            AssistantTurn([request_a, request_b]),
+            UserTurn(
+                [
+                    ContentText(text="Before"),
+                    ContentToolResult(value="here is the plot", request=request_a),
+                    ContentToolResult(value=image, request=request_a),
+                    ContentText(text="Between"),
+                    ContentToolResult(value="text b", request=request_b),
+                    ContentText(text="After"),
+                ]
+            ),
+        ]
+    )
 
     messages = AnthropicProvider(
         model="claude-sonnet-4-5", api_key="dummy", kwargs=None

--- a/tests/test_turns.py
+++ b/tests/test_turns.py
@@ -13,7 +13,13 @@ from chatlas._turn import (
     UserTurn,
     check_finish_reason,
 )
-from chatlas.types import ContentJson, ContentText, ContentToolRequest, ContentToolResult
+from chatlas.types import (
+    ContentImageInline,
+    ContentJson,
+    ContentText,
+    ContentToolRequest,
+    ContentToolResult,
+)
 
 
 def test_system_prompt_applied_correctly():
@@ -173,6 +179,35 @@ def test_get_turns_tool_result_role_assistant():
     assert isinstance(turns[1].contents[1], ContentToolRequest) 
     assert isinstance(turns[1].contents[2], ContentToolResult)
     assert isinstance(turns[1].contents[3], ContentText)
+
+
+def test_get_turns_rich_tool_result_role_assistant():
+    request = ContentToolRequest(id="plot-1", name="plot", arguments={})
+    image = ContentImageInline(
+        data="aGVsbG8=",
+        image_content_type="image/png",
+    )
+    result = ContentToolResult(
+        value=[ContentText(text="Chart displayed."), image],
+        model_format="as_is",
+        request=request,
+    )
+    result_turn = UserTurn([result])
+
+    assert result_turn.contents == [result]
+
+    chat = ChatAnthropic()
+    chat.set_turns(
+        [
+            UserTurn("plot the data"),
+            AssistantTurn([request]),
+            result_turn,
+            AssistantTurn("The chart is ready."),
+        ]
+    )
+
+    turns = chat.get_turns(tool_result_role="assistant")
+    assert [turn.role for turn in turns] == ["user", "assistant"]
 
 
 def test_get_turns_tool_result_role_collapse_consecutive():

--- a/tests/test_turns.py
+++ b/tests/test_turns.py
@@ -12,10 +12,12 @@ from chatlas._turn import (
     Turn,
     UserTurn,
     check_finish_reason,
+    normalize_turn_for_provider,
 )
 from chatlas.types import (
     ContentImageInline,
     ContentJson,
+    ContentPDF,
     ContentText,
     ContentToolRequest,
     ContentToolResult,
@@ -208,6 +210,59 @@ def test_get_turns_rich_tool_result_role_assistant():
 
     turns = chat.get_turns(tool_result_role="assistant")
     assert [turn.role for turn in turns] == ["user", "assistant"]
+    assert chat.get_turns()[1].contents == [request]
+
+
+def test_rich_tool_result_json_round_trip_preserves_content_types():
+    request = ContentToolRequest(id="plot-1", name="plot", arguments={})
+    image = ContentImageInline(
+        data="aGVsbG8=",
+        image_content_type="image/png",
+    )
+    pdf = ContentPDF(data=b"pdf", filename="report.pdf")
+    result = ContentToolResult(
+        value=[ContentText(text="Chart displayed."), image, pdf],
+        model_format="as_is",
+        request=request,
+    )
+
+    restored = Turn.model_validate_json(UserTurn([result]).model_dump_json())
+    restored_result = restored.contents[0]
+    assert isinstance(restored_result, ContentToolResult)
+    assert isinstance(restored_result.value[0], ContentText)
+    assert isinstance(restored_result.value[1], ContentImageInline)
+    assert isinstance(restored_result.value[2], ContentPDF)
+
+    provider_turn = normalize_turn_for_provider(restored)
+    assert any(isinstance(x, ContentImageInline) for x in provider_turn.contents)
+    assert any(isinstance(x, ContentPDF) for x in provider_turn.contents)
+
+
+def test_tool_result_content_type_mapping_remains_mapping():
+    value = {"content_type": "text", "text": "ordinary tool data"}
+    result = ContentToolResult(value=value, model_format="as_is")
+
+    assert isinstance(result.value, dict)
+    assert result.value == value
+
+    restored = Turn.model_validate_json(UserTurn([result]).model_dump_json())
+    restored_result = restored.contents[0]
+    assert isinstance(restored_result, ContentToolResult)
+    assert isinstance(restored_result.value, dict)
+    assert restored_result.value == value
+
+
+def test_rich_tool_result_json_round_trip_preserves_nested_mapping_content():
+    image = ContentImageInline(
+        data="aGVsbG8=",
+        image_content_type="image/png",
+    )
+    result = ContentToolResult(value={"plot": image}, model_format="as_is")
+
+    restored = Turn.model_validate_json(UserTurn([result]).model_dump_json())
+    restored_result = restored.contents[0]
+    assert isinstance(restored_result, ContentToolResult)
+    assert isinstance(restored_result.value["plot"], ContentImageInline)
 
 
 def test_get_turns_tool_result_role_collapse_consecutive():

--- a/tests/test_turns.py
+++ b/tests/test_turns.py
@@ -252,6 +252,18 @@ def test_tool_result_content_type_mapping_remains_mapping():
     assert restored_result.value == value
 
 
+def test_tool_result_content_sentinel_mapping_remains_mapping():
+    value = {"__chatlas_content__": "ordinary tool data"}
+    result = ContentToolResult(value=value, model_format="as_is")
+
+    assert result.value == value
+
+    restored = Turn.model_validate_json(UserTurn([result]).model_dump_json())
+    restored_result = restored.contents[0]
+    assert isinstance(restored_result, ContentToolResult)
+    assert restored_result.value == value
+
+
 def test_rich_tool_result_json_round_trip_preserves_nested_mapping_content():
     image = ContentImageInline(
         data="aGVsbG8=",


### PR DESCRIPTION
## Why this matters

Rich tool results containing images or PDFs are currently rewritten into provider transport content when a `UserTurn` is constructed. That makes XML association tags and adjacent media part of canonical conversation history, so restoring a saved conversation can display provider-only scaffolding as user-authored content.

This change keeps newly saved history semantic: one `ContentToolResult` remains one `ContentToolResult`. Merge, ordering, and XML/media expansion still happen, but only on copies prepared immediately before provider calls.

## Historical context

- September 2025, d6f8124e / #179: Added `get_turns(tool_result_role="assistant")` for display and bookmarking. It recognizes a tool-result turn only when every item is a `ContentToolResult`.
- November 2025, 088fa824 / #231: Added images and PDFs in tool results. Since most providers cannot place media directly inside a tool-result block, chatlas expanded rich results into a text result, XML association tags, and adjacent media.
- July 2026, be356c65 / #363: Extended `UserTurn` normalization to merge multiple results for one call and place tool results first for provider ordering requirements.

`UserTurn` provided a convenient shared location for preprocessing needed by four providers. However, the original feature followed [ellmer #735](https://github.com/tidyverse/ellmer/pull/735), where review explicitly requested that expansion happen "just prior to any API call." Ellmer followed that design; chatlas instead placed it in a Pydantic model validator, with no discussion found explaining the divergence.

The expansion is necessary. The issue is that provider-specific wire normalization leaked into semantic conversation history. No test connected rich result expansion with the older `tool_result_role="assistant"` behavior, so the incompatibility went unnoticed.

## What changes

- Preserve semantic rich tool results in stored turns and serialized conversations.
- Normalize provider-facing copies for sync and async chat, streaming hooks, token counting, and batch submission.
- Round-trip nested rich content through an explicit serialization envelope without interpreting ordinary tool payload dictionaries.
- Prevent `get_turns(tool_result_role="assistant")` from mutating stored history.
- Keep existing already-expanded saved conversations unchanged; this applies to newly saved history.

## Verification

- 157 focused tests passed.
- 1,227 broad-suite tests passed, excluding credential-dependent/live-provider and terminal-control cases.
- Ruff and Pyright passed.
