### PR TITLE
fix(ollama): distinguish remote endpoint failures and validate supplied models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -->
 
 
+## [Unreleased]
+
+### Bug fixes
+
+* `ChatOllama()` now distinguishes a remote endpoint it can't reach from a genuinely missing local install, and validates a supplied `model` against `/api/tags` at construction time instead of only when `model` is omitted. (#393)
+
 ## [0.22.0] - 2026-08-25
 
 ### Changes

--- a/chatlas/_provider_ollama.py
+++ b/chatlas/_provider_ollama.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 import urllib.request
 from typing import TYPE_CHECKING, Optional
+from urllib.parse import urlparse
 
 import orjson
 
@@ -66,7 +67,7 @@ def ChatOllama(
     Parameters
     ----------
     model
-        The model to use for the chat. If `None`, a list of locally installed
+        The model to use for the chat. If `None`, a list of available
         models will be printed.
     system_prompt
         A system prompt to set the behavior of the assistant.
@@ -95,15 +96,29 @@ def ChatOllama(
     """
 
     base_url = re.sub("/+$", "", base_url)
+    is_local = is_local_ollama(base_url)
 
     if not has_ollama(base_url):
-        raise RuntimeError("Can't find locally running ollama.")
+        if is_local:
+            raise RuntimeError("Can't find locally running ollama.")
+        raise RuntimeError(f"Can't connect to ollama at {base_url}.")
+
+    model_ids = [m["id"] for m in ollama_model_info(base_url)]
 
     if model is None:
-        models = ollama_model_info(base_url)
-        model_ids = [m["id"] for m in models]
         raise ValueError(
-            f"Must specify model. Locally installed models: {', '.join(model_ids)}"
+            f"Must specify model. Available models: {', '.join(model_ids)}"
+        )
+    elif model not in model_ids:
+        if is_local:
+            raise ValueError(
+                f"Model {model!r} is not installed locally. "
+                f"Run `ollama pull {model}` to install it. "
+                f"Available models: {', '.join(model_ids)}"
+            )
+        raise ValueError(
+            f"Model {model!r} is not available on {base_url}. "
+            f"Available models: {', '.join(model_ids)}"
         )
     if isinstance(seed, MISSING_TYPE):
         seed = 1014 if is_testing() else None
@@ -168,3 +183,8 @@ def has_ollama(base_url):
         return True
     except Exception:
         return False
+
+
+def is_local_ollama(base_url: str) -> bool:
+    host = urlparse(base_url).hostname
+    return host in ("localhost", "127.0.0.1", "::1")

--- a/chatlas/_provider_ollama.py
+++ b/chatlas/_provider_ollama.py
@@ -109,7 +109,7 @@ def ChatOllama(
         raise ValueError(
             f"Must specify model. Available models: {', '.join(model_ids)}"
         )
-    elif model not in model_ids:
+    elif re.sub(":latest$", "", model) not in model_ids:
         if is_local:
             raise ValueError(
                 f"Model {model!r} is not installed locally. "

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -51,12 +51,20 @@ def test_maybe_write_roundtrip(tmp_path):
 
 def test_files_accessor_type(monkeypatch):
     monkeypatch.setattr("chatlas._provider_ollama.has_ollama", lambda base_url: True)
+    monkeypatch.setattr(
+        "chatlas._provider_ollama.ollama_model_info",
+        lambda base_url: [{"id": "llama3.1", "created_at": "x", "size": 1}],
+    )
     chat = ChatOllama(model="llama3.1")
     assert isinstance(chat.files, FileManager)
 
 
 def test_unsupported_provider_raises(monkeypatch):
     monkeypatch.setattr("chatlas._provider_ollama.has_ollama", lambda base_url: True)
+    monkeypatch.setattr(
+        "chatlas._provider_ollama.ollama_model_info",
+        lambda base_url: [{"id": "llama3.1", "created_at": "x", "size": 1}],
+    )
     chat = ChatOllama(model="llama3.1")
     with pytest.raises(NotImplementedError, match="file management"):
         chat.files.upload("some.pdf")

--- a/tests/test_provider_ollama.py
+++ b/tests/test_provider_ollama.py
@@ -1,9 +1,20 @@
+import pytest
+
 from chatlas import ChatOllama
+from chatlas._provider_ollama import is_local_ollama
+
+_MODELS = [
+    {"id": "qwen3:4b", "created_at": "x", "size": 1},
+    {"id": "llama3.2", "created_at": "x", "size": 1},
+]
 
 
 def test_ollama_reasoning_effort(monkeypatch):
     """reasoning_effort is passed through as a request body field."""
     monkeypatch.setattr("chatlas._provider_ollama.has_ollama", lambda base_url: True)
+    monkeypatch.setattr(
+        "chatlas._provider_ollama.ollama_model_info", lambda base_url: _MODELS
+    )
 
     chat = ChatOllama(model="qwen3:4b", reasoning_effort="none")
     assert chat.kwargs_chat == {"reasoning_effort": "none"}
@@ -11,6 +22,80 @@ def test_ollama_reasoning_effort(monkeypatch):
 
 def test_ollama_no_reasoning_effort_by_default(monkeypatch):
     monkeypatch.setattr("chatlas._provider_ollama.has_ollama", lambda base_url: True)
+    monkeypatch.setattr(
+        "chatlas._provider_ollama.ollama_model_info", lambda base_url: _MODELS
+    )
 
     chat = ChatOllama(model="llama3.2")
     assert chat.kwargs_chat == {}
+
+
+@pytest.mark.parametrize(
+    "base_url,expected",
+    [
+        ("http://localhost:11434", True),
+        ("http://127.0.0.1:11434", True),
+        ("http://[::1]:11434", True),
+        ("http://remote-host.example.com:11434", False),
+        ("https://ollama.internal.example.org", False),
+    ],
+)
+def test_is_local_ollama(base_url, expected):
+    assert is_local_ollama(base_url) == expected
+
+
+def test_ollama_local_connection_failure(monkeypatch):
+    """A local endpoint that can't be reached keeps the local-install guidance."""
+    monkeypatch.setattr("chatlas._provider_ollama.has_ollama", lambda base_url: False)
+
+    with pytest.raises(RuntimeError, match="Can't find locally running ollama."):
+        ChatOllama(model="llama3.2", base_url="http://localhost:11434")
+
+
+def test_ollama_remote_connection_failure(monkeypatch):
+    """A remote endpoint that can't be reached names the endpoint, not 'locally'."""
+    monkeypatch.setattr("chatlas._provider_ollama.has_ollama", lambda base_url: False)
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"Can't connect to ollama at http://remote-host\.example\.com:11434\.",
+    ):
+        ChatOllama(model="llama3.2", base_url="http://remote-host.example.com:11434")
+
+
+def test_ollama_model_none_lists_available_models(monkeypatch):
+    monkeypatch.setattr("chatlas._provider_ollama.has_ollama", lambda base_url: True)
+    monkeypatch.setattr(
+        "chatlas._provider_ollama.ollama_model_info", lambda base_url: _MODELS
+    )
+
+    with pytest.raises(
+        ValueError, match="Must specify model. Available models: qwen3:4b, llama3.2"
+    ):
+        ChatOllama(model=None, base_url="http://localhost:11434")
+
+
+def test_ollama_unavailable_model_local_guidance(monkeypatch):
+    monkeypatch.setattr("chatlas._provider_ollama.has_ollama", lambda base_url: True)
+    monkeypatch.setattr(
+        "chatlas._provider_ollama.ollama_model_info", lambda base_url: _MODELS
+    )
+
+    with pytest.raises(ValueError, match="not installed locally"):
+        ChatOllama(model="not-a-real-model", base_url="http://localhost:11434")
+
+
+def test_ollama_unavailable_model_remote_guidance(monkeypatch):
+    monkeypatch.setattr("chatlas._provider_ollama.has_ollama", lambda base_url: True)
+    monkeypatch.setattr(
+        "chatlas._provider_ollama.ollama_model_info", lambda base_url: _MODELS
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"not available on http://remote-host\.example\.com:11434",
+    ):
+        ChatOllama(
+            model="not-a-real-model",
+            base_url="http://remote-host.example.com:11434",
+        )

--- a/tests/test_provider_ollama.py
+++ b/tests/test_provider_ollama.py
@@ -99,3 +99,14 @@ def test_ollama_unavailable_model_remote_guidance(monkeypatch):
             model="not-a-real-model",
             base_url="http://remote-host.example.com:11434",
         )
+
+
+def test_ollama_model_with_explicit_latest_tag_accepted(monkeypatch):
+    """ollama_model_info() strips ':latest', so a model requested with the
+    tag users copy straight from `ollama list` must still match."""
+    monkeypatch.setattr("chatlas._provider_ollama.has_ollama", lambda base_url: True)
+    monkeypatch.setattr(
+        "chatlas._provider_ollama.ollama_model_info", lambda base_url: _MODELS
+    )
+
+    ChatOllama(model="llama3.2:latest", base_url="http://localhost:11434")

--- a/tests/test_tools_builtin.py
+++ b/tests/test_tools_builtin.py
@@ -414,6 +414,10 @@ class TestUnsupportedProviders:
         monkeypatch.setattr(
             "chatlas._provider_ollama.has_ollama", lambda base_url: True
         )
+        monkeypatch.setattr(
+            "chatlas._provider_ollama.ollama_model_info",
+            lambda base_url: [{"id": "llama3.2", "created_at": "x", "size": 1}],
+        )
         chat = ChatOllama(model="llama3.2")
         with pytest.raises(ValueError, match="`web_search`.*not supported by Ollama"):
             chat.register_tool(tool_web_search())


### PR DESCRIPTION
## Root cause

`ChatOllama()` unconditionally raised `Can't find locally running ollama.` when
the endpoint check failed, even when `base_url` pointed at a remote server, and
it only validated `model` against the tags endpoint in the `model is None`
branch. A supplied model that did not exist passed through unchecked, and the
failure only surfaced later as an opaque provider error.

## Fix

Adds `is_local_ollama()`, classifying `localhost`/`127.0.0.1`/`::1` (after
normalizing `base_url`) as local, mirroring the approach ellmer already ships
for this (tidyverse/ellmer#1073). `ChatOllama()` now:

- names the endpoint in the connection-failure message for a remote
  `base_url`, keeping the local-install message only for local endpoints;
- fetches the available model IDs from `/api/tags` unconditionally, so a
  supplied-but-unavailable model raises immediately with local- or
  remote-specific guidance, instead of only when `model` is omitted.

Model-capability validation and tool-calling behavior are unchanged, per the
issue's stated non-goals.

## Verification

- New regression tests in `tests/test_provider_ollama.py` cover
  `is_local_ollama()` (localhost/127.0.0.1/::1/remote), the local vs. remote
  connection-failure message, and the local vs. remote unavailable-model
  message; confirmed they fail on unmodified `main` (missing `is_local_ollama`)
  and pass on this branch.
- Updated the three existing tests across `tests/test_provider_ollama.py`,
  `tests/test_files.py`, and `tests/test_tools_builtin.py` that construct
  `ChatOllama()` with only `has_ollama` mocked, since model IDs are now always
  fetched; all 15 ollama-related tests pass on Python 3.10 and 3.14 in Docker.
- `ruff check chatlas` and `ruff format --check` on the changed files, and
  `pyright` on the changed files, all clean.
- Not verified: behavior against a real Ollama server (local or remote); the
  new tests mock `has_ollama`/`ollama_model_info` per the issue's own ask for
  no live Ollama dependency.

Fixes #393
