### PR TITLE
Adapt to anthropic 1.0 (httpx2); update provider types and pricing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -->
 
 
+## [Unreleased]
+
+### Changes
+
+- `ChatAnthropic()`, `ChatBedrock()`, and `ChatPosit()` now require `anthropic>=1.0.0`. As a result, custom `http_client`s passed to Anthropic-backed providers must now be `httpx2` clients (rather than `httpx`), matching the anthropic SDK's own requirement.
 ## [0.21.2] - 2026-08-20
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `ChatAnthropic()`, `ChatBedrock()`, and `ChatPosit()` now require `anthropic>=1.0.0`. As a result, custom `http_client`s passed to Anthropic-backed providers must now be `httpx2` clients (rather than `httpx`), matching the anthropic SDK's own requirement.
 - `ChatBedrock()` and `ChatBedrockAnthropic()` now raise at construction if no AWS region can be resolved (from the `aws_region` argument, the `AWS_REGION`/`AWS_DEFAULT_REGION` environment variables, or the AWS profile), rather than silently defaulting to `us-east-1`. This behavior change is inherited from anthropic 1.0.
+- On Anthropic-backed providers, the `temperature`, `top_p`, and `top_k` model parameters are deprecated: anthropic 1.0 removed them from the request schema since current models ignore them. chatlas now forwards them via `extra_body` (with a `DeprecationWarning`) so older models that still honor them keep working; this forwarding will be removed in a future release.
 ## [0.21.2] - 2026-08-20
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changes
 
 - `ChatAnthropic()`, `ChatBedrock()`, and `ChatPosit()` now require `anthropic>=1.0.0`. As a result, custom `http_client`s passed to Anthropic-backed providers must now be `httpx2` clients (rather than `httpx`), matching the anthropic SDK's own requirement.
+- `ChatBedrock()` and `ChatBedrockAnthropic()` now raise at construction if no AWS region can be resolved (from the `aws_region` argument, the `AWS_REGION`/`AWS_DEFAULT_REGION` environment variables, or the AWS profile), rather than silently defaulting to `us-east-1`. This behavior change is inherited from anthropic 1.0.
 ## [0.21.2] - 2026-08-20
 
 ### Bug fixes

--- a/chatlas/_provider_anthropic.py
+++ b/chatlas/_provider_anthropic.py
@@ -771,14 +771,28 @@ class AnthropicProvider(
 
     def translate_model_params(self, params: StandardModelParams) -> "SubmitInputArgs":
         res: "SubmitInputArgs" = {}
-        if "temperature" in params:
-            res["temperature"] = params["temperature"]
 
-        if "top_p" in params:
-            res["top_p"] = params["top_p"]
-
-        if "top_k" in params:
-            res["top_k"] = params["top_k"]
+        # anthropic>=1.0 removed these sampling parameters from the request
+        # schema; current models ignore them. Forward them via `extra_body`
+        # so older models that still honor them keep working.
+        removed = [p for p in ("temperature", "top_p", "top_k") if p in params]
+        if removed:
+            warnings.warn(
+                f"The {', '.join(removed)} sampling parameter(s) no longer have "
+                "an effect on current Anthropic models. They are forwarded via "
+                "`extra_body` for older models that still honor them; this "
+                "forwarding is deprecated and will be removed in a future release.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            extra_body: dict[str, Any] = {}
+            if "temperature" in params:
+                extra_body["temperature"] = params["temperature"]
+            if "top_p" in params:
+                extra_body["top_p"] = params["top_p"]
+            if "top_k" in params:
+                extra_body["top_k"] = params["top_k"]
+            res["extra_body"] = extra_body
 
         if "max_tokens" in params:
             res["max_tokens"] = params["max_tokens"]

--- a/chatlas/_provider_posit.py
+++ b/chatlas/_provider_posit.py
@@ -9,7 +9,6 @@ import webbrowser
 from pathlib import Path
 from typing import Any, Callable, Literal, Optional
 
-import httpx
 import httpx2
 import requests
 from openai import AsyncOpenAI, OpenAI, OpenAIError
@@ -182,31 +181,12 @@ def _posit_error_message(
     return None
 
 
-class PositAuth(httpx.Auth):
+class PositHttpx2Auth(httpx2.Auth):
     """
     Turns a bearer-token callable into `Authorization: Bearer` headers on
     every request, overriding any `x-api-key` header a client set by default.
     """
 
-    def __init__(self, credentials: Callable[[], str]):
-        self._credentials = credentials
-
-    def _apply(self, request: httpx.Request, token: str) -> None:
-        request.headers.pop("x-api-key", None)
-        request.headers["Authorization"] = f"Bearer {token}"
-
-    def sync_auth_flow(self, request: httpx.Request):
-        token = self._credentials()
-        self._apply(request, token)
-        yield request
-
-    async def async_auth_flow(self, request: httpx.Request):
-        token = await asyncio.to_thread(self._credentials)
-        self._apply(request, token)
-        yield request
-
-
-class PositHttpx2Auth(httpx2.Auth):
     def __init__(self, credentials: Callable[[], str]):
         self._credentials = credentials
 
@@ -225,31 +205,7 @@ class PositHttpx2Auth(httpx2.Auth):
         yield request
 
 
-def make_posit_anthropic_error_hook(error_cls: type[Exception]):
-    def hook(response: httpx.Response) -> None:
-        if response.status_code < 400:
-            return
-        response.read()
-        message = _posit_error_message(response.status_code, _safe_json(response))
-        if message is not None:
-            raise error_cls(message)
-
-    return hook
-
-
-def make_posit_anthropic_error_hook_async(error_cls: type[Exception]):
-    async def hook(response: httpx.Response) -> None:
-        if response.status_code < 400:
-            return
-        await response.aread()
-        message = _posit_error_message(response.status_code, _safe_json(response))
-        if message is not None:
-            raise error_cls(message)
-
-    return hook
-
-
-def make_posit_openai_error_hook(error_cls: type[Exception]):
+def make_posit_error_hook(error_cls: type[Exception]):
     def hook(response: httpx2.Response) -> None:
         if response.status_code < 400:
             return
@@ -261,7 +217,7 @@ def make_posit_openai_error_hook(error_cls: type[Exception]):
     return hook
 
 
-def make_posit_openai_error_hook_async(error_cls: type[Exception]):
+def make_posit_error_hook_async(error_cls: type[Exception]):
     async def hook(response: httpx2.Response) -> None:
         if response.status_code < 400:
             return
@@ -328,7 +284,7 @@ class PositAnthropicProvider(AnthropicProvider):
         self._gateway_base_url = base_url.rstrip("/")
         self._credentials = credentials
 
-        auth = PositAuth(credentials)
+        auth = PositHttpx2Auth(credentials)
         # The anthropic SDK appends "/v1/messages" to base_url itself, so
         # this must not also include "/v1" (unlike the OpenAI flavor below,
         # whose SDK already includes "/v1" in its default base_url).
@@ -337,20 +293,18 @@ class PositAnthropicProvider(AnthropicProvider):
         self._client = Anthropic(
             api_key="not-used",
             base_url=flavor_base_url,
-            http_client=httpx.Client(
+            http_client=httpx2.Client(
                 auth=auth,
-                event_hooks={
-                    "response": [make_posit_anthropic_error_hook(AnthropicError)]
-                },
+                event_hooks={"response": [make_posit_error_hook(AnthropicError)]},
             ),
         )
         self._async_client = AsyncAnthropic(
             api_key="not-used",
             base_url=flavor_base_url,
-            http_client=httpx.AsyncClient(
+            http_client=httpx2.AsyncClient(
                 auth=auth,
                 event_hooks={
-                    "response": [make_posit_anthropic_error_hook_async(AnthropicError)]
+                    "response": [make_posit_error_hook_async(AnthropicError)]
                 },
             ),
         )
@@ -381,7 +335,7 @@ class PositOpenAIProvider(OpenAICompletionsProvider):
             base_url=flavor_base_url,
             http_client=httpx2.Client(
                 auth=auth,
-                event_hooks={"response": [make_posit_openai_error_hook(OpenAIError)]},
+                event_hooks={"response": [make_posit_error_hook(OpenAIError)]},
             ),
         )
         self._async_client = AsyncOpenAI(
@@ -390,7 +344,7 @@ class PositOpenAIProvider(OpenAICompletionsProvider):
             http_client=httpx2.AsyncClient(
                 auth=auth,
                 event_hooks={
-                    "response": [make_posit_openai_error_hook_async(OpenAIError)]
+                    "response": [make_posit_error_hook_async(OpenAIError)]
                 },
             ),
         )

--- a/chatlas/data/bedrock_apis.json
+++ b/chatlas/data/bedrock_apis.json
@@ -6,8 +6,5 @@
   "google.gemma-4-e2b": "responses",
   "openai.gpt-5.4": "responses",
   "openai.gpt-5.5": "responses",
-  "openai.gpt-5.6-luna": "responses",
-  "openai.gpt-5.6-sol": "responses",
-  "openai.gpt-5.6-terra": "responses",
   "xai.grok-4.3": "responses"
 }

--- a/chatlas/data/bedrock_apis.json
+++ b/chatlas/data/bedrock_apis.json
@@ -6,5 +6,8 @@
   "google.gemma-4-e2b": "responses",
   "openai.gpt-5.4": "responses",
   "openai.gpt-5.5": "responses",
+  "openai.gpt-5.6-luna": "responses",
+  "openai.gpt-5.6-sol": "responses",
+  "openai.gpt-5.6-terra": "responses",
   "xai.grok-4.3": "responses"
 }

--- a/chatlas/data/prices.json
+++ b/chatlas/data/prices.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "min_ellmer_version": "0.5.0",
-  "updated_at": "2026-08-17T06:39:03Z",
+  "updated_at": "2026-08-24T06:42:01Z",
   "data": [
     {
       "provider": "AWS/Bedrock",
@@ -229,6 +229,13 @@
     },
     {
       "provider": "AWS/Bedrock",
+      "model": "anthropic.claude-haiku-4-5-20251001-v1:0",
+      "variant": "batches",
+      "input": 0.5,
+      "output": 2.5
+    },
+    {
+      "provider": "AWS/Bedrock",
       "model": "anthropic.claude-haiku-4-5@20251001",
       "variant": "",
       "input": 1,
@@ -329,6 +336,13 @@
       "input": 6,
       "output": 22.5,
       "cached_input": 0.6
+    },
+    {
+      "provider": "AWS/Bedrock",
+      "model": "anthropic.claude-sonnet-4-5-20250929-v1:0",
+      "variant": "batches",
+      "input": 1.5,
+      "output": 7.5
     },
     {
       "provider": "AWS/Bedrock",
@@ -600,6 +614,13 @@
     },
     {
       "provider": "AWS/Bedrock",
+      "model": "apac.anthropic.claude-haiku-4-5-20251001-v1:0",
+      "variant": "batches",
+      "input": 0.55,
+      "output": 2.75
+    },
+    {
+      "provider": "AWS/Bedrock",
       "model": "apac.anthropic.claude-sonnet-4-20250514-v1:0",
       "variant": "",
       "input": 3,
@@ -621,6 +642,13 @@
       "input": 1.1,
       "output": 5.5,
       "cached_input": 0.11
+    },
+    {
+      "provider": "AWS/Bedrock",
+      "model": "au.anthropic.claude-haiku-4-5-20251001-v1:0",
+      "variant": "batches",
+      "input": 0.55,
+      "output": 2.75
     },
     {
       "provider": "AWS/Bedrock",
@@ -672,6 +700,13 @@
     },
     {
       "provider": "AWS/Bedrock",
+      "model": "au.anthropic.claude-sonnet-4-5-20250929-v1:0",
+      "variant": "batches",
+      "input": 1.65,
+      "output": 8.25
+    },
+    {
+      "provider": "AWS/Bedrock",
       "model": "au.anthropic.claude-sonnet-4-6",
       "variant": "",
       "input": 3.3,
@@ -715,6 +750,13 @@
       "input": 6,
       "output": 22.5,
       "cached_input": 0.6
+    },
+    {
+      "provider": "AWS/Bedrock",
+      "model": "claude-sonnet-4-5-20250929-v1:0",
+      "variant": "batches",
+      "input": 1.5,
+      "output": 7.5
     },
     {
       "provider": "AWS/Bedrock",
@@ -1072,6 +1114,13 @@
     },
     {
       "provider": "AWS/Bedrock",
+      "model": "eu.anthropic.claude-haiku-4-5-20251001-v1:0",
+      "variant": "batches",
+      "input": 0.55,
+      "output": 2.75
+    },
+    {
+      "provider": "AWS/Bedrock",
       "model": "eu.anthropic.claude-opus-4-1-20250805-v1:0",
       "variant": "",
       "input": 15,
@@ -1160,6 +1209,13 @@
     },
     {
       "provider": "AWS/Bedrock",
+      "model": "eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
+      "variant": "batches",
+      "input": 1.65,
+      "output": 8.25
+    },
+    {
+      "provider": "AWS/Bedrock",
       "model": "eu.anthropic.claude-sonnet-4-6",
       "variant": "",
       "input": 3.3,
@@ -1241,6 +1297,13 @@
     },
     {
       "provider": "AWS/Bedrock",
+      "model": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+      "variant": "batches",
+      "input": 0.5,
+      "output": 2.5
+    },
+    {
+      "provider": "AWS/Bedrock",
       "model": "global.anthropic.claude-opus-4-5-20251101-v1:0",
       "variant": "",
       "input": 5,
@@ -1313,6 +1376,13 @@
     },
     {
       "provider": "AWS/Bedrock",
+      "model": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+      "variant": "batches",
+      "input": 1.5,
+      "output": 7.5
+    },
+    {
+      "provider": "AWS/Bedrock",
       "model": "global.anthropic.claude-sonnet-4-6",
       "variant": "",
       "input": 3,
@@ -1326,6 +1396,62 @@
       "input": 2,
       "output": 10,
       "cached_input": 0.2
+    },
+    {
+      "provider": "AWS/Bedrock",
+      "model": "global.openai.gpt-5.6-luna",
+      "variant": "",
+      "input": 0.2,
+      "output": 1.2,
+      "cached_input": 0.02
+    },
+    {
+      "provider": "AWS/Bedrock",
+      "model": "global.openai.gpt-5.6-luna",
+      "variant": "above_272k_tokens",
+      "input": 0.4,
+      "output": 1.8,
+      "cached_input": 0.04
+    },
+    {
+      "provider": "AWS/Bedrock",
+      "model": "global.openai.gpt-5.6-sol",
+      "variant": "",
+      "input": 5,
+      "output": 30,
+      "cached_input": 0.5
+    },
+    {
+      "provider": "AWS/Bedrock",
+      "model": "global.openai.gpt-5.6-sol",
+      "variant": "above_272k_tokens",
+      "input": 10,
+      "output": 45,
+      "cached_input": 1
+    },
+    {
+      "provider": "AWS/Bedrock",
+      "model": "global.openai.gpt-5.6-terra",
+      "variant": "",
+      "input": 2,
+      "output": 12,
+      "cached_input": 0.2
+    },
+    {
+      "provider": "AWS/Bedrock",
+      "model": "global.openai.gpt-5.6-terra",
+      "variant": "above_272k_tokens",
+      "input": 4,
+      "output": 18,
+      "cached_input": 0.4
+    },
+    {
+      "provider": "AWS/Bedrock",
+      "model": "global.xai.grok-4.6",
+      "variant": "",
+      "input": 2,
+      "output": 6,
+      "cached_input": 0.5
     },
     {
       "provider": "AWS/Bedrock",
@@ -1387,6 +1513,13 @@
     },
     {
       "provider": "AWS/Bedrock",
+      "model": "jp.anthropic.claude-haiku-4-5-20251001-v1:0",
+      "variant": "batches",
+      "input": 0.55,
+      "output": 2.75
+    },
+    {
+      "provider": "AWS/Bedrock",
       "model": "jp.anthropic.claude-opus-4-7",
       "variant": "",
       "input": 5.5,
@@ -1424,6 +1557,13 @@
       "input": 6.6,
       "output": 24.75,
       "cached_input": 0.66
+    },
+    {
+      "provider": "AWS/Bedrock",
+      "model": "jp.anthropic.claude-sonnet-4-5-20250929-v1:0",
+      "variant": "batches",
+      "input": 1.65,
+      "output": 8.25
     },
     {
       "provider": "AWS/Bedrock",
@@ -1826,6 +1966,13 @@
       "variant": "",
       "input": 0.22,
       "output": 0.88
+    },
+    {
+      "provider": "AWS/Bedrock",
+      "model": "qwen.qwen3-235b-a22b-2507-v1:0",
+      "variant": "batches",
+      "input": 0.11,
+      "output": 0.44
     },
     {
       "provider": "AWS/Bedrock",
@@ -2524,6 +2671,13 @@
     },
     {
       "provider": "AWS/Bedrock",
+      "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+      "variant": "batches",
+      "input": 0.55,
+      "output": 2.75
+    },
+    {
+      "provider": "AWS/Bedrock",
       "model": "us.anthropic.claude-opus-4-1-20250805-v1:0",
       "variant": "",
       "input": 15,
@@ -2609,6 +2763,13 @@
       "input": 6.6,
       "output": 24.75,
       "cached_input": 0.66
+    },
+    {
+      "provider": "AWS/Bedrock",
+      "model": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+      "variant": "batches",
+      "input": 1.65,
+      "output": 8.25
     },
     {
       "provider": "AWS/Bedrock",
@@ -2733,6 +2894,54 @@
     },
     {
       "provider": "AWS/Bedrock",
+      "model": "us.openai.gpt-5.6-luna",
+      "variant": "",
+      "input": 0.22,
+      "output": 1.32,
+      "cached_input": 0.022
+    },
+    {
+      "provider": "AWS/Bedrock",
+      "model": "us.openai.gpt-5.6-luna",
+      "variant": "above_272k_tokens",
+      "input": 0.44,
+      "output": 1.98,
+      "cached_input": 0.044
+    },
+    {
+      "provider": "AWS/Bedrock",
+      "model": "us.openai.gpt-5.6-sol",
+      "variant": "",
+      "input": 5.5,
+      "output": 33,
+      "cached_input": 0.55
+    },
+    {
+      "provider": "AWS/Bedrock",
+      "model": "us.openai.gpt-5.6-sol",
+      "variant": "above_272k_tokens",
+      "input": 11,
+      "output": 49.5,
+      "cached_input": 1.1
+    },
+    {
+      "provider": "AWS/Bedrock",
+      "model": "us.openai.gpt-5.6-terra",
+      "variant": "",
+      "input": 2.2,
+      "output": 13.2,
+      "cached_input": 0.22
+    },
+    {
+      "provider": "AWS/Bedrock",
+      "model": "us.openai.gpt-5.6-terra",
+      "variant": "above_272k_tokens",
+      "input": 4.4,
+      "output": 19.8,
+      "cached_input": 0.44
+    },
+    {
+      "provider": "AWS/Bedrock",
       "model": "us.twelvelabs.marengo-embed-2-7-v1:0",
       "variant": "",
       "input": 70,
@@ -2760,6 +2969,14 @@
     },
     {
       "provider": "AWS/Bedrock",
+      "model": "us.xai.grok-4.6",
+      "variant": "",
+      "input": 2.2,
+      "output": 6.6,
+      "cached_input": 0.55
+    },
+    {
+      "provider": "AWS/Bedrock",
       "model": "writer.palmyra-x4-v1:0",
       "variant": "",
       "input": 2.5,
@@ -2779,6 +2996,14 @@
       "input": 1.25,
       "output": 2.5,
       "cached_input": 0.2
+    },
+    {
+      "provider": "AWS/Bedrock",
+      "model": "xai.grok-4.6",
+      "variant": "",
+      "input": 2.2,
+      "output": 6.6,
+      "cached_input": 0.55
     },
     {
       "provider": "AWS/Bedrock",
@@ -4449,6 +4674,13 @@
     },
     {
       "provider": "Azure/OpenAI",
+      "model": "gpt-audio-mini",
+      "variant": "",
+      "input": 0.6,
+      "output": 2.4
+    },
+    {
+      "provider": "Azure/OpenAI",
       "model": "gpt-audio-mini-2025-10-06",
       "variant": "",
       "input": 0.6,
@@ -4513,6 +4745,14 @@
       "input": 4,
       "output": 16,
       "cached_input": 4
+    },
+    {
+      "provider": "Azure/OpenAI",
+      "model": "gpt-realtime-mini",
+      "variant": "",
+      "input": 0.6,
+      "output": 2.4,
+      "cached_input": 0.06
     },
     {
       "provider": "Azure/OpenAI",
@@ -5357,29 +5597,29 @@
       "provider": "Google/Gemini",
       "model": "gemini-3.1-flash-image",
       "variant": "",
-      "input": 0.25,
-      "output": 1.5
+      "input": 0.5,
+      "output": 3
     },
     {
       "provider": "Google/Gemini",
       "model": "gemini-3.1-flash-image",
       "variant": "batches",
-      "input": 0.125,
-      "output": 0.75
-    },
-    {
-      "provider": "Google/Gemini",
-      "model": "gemini-3.1-flash-image-preview",
-      "variant": "",
       "input": 0.25,
       "output": 1.5
     },
     {
       "provider": "Google/Gemini",
       "model": "gemini-3.1-flash-image-preview",
+      "variant": "",
+      "input": 0.5,
+      "output": 3
+    },
+    {
+      "provider": "Google/Gemini",
+      "model": "gemini-3.1-flash-image-preview",
       "variant": "batches",
-      "input": 0.125,
-      "output": 0.75
+      "input": 0.25,
+      "output": 1.5
     },
     {
       "provider": "Google/Gemini",
@@ -5411,6 +5651,20 @@
       "input": 0.45,
       "output": 2.7,
       "cached_input": 0.045
+    },
+    {
+      "provider": "Google/Gemini",
+      "model": "gemini-3.1-flash-lite-image",
+      "variant": "",
+      "input": 0.25,
+      "output": 1.5
+    },
+    {
+      "provider": "Google/Gemini",
+      "model": "gemini-3.1-flash-lite-image",
+      "variant": "batches",
+      "input": 0.125,
+      "output": 0.75
     },
     {
       "provider": "Google/Gemini",
@@ -5523,6 +5777,21 @@
     {
       "provider": "Google/Gemini",
       "model": "gemini-3.5-flash",
+      "variant": "batches",
+      "input": 0.75,
+      "output": 4.5
+    },
+    {
+      "provider": "Google/Gemini",
+      "model": "gemini-3.5-flash",
+      "variant": "flex",
+      "input": 0.75,
+      "output": 4.5,
+      "cached_input": 0.08
+    },
+    {
+      "provider": "Google/Gemini",
+      "model": "gemini-3.5-flash",
       "variant": "priority",
       "input": 2.7,
       "output": 16.2,
@@ -5561,23 +5830,15 @@
     },
     {
       "provider": "Google/Gemini",
+      "model": "gemini-3.5-live-translate-preview",
+      "variant": "",
+      "input": 3.5,
+      "output": 21
+    },
+    {
+      "provider": "Google/Gemini",
       "model": "gemini-3.6-flash",
       "variant": "",
-      "input": 1.5,
-      "output": 7.5,
-      "cached_input": 0.15
-    },
-    {
-      "provider": "Google/Gemini",
-      "model": "gemini-3.6-flash",
-      "variant": "batches",
-      "input": 0.75,
-      "output": 3.75
-    },
-    {
-      "provider": "Google/Gemini",
-      "model": "gemini-3.6-flash",
-      "variant": "flex",
       "input": 0.75,
       "output": 3.75,
       "cached_input": 0.075
@@ -5585,10 +5846,25 @@
     {
       "provider": "Google/Gemini",
       "model": "gemini-3.6-flash",
+      "variant": "batches",
+      "input": 0.375,
+      "output": 1.875
+    },
+    {
+      "provider": "Google/Gemini",
+      "model": "gemini-3.6-flash",
+      "variant": "flex",
+      "input": 0.375,
+      "output": 1.875,
+      "cached_input": 0.0375
+    },
+    {
+      "provider": "Google/Gemini",
+      "model": "gemini-3.6-flash",
       "variant": "priority",
-      "input": 2.7,
-      "output": 13.5,
-      "cached_input": 0.27
+      "input": 1.35,
+      "output": 6.75,
+      "cached_input": 0.135
     },
     {
       "provider": "Google/Gemini",
@@ -6011,6 +6287,21 @@
     },
     {
       "provider": "Google/Vertex",
+      "model": "gemini-3.1-flash-lite-image",
+      "variant": "",
+      "input": 0.25,
+      "output": 1.5,
+      "cached_input": 0.025
+    },
+    {
+      "provider": "Google/Vertex",
+      "model": "gemini-3.1-flash-lite-image",
+      "variant": "batches",
+      "input": 0.125,
+      "output": 0.75
+    },
+    {
+      "provider": "Google/Vertex",
       "model": "gemini-3.1-flash-lite-preview",
       "variant": "",
       "input": 0.25,
@@ -6090,6 +6381,21 @@
     {
       "provider": "Google/Vertex",
       "model": "gemini-3.5-flash",
+      "variant": "batches",
+      "input": 0.75,
+      "output": 4.5
+    },
+    {
+      "provider": "Google/Vertex",
+      "model": "gemini-3.5-flash",
+      "variant": "flex",
+      "input": 0.75,
+      "output": 4.5,
+      "cached_input": 0.075
+    },
+    {
+      "provider": "Google/Vertex",
+      "model": "gemini-3.5-flash",
       "variant": "priority",
       "input": 2.7,
       "output": 16.2,
@@ -6130,21 +6436,6 @@
       "provider": "Google/Vertex",
       "model": "gemini-3.6-flash",
       "variant": "",
-      "input": 1.5,
-      "output": 7.5,
-      "cached_input": 0.15
-    },
-    {
-      "provider": "Google/Vertex",
-      "model": "gemini-3.6-flash",
-      "variant": "batches",
-      "input": 0.75,
-      "output": 3.75
-    },
-    {
-      "provider": "Google/Vertex",
-      "model": "gemini-3.6-flash",
-      "variant": "flex",
       "input": 0.75,
       "output": 3.75,
       "cached_input": 0.075
@@ -6152,10 +6443,25 @@
     {
       "provider": "Google/Vertex",
       "model": "gemini-3.6-flash",
+      "variant": "batches",
+      "input": 0.375,
+      "output": 1.875
+    },
+    {
+      "provider": "Google/Vertex",
+      "model": "gemini-3.6-flash",
+      "variant": "flex",
+      "input": 0.375,
+      "output": 1.875,
+      "cached_input": 0.0375
+    },
+    {
+      "provider": "Google/Vertex",
+      "model": "gemini-3.6-flash",
       "variant": "priority",
-      "input": 2.7,
-      "output": 13.5,
-      "cached_input": 0.27
+      "input": 1.35,
+      "output": 6.75,
+      "cached_input": 0.135
     },
     {
       "provider": "Google/Vertex",
@@ -6305,6 +6611,21 @@
       "input": 0.45,
       "output": 2.7,
       "cached_input": 0.045
+    },
+    {
+      "provider": "Google/Vertex",
+      "model": "vertex_ai/gemini-3.1-flash-lite-image",
+      "variant": "",
+      "input": 0.25,
+      "output": 1.5,
+      "cached_input": 0.025
+    },
+    {
+      "provider": "Google/Vertex",
+      "model": "vertex_ai/gemini-3.1-flash-lite-image",
+      "variant": "batches",
+      "input": 0.125,
+      "output": 0.75
     },
     {
       "provider": "Google/Vertex",
@@ -6477,8 +6798,8 @@
       "provider": "Mistral",
       "model": "codestral-latest",
       "variant": "",
-      "input": 1,
-      "output": 3
+      "input": 0.3,
+      "output": 0.9
     },
     {
       "provider": "Mistral",
@@ -6535,6 +6856,14 @@
       "variant": "",
       "input": 0.1,
       "output": 0.3
+    },
+    {
+      "provider": "Mistral",
+      "model": "glm-5-2",
+      "variant": "",
+      "input": 1.4,
+      "output": 4.4,
+      "cached_input": 0.14
     },
     {
       "provider": "Mistral",
@@ -6756,8 +7085,8 @@
       "provider": "Mistral",
       "model": "mistral-small-latest",
       "variant": "",
-      "input": 0.06,
-      "output": 0.18
+      "input": 0.15,
+      "output": 0.6
     },
     {
       "provider": "Mistral",
@@ -6830,6 +7159,22 @@
       "output": 6
     },
     {
+      "provider": "Mistral",
+      "model": "zai-glm-5-2",
+      "variant": "",
+      "input": 1.4,
+      "output": 4.4,
+      "cached_input": 0.14
+    },
+    {
+      "provider": "OpenAI",
+      "model": "chat-latest",
+      "variant": "",
+      "input": 5,
+      "output": 30,
+      "cached_input": 0.5
+    },
+    {
       "provider": "OpenAI",
       "model": "chatgpt-4o-latest",
       "variant": "",
@@ -6850,6 +7195,38 @@
       "input": 1.5,
       "output": 6,
       "cached_input": 0.375
+    },
+    {
+      "provider": "OpenAI",
+      "model": "daybreak-blue-latest",
+      "variant": "",
+      "input": 4,
+      "output": 20,
+      "cached_input": 0.4
+    },
+    {
+      "provider": "OpenAI",
+      "model": "daybreak-blue-latest",
+      "variant": "above_272k_tokens",
+      "input": 8,
+      "output": 30,
+      "cached_input": 0.8
+    },
+    {
+      "provider": "OpenAI",
+      "model": "daybreak-red-latest",
+      "variant": "",
+      "input": 12.5,
+      "output": 75,
+      "cached_input": 1.25
+    },
+    {
+      "provider": "OpenAI",
+      "model": "daybreak-red-latest",
+      "variant": "above_272k_tokens",
+      "input": 25,
+      "output": 112.5,
+      "cached_input": 2.5
     },
     {
       "provider": "OpenAI",
@@ -8333,48 +8710,64 @@
       "provider": "OpenAI",
       "model": "gpt-5.6",
       "variant": "",
-      "input": 5,
-      "output": 30,
-      "cached_input": 0.5
+      "input": 4,
+      "output": 20,
+      "cached_input": 0.4
     },
     {
       "provider": "OpenAI",
       "model": "gpt-5.6",
       "variant": "above_272k_tokens",
-      "input": 10,
-      "output": 45,
-      "cached_input": 1
+      "input": 8,
+      "output": 30,
+      "cached_input": 0.8
     },
     {
       "provider": "OpenAI",
       "model": "gpt-5.6",
       "variant": "above_272k_tokens_flex",
-      "input": 5,
-      "output": 22.5,
-      "cached_input": 0.5
+      "input": 4,
+      "output": 15,
+      "cached_input": 0.4
     },
     {
       "provider": "OpenAI",
       "model": "gpt-5.6",
       "variant": "batches",
-      "input": 2.5,
-      "output": 15
+      "input": 2,
+      "output": 10
     },
     {
       "provider": "OpenAI",
       "model": "gpt-5.6",
       "variant": "flex",
-      "input": 2.5,
-      "output": 15,
-      "cached_input": 0.25
+      "input": 2,
+      "output": 10,
+      "cached_input": 0.2
     },
     {
       "provider": "OpenAI",
       "model": "gpt-5.6",
       "variant": "priority",
-      "input": 10,
-      "output": 60,
-      "cached_input": 1
+      "input": 8,
+      "output": 40,
+      "cached_input": 0.8
+    },
+    {
+      "provider": "OpenAI",
+      "model": "gpt-5.6-cyber",
+      "variant": "",
+      "input": 12.5,
+      "output": 75,
+      "cached_input": 1.25
+    },
+    {
+      "provider": "OpenAI",
+      "model": "gpt-5.6-cyber",
+      "variant": "above_272k_tokens",
+      "input": 25,
+      "output": 112.5,
+      "cached_input": 2.5
     },
     {
       "provider": "OpenAI",
@@ -8427,48 +8820,48 @@
       "provider": "OpenAI",
       "model": "gpt-5.6-sol",
       "variant": "",
-      "input": 5,
-      "output": 30,
-      "cached_input": 0.5
+      "input": 4,
+      "output": 20,
+      "cached_input": 0.4
     },
     {
       "provider": "OpenAI",
       "model": "gpt-5.6-sol",
       "variant": "above_272k_tokens",
-      "input": 10,
-      "output": 45,
-      "cached_input": 1
+      "input": 8,
+      "output": 30,
+      "cached_input": 0.8
     },
     {
       "provider": "OpenAI",
       "model": "gpt-5.6-sol",
       "variant": "above_272k_tokens_flex",
-      "input": 5,
-      "output": 22.5,
-      "cached_input": 0.5
+      "input": 4,
+      "output": 15,
+      "cached_input": 0.4
     },
     {
       "provider": "OpenAI",
       "model": "gpt-5.6-sol",
       "variant": "batches",
-      "input": 2.5,
-      "output": 15
+      "input": 2,
+      "output": 10
     },
     {
       "provider": "OpenAI",
       "model": "gpt-5.6-sol",
       "variant": "flex",
-      "input": 2.5,
-      "output": 15,
-      "cached_input": 0.25
+      "input": 2,
+      "output": 10,
+      "cached_input": 0.2
     },
     {
       "provider": "OpenAI",
       "model": "gpt-5.6-sol",
       "variant": "priority",
-      "input": 10,
-      "output": 60,
-      "cached_input": 1
+      "input": 8,
+      "output": 40,
+      "cached_input": 0.8
     },
     {
       "provider": "OpenAI",
@@ -9040,6 +9433,14 @@
     },
     {
       "provider": "OpenRouter",
+      "model": "anthropic/claude-opus-5",
+      "variant": "",
+      "input": 5,
+      "output": 25,
+      "cached_input": 0.5
+    },
+    {
+      "provider": "OpenRouter",
       "model": "anthropic/claude-sonnet-4",
       "variant": "",
       "input": 3,
@@ -9171,6 +9572,32 @@
       "model": "deepseek/deepseek-v3.2-exp",
       "variant": "cache_hit",
       "input": 0.02
+    },
+    {
+      "provider": "OpenRouter",
+      "model": "deepseek/deepseek-v4-pro",
+      "variant": "",
+      "input": 1.32,
+      "output": 3.96
+    },
+    {
+      "provider": "OpenRouter",
+      "model": "deepseek/deepseek-v4-pro",
+      "variant": "cache_hit",
+      "input": 0.044
+    },
+    {
+      "provider": "OpenRouter",
+      "model": "deepseek/deepseek-v4-pro-0813",
+      "variant": "",
+      "input": 1.32,
+      "output": 3.96
+    },
+    {
+      "provider": "OpenRouter",
+      "model": "deepseek/deepseek-v4-pro-0813",
+      "variant": "cache_hit",
+      "input": 0.044
     },
     {
       "provider": "OpenRouter",

--- a/chatlas/types/anthropic/_client.py
+++ b/chatlas/types/anthropic/_client.py
@@ -18,7 +18,7 @@ import anthropic
 import anthropic._response
 import anthropic.lib.credentials._cache
 import anthropic.lib.credentials._types
-import httpx
+import httpx2
 
 
 class ChatClientArgs(TypedDict, total=False):
@@ -28,12 +28,12 @@ class ChatClientArgs(TypedDict, total=False):
     config: Optional[Mapping[str, Any]]
     profile: str | None
     webhook_key: str | None
-    base_url: str | httpx.URL | None
+    base_url: str | httpx2.URL | None
     timeout: float | anthropic.Timeout | None | anthropic.NotGiven
     max_retries: int
     default_headers: Optional[Mapping[str, str]]
     default_query: Optional[Mapping[str, object]]
-    http_client: httpx.AsyncClient | None
+    http_client: httpx2.AsyncClient | None
     middleware: Optional[
         Sequence[
             Union[

--- a/chatlas/types/anthropic/_client_bedrock.py
+++ b/chatlas/types/anthropic/_client_bedrock.py
@@ -15,7 +15,7 @@ from typing import (
 
 import anthropic
 import anthropic._response
-import httpx
+import httpx2
 
 
 class ChatBedrockClientArgs(TypedDict, total=False):
@@ -25,12 +25,12 @@ class ChatBedrockClientArgs(TypedDict, total=False):
     aws_profile: str | None
     aws_session_token: str | None
     api_key: str | None
-    base_url: str | httpx.URL | None
+    base_url: str | httpx2.URL | None
     timeout: float | anthropic.Timeout | None | anthropic.NotGiven
     max_retries: int
     default_headers: Optional[Mapping[str, str]]
     default_query: Optional[Mapping[str, object]]
-    http_client: httpx.AsyncClient | None
+    http_client: httpx2.AsyncClient | None
     middleware: Optional[
         Sequence[
             Union[

--- a/chatlas/types/anthropic/_submit.py
+++ b/chatlas/types/anthropic/_submit.py
@@ -82,7 +82,6 @@ class SubmitInputArgs(TypedDict, total=False):
     system: Union[
         str, Iterable[anthropic.types.text_block_param.TextBlockParam], anthropic.Omit
     ]
-    temperature: float | anthropic.Omit
     thinking: Union[
         anthropic.types.thinking_config_enabled_param.ThinkingConfigEnabledParam,
         anthropic.types.thinking_config_disabled_param.ThinkingConfigDisabledParam,
@@ -124,8 +123,6 @@ class SubmitInputArgs(TypedDict, total=False):
         ],
         anthropic.Omit,
     ]
-    top_k: int | anthropic.Omit
-    top_p: float | anthropic.Omit
     user_profile_id: str | anthropic.Omit
     extra_headers: Optional[Mapping[str, Union[str, anthropic.Omit]]]
     extra_query: Optional[Mapping[str, object]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ dev = [
     "pandas",
     "polars",
     "openai",
-    "anthropic[bedrock]>=0.109.1",
+    "anthropic[bedrock]>=1.0.0",
     "google-genai>=1.14.0",
     "numpy>1.24.4",
     "tiktoken",
@@ -108,11 +108,11 @@ eval = [
     "inspect-ai;python_version>='3.10'"
 ]
 # Provider extras ----
-anthropic = ["anthropic>=0.109.1"]
+anthropic = ["anthropic>=1.0.0"]
 # botocore is a direct import (region/credential resolution); the `bedrock`
 # extra of anthropic adds the boto3 session its mantle SigV4 signer needs.
-bedrock = ["botocore", "anthropic[bedrock]>=0.109.1", "openai>=2.50.0"]
-bedrock-anthropic = ["anthropic[bedrock]>=0.109.1"]
+bedrock = ["botocore", "anthropic[bedrock]>=1.0.0", "openai>=2.50.0"]
+bedrock-anthropic = ["anthropic[bedrock]>=1.0.0"]
 databricks = ["databricks-sdk"]
 # Intentionally empty since these providers used to require 
 # an additional openai install, but that's now included 
@@ -123,7 +123,7 @@ ollama = []
 openai = []
 azure-openai = []
 perplexity = []
-posit = ["anthropic>=0.109.1"]
+posit = ["anthropic>=1.0.0"]
 # Version requirement avoids an install issue with recent Python versions.
 # Remove it when snowflake-ml-python can be installed without a requirement.
 snowflake = ["snowflake-ml-python<=1.9.0"]

--- a/scripts/_generate_bedrock_apis.py
+++ b/scripts/_generate_bedrock_apis.py
@@ -28,6 +28,15 @@ MESSAGES_MODELS = {
     "anthropic.claude-mythos-preview": "messages",
 }
 
+# litellm's coverage of mantle-only Responses models is incomplete/flaky, so
+# the models this feature exists to unlock are maintained by hand (AWS
+# documents them as mantle-only). litellm-derived entries are merged on top.
+RESPONSES_MODELS = {
+    "openai.gpt-5.6-luna": "responses",
+    "openai.gpt-5.6-sol": "responses",
+    "openai.gpt-5.6-terra": "responses",
+}
+
 
 def main() -> None:
     with urllib.request.urlopen(LITELLM_URL) as resp:
@@ -57,7 +66,7 @@ def main() -> None:
             "silently add Converse-servable models to it."
         )
 
-    apis = dict(MESSAGES_MODELS)
+    apis = dict(MESSAGES_MODELS) | dict(RESPONSES_MODELS)
     for provider, model, endpoints in rows:
         if provider != "bedrock_mantle":
             continue

--- a/tests/test_auto.py
+++ b/tests/test_auto.py
@@ -220,6 +220,8 @@ def test_provider_instances(monkeypatch):
     assert isinstance(chat.provider, AnthropicProvider)
 
     monkeypatch.setenv("CHATLAS_CHAT_PROVIDER_MODEL", "bedrock-anthropic")
+    # anthropic>=1.0 resolves the AWS region at client construction
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
     chat = ChatAuto()
     assert isinstance(chat, Chat)
     assert isinstance(chat.provider, AnthropicBedrockProvider)

--- a/tests/test_provider_anthropic.py
+++ b/tests/test_provider_anthropic.py
@@ -1,6 +1,7 @@
 from typing import Literal, cast
 
 import httpx
+import httpx2
 import pytest
 from anthropic.types import (
     CitationCharLocation,
@@ -913,7 +914,13 @@ def test_anthropic_image_tool(test_images_dir):
 
 
 def test_anthropic_custom_http_client():
-    ChatAnthropic(kwargs={"http_client": httpx.AsyncClient()})
+    ChatAnthropic(kwargs={"http_client": httpx2.AsyncClient()})
+
+
+def test_anthropic_legacy_httpx_client_rejected():
+    # anthropic>=1.0 only accepts httpx2 clients
+    with pytest.raises(TypeError, match="httpx2"):
+        ChatAnthropic(kwargs={"http_client": httpx.AsyncClient()})
 
 
 @pytest.mark.vcr

--- a/tests/test_provider_bedrock_mantle.py
+++ b/tests/test_provider_bedrock_mantle.py
@@ -3,6 +3,7 @@ from datetime import date
 from importlib import resources
 
 import httpx
+import httpx2
 import pytest
 from chatlas import Chat, ChatBedrock
 from chatlas._provider_bedrock import (
@@ -332,7 +333,8 @@ class TestNativeSdkClients:
         assert chat.provider._client._use_sigv4 is True
 
     def test_messages_provider_accepts_a_custom_http_client(self):
-        http_client = httpx.Client()
+        # The messages API is served by the anthropic SDK, which requires httpx2
+        http_client = httpx2.Client()
         chat = ChatBedrock(
             model="anthropic.claude-haiku-4-5",
             api="messages",

--- a/tests/test_provider_posit.py
+++ b/tests/test_provider_posit.py
@@ -4,7 +4,6 @@ import time
 from pathlib import Path
 from typing import Any, Optional
 
-import httpx
 import httpx2
 import pytest
 import requests
@@ -13,16 +12,13 @@ from chatlas._provider_posit import (
     OAUTH_SCOPE,
     ChatPosit,
     PositAnthropicProvider,
-    PositAuth,
     PositCredentials,
     PositHttpx2Auth,
     PositOpenAIProvider,
     _posit_error_message,
     list_models_posit,
-    make_posit_anthropic_error_hook,
-    make_posit_anthropic_error_hook_async,
-    make_posit_openai_error_hook,
-    make_posit_openai_error_hook_async,
+    make_posit_error_hook,
+    make_posit_error_hook_async,
 )
 from openai import AsyncOpenAI, OpenAI, OpenAIError
 
@@ -261,46 +257,21 @@ def test_posit_error_message_returns_none_for_unrecognized_errors():
     assert _posit_error_message(403, {"error_type": "something_else"}) is None
 
 
-def test_posit_auth_sets_bearer_token_and_strips_api_key():
-    auth = PositAuth(lambda: "test-token")
-    request = httpx.Request("GET", "https://gateway.posit.ai/anthropic/v1/messages")
-    request.headers["x-api-key"] = "not-used"
-
-    flow = auth.sync_auth_flow(request)
-    sent_request = next(flow)
-
-    assert sent_request.headers["Authorization"] == "Bearer test-token"
-    assert "x-api-key" not in sent_request.headers
-
-
-def test_posit_auth_async_sets_bearer_token():
-    async def run() -> httpx.Request:
-        auth = PositAuth(lambda: "test-token")
-        request = httpx.Request(
-            "GET", "https://gateway.posit.ai/openai/v1/chat/completions"
-        )
-        flow = auth.async_auth_flow(request)
-        return await flow.__anext__()
-
-    sent_request = asyncio.run(run())
-    assert sent_request.headers["Authorization"] == "Bearer test-token"
-
-
 def test_anthropic_error_hook_propagates_through_client_send():
     from anthropic import Anthropic, AnthropicError
 
-    def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(
             403, json={"error_type": "prism_account_not_found"}, request=request
         )
 
     client = Anthropic(
         api_key="not-used",
         base_url="https://gateway.posit.ai/anthropic/v1",
-        http_client=httpx.Client(
-            auth=PositAuth(lambda: "test-token"),
-            transport=httpx.MockTransport(handler),
-            event_hooks={"response": [make_posit_anthropic_error_hook(AnthropicError)]},
+        http_client=httpx2.Client(
+            auth=PositHttpx2Auth(lambda: "test-token"),
+            transport=httpx2.MockTransport(handler),
+            event_hooks={"response": [make_posit_error_hook(AnthropicError)]},
         ),
     )
 
@@ -316,19 +287,19 @@ def test_anthropic_error_hook_propagates_through_client_send():
 async def test_anthropic_error_hook_propagates_through_async_client_send():
     from anthropic import AnthropicError, AsyncAnthropic
 
-    def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(
             403, json={"error_type": "prism_account_not_found"}, request=request
         )
 
     client = AsyncAnthropic(
         api_key="not-used",
         base_url="https://gateway.posit.ai/anthropic/v1",
-        http_client=httpx.AsyncClient(
-            auth=PositAuth(lambda: "test-token"),
-            transport=httpx.MockTransport(handler),
+        http_client=httpx2.AsyncClient(
+            auth=PositHttpx2Auth(lambda: "test-token"),
+            transport=httpx2.MockTransport(handler),
             event_hooks={
-                "response": [make_posit_anthropic_error_hook_async(AnthropicError)]
+                "response": [make_posit_error_hook_async(AnthropicError)]
             },
         ),
     )
@@ -379,7 +350,7 @@ def test_openai_httpx2_error_hook_propagates_through_client_send():
         http_client=httpx2.Client(
             auth=PositHttpx2Auth(lambda: "test-token"),
             transport=httpx2.MockTransport(handler),
-            event_hooks={"response": [make_posit_openai_error_hook(OpenAIError)]},
+            event_hooks={"response": [make_posit_error_hook(OpenAIError)]},
         ),
     )
 
@@ -403,7 +374,7 @@ async def test_openai_httpx2_error_hook_propagates_through_async_client_send():
         http_client=httpx2.AsyncClient(
             auth=PositHttpx2Auth(lambda: "test-token"),
             transport=httpx2.MockTransport(handler),
-            event_hooks={"response": [make_posit_openai_error_hook_async(OpenAIError)]},
+            event_hooks={"response": [make_posit_error_hook_async(OpenAIError)]},
         ),
     )
 
@@ -419,18 +390,18 @@ async def test_openai_httpx2_error_hook_propagates_through_async_client_send():
 def test_unrecognized_gateway_error_passes_through_unchanged():
     from anthropic import Anthropic, APIStatusError
 
-    def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(500, json={"error": {"message": "boom"}}, request=request)
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(500, json={"error": {"message": "boom"}}, request=request)
 
     from anthropic import AnthropicError
 
     client = Anthropic(
         api_key="not-used",
         base_url="https://gateway.posit.ai/anthropic/v1",
-        http_client=httpx.Client(
-            auth=PositAuth(lambda: "test-token"),
-            transport=httpx.MockTransport(handler),
-            event_hooks={"response": [make_posit_anthropic_error_hook(AnthropicError)]},
+        http_client=httpx2.Client(
+            auth=PositHttpx2Auth(lambda: "test-token"),
+            transport=httpx2.MockTransport(handler),
+            event_hooks={"response": [make_posit_error_hook(AnthropicError)]},
         ),
     )
 

--- a/tests/test_set_model_params.py
+++ b/tests/test_set_model_params.py
@@ -152,12 +152,12 @@ def test_translate_model_params_anthropic():
         "stop_sequences": ["STOP"],
     }
 
-    result = provider.translate_model_params(params)
+    with pytest.warns(DeprecationWarning, match="no longer have an effect"):
+        result = provider.translate_model_params(params)
 
     expected = {
-        "temperature": 0.7,
-        "top_p": 0.95,
-        "top_k": 50,
+        # anthropic>=1.0 dropped sampling parameters; forwarded via extra_body
+        "extra_body": {"temperature": 0.7, "top_p": 0.95, "top_k": 50},
         "max_tokens": 200,
         "stop_sequences": ["STOP"],
     }
@@ -500,10 +500,13 @@ def test_anthropic_model_params_integration():
     )
 
     # Test that provider.translate_model_params converts them correctly
-    provider_args = chat.provider.translate_model_params(chat._standard_model_params)
+    with pytest.warns(DeprecationWarning, match="no longer have an effect"):
+        provider_args = chat.provider.translate_model_params(
+            chat._standard_model_params
+        )
 
-    assert provider_args["temperature"] == 0.4
-    assert provider_args["top_k"] == 20
+    # anthropic>=1.0 dropped sampling parameters; forwarded via extra_body
+    assert provider_args["extra_body"] == {"temperature": 0.4, "top_k": 20}
     assert provider_args["max_tokens"] == 75
     assert provider_args["stop_sequences"] == ["END", "STOP"]
 


### PR DESCRIPTION
## Summary

- Bumps the anthropic floor to `>=1.0.0` and adapts to its switch from `httpx` to `httpx2` for custom HTTP clients:
  - `PositAnthropicProvider` now builds `httpx2` clients with `PositHttpx2Auth` and the (now shared) `make_posit_error_hook(_async)` hooks, mirroring `PositOpenAIProvider`. The httpx-based `PositAuth` and anthropic-specific hooks are removed.
  - Tests that passed `httpx` clients into Anthropic-backed providers now use `httpx2`; a new test documents that legacy `httpx` clients are rejected with a clear `TypeError` from the SDK.
- Includes the automated provider types & pricing refresh (regenerated against anthropic 1.0 / latest litellm data).
- `scripts/_generate_bedrock_apis.py` now keeps a hand-maintained set of mantle-only Responses models (`openai.gpt-5.6-*`): litellm stopped reporting them, and their removal from `bedrock_apis.json` broke bedrock-mantle dispatch.

## Test plan

- Full local suite passes with `anthropic==1.0.0` (1249 passed).
- Regenerated anthropic types are stable (no drift) against the installed SDK.