### PR TITLE
fix(databricks): normalize typed GPT-OSS response content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -->
 
 
-## [0.21.2] - 2026-08-20
+## [Unreleased]
 
 ### Bug fixes
 
 * `ChatDatabricks()` no longer crashes on GPT-OSS endpoints that return `message.content` / `delta.content` as a list of typed parts instead of a plain string; text parts are concatenated back into a string and reasoning summaries become `ContentThinking`/`ContentThinkingDelta`, both streaming and non-streaming. (#392)
+
+## [0.21.2] - 2026-08-20
+
+### Bug fixes
+
 * Rich tool results containing images or PDFs remain semantic `ContentToolResult` objects in saved chat history, so restoring a conversation no longer exposes provider-only XML and media as user-authored content.
 * `ChatOpenAI()` web-search citations no longer report the inline Markdown source link as `ContentCitation.grounded_span`; OpenAI's citation offsets identify that marker rather than the answer text it supports. (#388)
 * `ChatOpenAI()` no longer crashes while streaming web-search citations with current OpenAI SDKs, which emit annotations as model objects rather than dictionaries.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* `ChatDatabricks()` no longer crashes on GPT-OSS endpoints that return `message.content` / `delta.content` as a list of typed parts instead of a plain string; text parts are concatenated back into a string and reasoning summaries become `ContentThinking`/`ContentThinkingDelta`, both streaming and non-streaming. (#392)
 * Rich tool results containing images or PDFs remain semantic `ContentToolResult` objects in saved chat history, so restoring a conversation no longer exposes provider-only XML and media as user-authored content.
 * `ChatOpenAI()` web-search citations no longer report the inline Markdown source link as `ContentCitation.grounded_span`; OpenAI's citation offsets identify that marker rather than the answer text it supports. (#388)
 * `ChatOpenAI()` no longer crashes while streaming web-search citations with current OpenAI SDKs, which emit annotations as model objects rather than dictionaries.

--- a/chatlas/_provider_databricks.py
+++ b/chatlas/_provider_databricks.py
@@ -1,20 +1,45 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, cast
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 import httpx
 from openai import AsyncOpenAI
 
 from ._chat import Chat
+from ._content import Content
 from ._logging import log_model_default
 from ._provider_openai_completions import OpenAICompletionsProvider
 from ._provider_openai_generic import create_openai_client
+from ._turn import AssistantTurn
 
 if TYPE_CHECKING:
     from databricks.sdk import WorkspaceClient
 
     from ._provider_openai_completions import ChatCompletion
     from .types.openai import SubmitInputArgs
+
+
+def _normalize_content_parts(parts: list[Any]) -> tuple[Optional[str], Optional[str]]:
+    """Split a Databricks GPT-OSS typed content array into (text, reasoning).
+
+    GPT-OSS endpoints can return `message.content` / `delta.content` as a list
+    of typed parts (`{"type": "text", ...}`, `{"type": "reasoning", ...}`)
+    rather than the plain string the OpenAI-compatible parser assumes. Text
+    parts are concatenated back into a string; reasoning summaries are
+    concatenated into a separate string so callers can feed it into the
+    existing `reasoning` handling. Unrecognized part types are ignored, per
+    this provider's own scope (no generic typed-content support).
+    """
+    text = ""
+    reasoning = ""
+    for part in parts:
+        part_type = part.get("type") if isinstance(part, dict) else None
+        if part_type == "text":
+            text += part.get("text") or ""
+        elif part_type == "reasoning":
+            for summary in part.get("summary") or []:
+                reasoning += summary.get("text") or ""
+    return (text or None), (reasoning or None)
 
 
 def ChatDatabricks(
@@ -158,3 +183,28 @@ class DatabricksProvider(OpenAICompletionsProvider):
             del kwargs2["stream_options"]
 
         return kwargs2
+
+    # GPT-OSS endpoints can return delta.content as a list of typed parts
+    # instead of a plain string; normalize it in place, then reuse the base
+    # class's existing string/reasoning handling.
+    def stream_content(self, chunk, completion, turns=()) -> list[Content]:
+        delta = chunk.choices[0].delta if chunk.choices else None
+        if delta is not None and isinstance(delta.content, list):
+            text, reasoning = _normalize_content_parts(delta.content)
+            delta.content = text
+            if reasoning:
+                setattr(delta, "reasoning", reasoning)
+        return super().stream_content(chunk, completion, turns)
+
+    # Same normalization for the non-streaming/completed-response path.
+    @staticmethod
+    def _response_as_turn(
+        completion: "ChatCompletion", has_data_model: bool
+    ) -> AssistantTurn["ChatCompletion"]:
+        message = completion.choices[0].message
+        if isinstance(message.content, list):
+            text, reasoning = _normalize_content_parts(message.content)
+            message.content = text
+            if reasoning:
+                setattr(message, "reasoning", reasoning)
+        return OpenAICompletionsProvider._response_as_turn(completion, has_data_model)

--- a/tests/test_provider_databricks.py
+++ b/tests/test_provider_databricks.py
@@ -1,10 +1,12 @@
 import asyncio
 from types import SimpleNamespace
 from typing import Any, cast
+from unittest.mock import Mock
 
 import httpx
 import pytest
 from chatlas import ChatDatabricks
+from chatlas._content import ContentText, ContentThinking, ContentThinkingDelta
 from chatlas._provider_databricks import DatabricksProvider
 from openai import OpenAI
 
@@ -17,6 +19,21 @@ from .conftest import (
     assert_turns_system,
     make_vcr_config,
 )
+
+
+def _databricks_provider() -> DatabricksProvider:
+    """A DatabricksProvider that never touches the network."""
+    sync_client = OpenAI(
+        api_key="no-token",
+        base_url="https://workspace.example.com/serving-endpoints",
+        http_client=cast(Any, httpx.Client()),
+    )
+    workspace_client = SimpleNamespace(
+        serving_endpoints=SimpleNamespace(get_open_ai_client=lambda: sync_client)
+    )
+    return DatabricksProvider(
+        model="test", workspace_client=cast(Any, workspace_client)
+    )
 
 
 # Override VCR config to ignore host - Databricks host varies by environment
@@ -143,3 +160,128 @@ def test_databricks_async_client_preserves_legacy_httpx_auth():
     finally:
         provider._client.close()
         asyncio.run(provider._async_client.close())
+
+
+# GPT-OSS endpoints can return message.content / delta.content as a list of
+# typed parts instead of a plain string (#392); these exercise the
+# Databricks-only normalization layer, both non-streaming and streaming.
+
+
+def test_response_as_turn_normalizes_typed_content_array():
+    provider = _databricks_provider()
+    try:
+        message = Mock(
+            reasoning=None,
+            reasoning_content=None,
+            content=[
+                {
+                    "type": "reasoning",
+                    "summary": [{"type": "summary_text", "text": "thinking"}],
+                },
+                {"type": "text", "text": "Hello "},
+                {"type": "text", "text": "world"},
+            ],
+            tool_calls=None,
+        )
+        completion = Mock(choices=[Mock(message=message, finish_reason="stop")])
+
+        turn = provider._response_as_turn(completion, has_data_model=False)
+        assert len(turn.contents) == 2
+        assert isinstance(turn.contents[0], ContentThinking)
+        assert turn.contents[0].thinking == "thinking"
+        assert isinstance(turn.contents[1], ContentText)
+        assert turn.contents[1].text == "Hello world"
+    finally:
+        provider._client.close()
+
+
+def test_response_as_turn_normalizes_typed_content_array_text_only():
+    provider = _databricks_provider()
+    try:
+        message = Mock(
+            reasoning=None,
+            reasoning_content=None,
+            content=[{"type": "text", "text": "just an answer"}],
+            tool_calls=None,
+        )
+        completion = Mock(choices=[Mock(message=message, finish_reason="stop")])
+
+        turn = provider._response_as_turn(completion, has_data_model=False)
+        assert len(turn.contents) == 1
+        assert isinstance(turn.contents[0], ContentText)
+        assert turn.contents[0].text == "just an answer"
+    finally:
+        provider._client.close()
+
+
+def test_response_as_turn_preserves_plain_string_content():
+    """Non-array content (the common case) is untouched by the normalization."""
+    provider = _databricks_provider()
+    try:
+        message = Mock(
+            reasoning=None,
+            reasoning_content=None,
+            content="a plain string reply",
+            tool_calls=None,
+        )
+        completion = Mock(choices=[Mock(message=message, finish_reason="stop")])
+
+        turn = provider._response_as_turn(completion, has_data_model=False)
+        assert len(turn.contents) == 1
+        assert isinstance(turn.contents[0], ContentText)
+        assert turn.contents[0].text == "a plain string reply"
+    finally:
+        provider._client.close()
+
+
+def test_stream_content_normalizes_typed_content_array():
+    provider = _databricks_provider()
+    try:
+        delta = Mock(
+            reasoning=None,
+            reasoning_content=None,
+            content=[
+                {"type": "text", "text": "Hello "},
+                {"type": "text", "text": "world"},
+            ],
+        )
+        chunk = Mock(choices=[Mock(delta=delta)])
+
+        result = provider.stream_content(chunk, None)
+        assert result == [ContentText(text="Hello world")]
+    finally:
+        provider._client.close()
+
+
+def test_stream_content_normalizes_typed_reasoning_array():
+    provider = _databricks_provider()
+    try:
+        delta = Mock(
+            reasoning=None,
+            reasoning_content=None,
+            content=[
+                {
+                    "type": "reasoning",
+                    "summary": [{"type": "summary_text", "text": "hmm"}],
+                }
+            ],
+        )
+        chunk = Mock(choices=[Mock(delta=delta)])
+
+        result = provider.stream_content(chunk, None)
+        assert result == [ContentThinkingDelta(thinking="hmm")]
+    finally:
+        provider._client.close()
+
+
+def test_stream_content_preserves_plain_string_content():
+    """Non-array content (the common case) is untouched by the normalization."""
+    provider = _databricks_provider()
+    try:
+        delta = Mock(reasoning=None, reasoning_content=None, content="partial text")
+        chunk = Mock(choices=[Mock(delta=delta)])
+
+        result = provider.stream_content(chunk, None)
+        assert result == [ContentText(text="partial text")]
+    finally:
+        provider._client.close()


### PR DESCRIPTION
## Root cause

Databricks GPT-OSS endpoints can return chat-completion `message.content` (and
streaming `delta.content`) as an array of typed parts (`{"type": "text", ...}`,
`{"type": "reasoning", ...}`) rather than the plain string the inherited
`OpenAICompletionsProvider` parser assumes. `DatabricksProvider` overrides
neither `stream_content` nor `_response_as_turn`, so it inherits that
assumption unchanged: `ContentText(text=message.content)` receives a list and
raises a pydantic `ValidationError` before a `Turn` is ever produced, for both
the streaming and non-streaming paths.

## Fix

`DatabricksProvider` now normalizes a typed content array into a plain string
plus a separate reasoning string, then delegates to the existing
OpenAI-compatible reasoning/text handling (which already understands a
`reasoning` field, so nothing in `_provider_openai_completions.py` changes).
Text parts are concatenated; `reasoning` parts' `summary` text is concatenated
into the `reasoning` attribute the base class already checks. A plain string
or `None` content is untouched. Scoped to `_provider_databricks.py` only, per
the issue's own non-goal of not broadening the shared OpenAI-compatible
parser.

## Verification

- New `tests/test_provider_databricks.py` unit tests construct a typed content
  array (non-streaming and streaming, with and without a reasoning part);
  each fails on unpatched `main` with the `ValidationError` above and passes
  on this branch (confirmed both ways via `git stash`).
- Full `tests/test_provider_databricks.py` suite (existing VCR-backed tests
  included) passes unchanged on Python 3.10, 3.12 and 3.14; whole-repo suite
  on 3.12 has no new failures (45 pre-existing, environment-only, identical
  set on unpatched `main`).
- `ruff check`/`ruff format --diff` and `pyright` on the changed files are
  clean.
- Not verified: an actual Databricks GPT-OSS endpoint. The typed-part shape
  comes from this issue's own description; I do not have Databricks
  credentials to confirm the exact wire format.

Fixes #392
