### PR TITLE
Add settable `conversation_id` property to `Chat`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ChatAnthropic()`, `ChatBedrock()`, and `ChatPosit()` now require `anthropic>=1.0.0`. As a result, custom `http_client`s passed to Anthropic-backed providers must now be `httpx2` clients (rather than `httpx`), matching the anthropic SDK's own requirement.
 - `ChatBedrock()` and `ChatBedrockAnthropic()` now raise at construction if no AWS region can be resolved (from the `aws_region` argument, the `AWS_REGION`/`AWS_DEFAULT_REGION` environment variables, or the AWS profile), rather than silently defaulting to `us-east-1`. This behavior change is inherited from anthropic 1.0.
 - On Anthropic-backed providers, the `temperature`, `top_p`, and `top_k` model parameters are deprecated: anthropic 1.0 removed them from the request schema since current models ignore them. chatlas now forwards them via `extra_body` (with a `DeprecationWarning`) so older models that still honor them keep working; this forwarding will be removed in a future release.
+
+### Added
+
+- `Chat` gains a settable `.conversation_id` property. When set, the identifier is recorded as the `gen_ai.conversation.id` attribute on the OpenTelemetry `chat` and `invoke_agent` spans, allowing backends to group spans belonging to the same conversation (per the OpenTelemetry GenAI semantic conventions). Developer-facing: intended for frameworks that manage conversation history; chatlas never generates an identifier on its own.
 ## [0.21.2] - 2026-08-20
 
 ### Bug fixes

--- a/chatlas/_chat.py
+++ b/chatlas/_chat.py
@@ -195,6 +195,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         self._turns: list[Turn] = []
         self.system_prompt = system_prompt
         self.kwargs_chat: SubmitInputArgsT = kwargs_chat or {}
+        self._conversation_id: Optional[str] = None
 
         self._tools: dict[str, Tool | ToolBuiltIn] = {}
         self._on_tool_request_callbacks = CallbackManager()
@@ -488,6 +489,35 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
     @model.setter
     def model(self, value: str):
         self.provider.model = value
+
+    @property
+    def conversation_id(self) -> str | None:
+        """
+        A property to get (or set) an identifier for the current conversation.
+
+        When set, it is recorded as the `gen_ai.conversation.id` attribute on
+        OpenTelemetry spans emitted for subsequent model calls. Set to `None`
+        to clear.
+
+        Developer-facing: intended for frameworks that manage conversation
+        history (e.g., Shiny apps). chatlas never generates an identifier on
+        its own.
+
+        Returns
+        -------
+        str | None
+            The conversation identifier (if any).
+        """
+        return self._conversation_id
+
+    @conversation_id.setter
+    def conversation_id(self, value: str | None):
+        if value is not None and not isinstance(value, str):
+            raise TypeError(
+                "conversation_id must be a string or None, "
+                f"not {type(value).__name__}."
+            )
+        self._conversation_id = value
 
     def get_tokens(self) -> list[TokensDict]:
         """
@@ -2690,7 +2720,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         *,
         controller: StreamController,
     ) -> Generator[str | Content, None, None]:
-        agent_span = start_agent_span(self.provider)
+        agent_span = start_agent_span(self.provider, self._conversation_id)
         try:
             user_turn_result: UserTurn | None = user_turn
             while user_turn_result is not None:
@@ -2777,7 +2807,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         *,
         controller: StreamController,
     ) -> AsyncGenerator[str | Content, None]:
-        agent_span = start_agent_span(self.provider)
+        agent_span = start_agent_span(self.provider, self._conversation_id)
         try:
             user_turn_result: UserTurn | None = user_turn
             while user_turn_result is not None:
@@ -2878,7 +2908,9 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
 
         request_turns = [*self._turns, user_turn]
         provider_turns = normalize_turns_for_provider(request_turns)
-        chat_span = start_chat_span(self.provider, request_turns, _otel_parent)
+        chat_span = start_chat_span(
+            self.provider, request_turns, _otel_parent, self._conversation_id
+        )
         try:
 
             def emit(x: str | Content):
@@ -3036,7 +3068,9 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
     ) -> AsyncGenerator[str | Content, None]:
         request_turns = [*self._turns, user_turn]
         provider_turns = normalize_turns_for_provider(request_turns)
-        chat_span = start_chat_span(self.provider, request_turns, _otel_parent)
+        chat_span = start_chat_span(
+            self.provider, request_turns, _otel_parent, self._conversation_id
+        )
         try:
 
             def emit(x: str | Content):

--- a/chatlas/_otel.py
+++ b/chatlas/_otel.py
@@ -28,15 +28,21 @@ def capture_content() -> bool:
     ).lower() in ("true", "1")
 
 
-def start_agent_span(provider: Provider[Any, Any, Any, Any]) -> Span:
+def start_agent_span(
+    provider: Provider[Any, Any, Any, Any],
+    conversation_id: Optional[str] = None,
+) -> Span:
+    attributes: dict[str, Any] = {
+        "gen_ai.operation.name": "invoke_agent",
+        "gen_ai.provider.name": provider.name.lower(),
+        "gen_ai.request.model": provider.model,
+    }
+    if conversation_id is not None:
+        attributes["gen_ai.conversation.id"] = conversation_id
     return tracer.start_span(
         "invoke_agent",
         kind=SpanKind.CLIENT,
-        attributes={
-            "gen_ai.operation.name": "invoke_agent",
-            "gen_ai.provider.name": provider.name.lower(),
-            "gen_ai.request.model": provider.model,
-        },
+        attributes=attributes,
     )
 
 
@@ -44,16 +50,22 @@ def start_chat_span(
     provider: Provider[Any, Any, Any, Any],
     turns: list[Turn],
     parent: Optional[Span],
+    conversation_id: Optional[str] = None,
 ) -> Span:
     ctx = trace.set_span_in_context(parent) if parent is not None else None
+    attributes: dict[str, Any] = {
+        "gen_ai.operation.name": "chat",
+        "gen_ai.provider.name": provider.name.lower(),
+        "gen_ai.request.model": provider.model,
+    }
+    if conversation_id is not None:
+        # Per the GenAI semantic conventions, only set when a conversation
+        # identifier is readily available; never invent a fallback value.
+        attributes["gen_ai.conversation.id"] = conversation_id
     span = tracer.start_span(
         f"chat {provider.model}",
         kind=SpanKind.CLIENT,
-        attributes={
-            "gen_ai.operation.name": "chat",
-            "gen_ai.provider.name": provider.name.lower(),
-            "gen_ai.request.model": provider.model,
-        },
+        attributes=attributes,
         context=ctx,
     )
 

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -335,6 +335,69 @@ def test_chat_error_recorded_streaming(otel_setup: InMemorySpanExporter):
     )
 
 
+def test_conversation_id_recorded_on_spans(otel_setup: InMemorySpanExporter):
+    # When a conversation id is set on the Chat, both the invoke_agent and chat
+    # spans should carry it as `gen_ai.conversation.id` (the provider call is
+    # forced to fail so the test runs without network; the spans are still
+    # created and finished with their start-time attributes).
+    chat = ChatOpenAI(model="gpt-4o-mini")
+    chat.conversation_id = "conv_123"
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("provider blew up")
+
+    chat.provider.chat_perform = boom  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError, match="provider blew up"):
+        chat.chat("Say hello.")
+
+    spans = otel_setup.get_finished_spans()
+    agent_spans = [s for s in spans if s.name == "invoke_agent"]
+    chat_spans = [s for s in spans if s.name.startswith("chat ")]
+    assert len(agent_spans) == 1
+    assert len(chat_spans) == 1
+
+    for span in (*agent_spans, *chat_spans):
+        attrs = span.attributes or {}
+        assert attrs.get("gen_ai.conversation.id") == "conv_123", (
+            f"Expected gen_ai.conversation.id on span {span.name!r}"
+        )
+
+
+def test_conversation_id_absent_by_default(otel_setup: InMemorySpanExporter):
+    # Per the GenAI semantic conventions, no fallback identifier should be
+    # invented when the app hasn't provided one.
+    chat = ChatOpenAI(model="gpt-4o-mini")
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("provider blew up")
+
+    chat.provider.chat_perform = boom  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError, match="provider blew up"):
+        chat.chat("Say hello.")
+
+    for span in otel_setup.get_finished_spans():
+        attrs = span.attributes or {}
+        assert "gen_ai.conversation.id" not in attrs, (
+            f"Unexpected gen_ai.conversation.id on span {span.name!r}"
+        )
+
+
+def test_conversation_id_property():
+    chat = ChatOpenAI(model="gpt-4o-mini")
+    assert chat.conversation_id is None
+
+    chat.conversation_id = "conv_123"
+    assert chat.conversation_id == "conv_123"
+
+    chat.conversation_id = None
+    assert chat.conversation_id is None
+
+    with pytest.raises(TypeError, match="conversation_id"):
+        chat.conversation_id = 123  # type: ignore[assignment]
+
+
 def test_noop_without_provider():
     from opentelemetry import trace
     from opentelemetry.trace import NonRecordingSpan


### PR DESCRIPTION
Part of posit-dev/shinychat#307.

## Summary

Adds a settable `conversation_id` property to `Chat`. When set, the identifier is recorded as the `gen_ai.conversation.id` attribute on the `invoke_agent` and `chat` OpenTelemetry spans emitted for subsequent model calls, so backends can group spans belonging to the same conversation (per the [OTel GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/)).

This is developer-facing: intended for frameworks that manage conversation history (e.g., Shiny apps via shinychat) rather than end users. Following the conventions, chatlas never generates an identifier on its own — when unset (`None`, the default), the attribute is omitted entirely rather than falling back to an invented value. Setting the property only affects spans created for subsequent model calls; in-flight responses keep the ID captured at their submission.

## Verification

```python
chat = chatlas.ChatOpenAI(model="gpt-4o-mini")
chat.conversation_id = "conv_123"  # recorded as gen_ai.conversation.id on chat/invoke_agent spans
chat.conversation_id = None        # clear (e.g., starting a new conversation)
```

Tests in `tests/test_otel.py` cover: attribute present on both span types when set, absent by default, and property round-trip/validation.