### PR TITLE
Fix GoogleProvider crash replaying ContentThinking on later turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* `ChatGoogle()` no longer raises `ValueError: Unknown content type: ContentThinking` on the second and later turns when `reasoning` is enabled; thinking content is now replayed to the model as thought parts, and the `thought_signature` on thought parts is preserved (previously only tool-call parts kept it). (#403)
 * `ChatOllama()` now distinguishes a remote endpoint it can't reach from a genuinely missing local install, and validates a supplied `model` against `/api/tags` at construction time instead of only when `model` is omitted. (#393)
 
 ## [0.22.0] - 2026-08-25

--- a/chatlas/_provider_google.py
+++ b/chatlas/_provider_google.py
@@ -626,6 +626,14 @@ class GoogleProvider(
 
         if isinstance(content, ContentText):
             return Part.from_text(text=content.text)
+        elif isinstance(content, ContentThinking):
+            # Replay the thought (with its signature, if any) so multi-turn
+            # conversations with thinking models don't 400 (#403).
+            return Part(
+                text=content.thinking,
+                thought=True,
+                thought_signature=(content.extra or {}).get("thought_signature"),  # type: ignore
+            )
         elif isinstance(content, ContentJson):
             text = orjson.dumps(content.value).decode("utf-8")
             return Part.from_text(text=text)
@@ -745,7 +753,13 @@ class GoogleProvider(
                 if has_data_model:
                     contents.append(ContentJson(value=orjson.loads(text)))
                 elif part.get("thought"):
-                    contents.append(ContentThinking(thinking=text))
+                    thinking_extra: dict[str, object] = {}
+                    thought_signature = part.get("thought_signature")
+                    if thought_signature is not None:
+                        thinking_extra["thought_signature"] = thought_signature
+                    contents.append(
+                        ContentThinking(thinking=text, extra=thinking_extra)
+                    )
                 else:
                     contents.append(ContentText(text=text))
             function_call = part.get("function_call")

--- a/tests/test_provider_google.py
+++ b/tests/test_provider_google.py
@@ -627,6 +627,56 @@ def test_google_thought_signature_roundtrip():
     assert part.thought_signature == fake_signature
 
 
+def test_google_thinking_roundtrip():
+    """ContentThinking must replay as a thought Part on later turns (#403)."""
+    from chatlas._content import ContentThinking
+    from chatlas._provider_google import GoogleProvider
+
+    provider = GoogleProvider(
+        model="gemini-2.5-flash-preview-04-17",
+        api_key="dummy",
+        kwargs=None,
+    )
+
+    fake_signature = b"abc123signature"
+    message = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {
+                            "text": "Let me think...",
+                            "thought": True,
+                            "thought_signature": fake_signature,
+                        },
+                        {"text": "The answer is 42."},
+                    ]
+                },
+                "finish_reason": "STOP",
+            }
+        ],
+        "usage_metadata": {
+            "prompt_token_count": 10,
+            "candidates_token_count": 5,
+        },
+    }
+
+    turn = provider._as_turn(message, has_data_model=False)
+    assert len(turn.contents) == 2
+    thinking = turn.contents[0]
+    assert isinstance(thinking, ContentThinking)
+    assert thinking.thinking == "Let me think..."
+    assert thinking.extra.get("thought_signature") == fake_signature
+
+    # Replaying the turn's contents (as happens on the next chat turn)
+    # must not raise "Unknown content type" and must preserve the signature.
+    parts = [provider._as_part_type(c) for c in turn.contents]
+    assert parts[0].text == "Let me think..."
+    assert parts[0].thought is True
+    assert parts[0].thought_signature == fake_signature
+    assert parts[1].text == "The answer is 42."
+
+
 def test_normalize_retrieval_status():
     from chatlas._provider_google import normalize_retrieval_status
 


### PR DESCRIPTION
Fixes #403

## Summary
With `reasoning` enabled, assistant turns store the model's thoughts as `ContentThinking`, but `GoogleProvider._as_part_type()` had no case for it, so replaying the conversation history on the 2nd turn raised `ValueError: Unknown content type: ContentThinking`. Thoughts are now replayed as `Part(text=..., thought=True, thought_signature=...)` (matching ellmer), and `_as_turn()` now captures the `thought_signature` from thought parts into `ContentThinking.extra` so it round-trips — previously only tool-call parts kept their signature, which Gemini 3 thinking models may require.

## Verification
New `test_google_thinking_roundtrip` unit test covers parsing a thought part with a signature and replaying the full turn contents through `_as_part_type()`. All 55 Google provider tests and pyright pass. A live multi-turn run of the issue's reprex against a thinking model (e.g. `gemini-3-flash-preview` with `reasoning="medium"`) is a worthwhile final check.