### PR TITLE
Forward Shiny viewer session token to Connect's LLM gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### New features
+
+* When running on Posit Connect, chatlas now forwards the Shiny viewer's session token to Connect's LLM gateway (as a `Posit-Connect-User-Session-Token` header) so gateway usage can be attributed to the viewer. This happens automatically for Shiny content and only affects requests to the gateway.
+
 ### Bug fixes
 
 * `ChatGoogle()` no longer raises `ValueError: Unknown content type: ContentThinking` on the second and later turns when `reasoning` is enabled; thinking content is now replayed to the model as thought parts, and the `thought_signature` on thought parts is preserved (previously only tool-call parts kept it). (#403)

--- a/chatlas/_connect.py
+++ b/chatlas/_connect.py
@@ -1,0 +1,73 @@
+"""Forward the Shiny viewer's session token to Posit Connect's LLM gateway.
+
+When chat traffic on Posit Connect goes through Connect's LLM gateway, the
+current viewer's session token is forwarded as a
+``Posit-Connect-User-Session-Token`` header so Connect can attribute the call
+to the viewer. The header is only added when running on Connect, and only sent
+to Connect's own gateway URL.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+from urllib.parse import urlparse
+
+CONNECT_VIEWER_TOKEN_HEADER = "Posit-Connect-User-Session-Token"
+
+
+def connect_viewer_headers(url: str) -> dict[str, str]:
+    """
+    Headers attributing a Connect gateway request to the current Shiny viewer.
+
+    Parameters
+    ----------
+    url
+        The URL the request will be sent to (e.g. the provider's base URL).
+
+    Returns
+    -------
+    :
+        A dict with the ``Posit-Connect-User-Session-Token`` header, or an
+        empty dict when not running on Connect, when there's no active Shiny
+        session, or when `url` isn't Connect's LLM gateway.
+    """
+    if not _is_connect_gateway_url(url):
+        return {}
+    token = _connect_viewer_token()
+    if token is None:
+        return {}
+    return {CONNECT_VIEWER_TOKEN_HEADER: token}
+
+
+def _is_connect_gateway_url(url: str) -> bool:
+    # The token is only ever sent back to the Connect server that injected it.
+    server = os.environ.get("CONNECT_SERVER", "")
+    if not server:
+        return False
+    server_parsed = urlparse(server)
+    url_parsed = urlparse(url)
+    return (
+        url_parsed.scheme.lower() == server_parsed.scheme.lower()
+        and (url_parsed.hostname or "").lower()
+        == (server_parsed.hostname or "").lower()
+        and url_parsed.port == server_parsed.port
+        and url_parsed.path.startswith("/__gateway__/")
+    )
+
+
+def _connect_viewer_token() -> Optional[str]:
+    # Only read the session token when actually running on Connect
+    if os.environ.get("RSTUDIO_PRODUCT") != "CONNECT":
+        return None
+    try:
+        from shiny.session import get_current_session
+    except ImportError:
+        return None
+    session = get_current_session()
+    if session is None:
+        return None
+    http_conn = getattr(session, "http_conn", None)
+    if http_conn is None:
+        return None
+    return http_conn.headers.get(CONNECT_VIEWER_TOKEN_HEADER.lower())

--- a/chatlas/_connect.py
+++ b/chatlas/_connect.py
@@ -51,9 +51,22 @@ def _is_connect_gateway_url(url: str) -> bool:
         url_parsed.scheme.lower() == server_parsed.scheme.lower()
         and (url_parsed.hostname or "").lower()
         == (server_parsed.hostname or "").lower()
-        and url_parsed.port == server_parsed.port
+        and _port(url_parsed) == _port(server_parsed)
         and url_parsed.path.startswith("/__gateway__/")
     )
+
+
+def _port(parsed) -> Optional[int]:
+    # Treat an omitted port as the scheme's default so that, e.g.,
+    # https://host and https://host:443 compare equal
+    if parsed.port is not None:
+        return parsed.port
+    scheme = parsed.scheme.lower()
+    if scheme == "https":
+        return 443
+    if scheme == "http":
+        return 80
+    return None
 
 
 def _connect_viewer_token() -> Optional[str]:
@@ -70,4 +83,9 @@ def _connect_viewer_token() -> Optional[str]:
     http_conn = getattr(session, "http_conn", None)
     if http_conn is None:
         return None
-    return http_conn.headers.get(CONNECT_VIEWER_TOKEN_HEADER.lower())
+    headers = http_conn.headers
+    # starlette's Headers lookup is case-insensitive, but don't rely on it:
+    # try the canonical casing first, then lowercase
+    return headers.get(CONNECT_VIEWER_TOKEN_HEADER) or headers.get(
+        CONNECT_VIEWER_TOKEN_HEADER.lower()
+    )

--- a/chatlas/_provider_anthropic.py
+++ b/chatlas/_provider_anthropic.py
@@ -18,6 +18,7 @@ import orjson
 from pydantic import BaseModel
 
 from ._chat import Chat
+from ._connect import connect_viewer_headers
 from ._content import (
     PROVIDER_ANNOTATION_TYPES,
     Content,
@@ -44,7 +45,6 @@ from ._content import (
 from ._content_file import ensure_bytes
 from ._files import FileMetadata, maybe_write, open_binary
 from ._logging import log_model_default
-from ._connect import connect_viewer_headers
 from ._provider import (
     BatchStatus,
     ModelInfo,

--- a/chatlas/_provider_anthropic.py
+++ b/chatlas/_provider_anthropic.py
@@ -44,6 +44,7 @@ from ._content import (
 from ._content_file import ensure_bytes
 from ._files import FileMetadata, maybe_write, open_binary
 from ._logging import log_model_default
+from ._connect import connect_viewer_headers
 from ._provider import (
     BatchStatus,
     ModelInfo,
@@ -562,6 +563,12 @@ class AnthropicProvider(
         if has_uploaded(turns):
             headers = dict(kwargs_full.get("extra_headers") or {})
             headers.setdefault("anthropic-beta", "files-api-2025-04-14")
+            kwargs_full["extra_headers"] = headers
+
+        viewer_headers = connect_viewer_headers(str(self._client.base_url))
+        if viewer_headers:
+            headers = dict(kwargs_full.get("extra_headers") or {})
+            headers.update(viewer_headers)
             kwargs_full["extra_headers"] = headers
 
         return kwargs_full

--- a/chatlas/_provider_openai.py
+++ b/chatlas/_provider_openai.py
@@ -47,6 +47,7 @@ from ._content import (
 from ._content_file import ensure_bytes
 from ._files import FileMetadata, maybe_write, open_binary
 from ._logging import log_model_default
+from ._connect import connect_viewer_headers
 from ._provider import StandardModelParamNames, StandardModelParams
 from ._provider_openai_completions import load_tool_request_args
 from ._provider_openai_generic import BatchResult, OpenAIAbstractProvider
@@ -343,6 +344,12 @@ class OpenAIProvider(
 
         if include:
             kwargs_full["include"] = include
+
+        viewer_headers = connect_viewer_headers(str(self._client.base_url))
+        if viewer_headers:
+            headers = dict(kwargs_full.get("extra_headers") or {})
+            headers.update(viewer_headers)
+            kwargs_full["extra_headers"] = headers
 
         return kwargs_full
 

--- a/chatlas/_provider_openai.py
+++ b/chatlas/_provider_openai.py
@@ -23,6 +23,7 @@ from openai.types.responses.response_output_text_annotation_added_event import (
 from pydantic import BaseModel
 
 from ._chat import Chat
+from ._connect import connect_viewer_headers
 from ._content import (
     PROVIDER_ANNOTATION_TYPES,
     Content,
@@ -47,7 +48,6 @@ from ._content import (
 from ._content_file import ensure_bytes
 from ._files import FileMetadata, maybe_write, open_binary
 from ._logging import log_model_default
-from ._connect import connect_viewer_headers
 from ._provider import StandardModelParamNames, StandardModelParams
 from ._provider_openai_completions import load_tool_request_args
 from ._provider_openai_generic import BatchResult, OpenAIAbstractProvider

--- a/chatlas/_provider_openai_completions.py
+++ b/chatlas/_provider_openai_completions.py
@@ -35,6 +35,7 @@ from ._content import (
 from ._content_file import ensure_bytes
 from ._logging import log_model_default
 from ._merge import merge_dicts
+from ._connect import connect_viewer_headers
 from ._provider import StandardModelParamNames, StandardModelParams
 from ._provider_openai_generic import BatchResult, OpenAIAbstractProvider
 from ._tools import Tool, ToolBuiltIn, basemodel_to_param_schema
@@ -275,6 +276,12 @@ class OpenAICompletionsProvider(
 
         if stream and "stream_options" not in kwargs_full:
             kwargs_full["stream_options"] = {"include_usage": True}
+
+        viewer_headers = connect_viewer_headers(str(self._client.base_url))
+        if viewer_headers:
+            headers = dict(kwargs_full.get("extra_headers") or {})
+            headers.update(viewer_headers)
+            kwargs_full["extra_headers"] = headers
 
         return kwargs_full
 

--- a/chatlas/_provider_openai_completions.py
+++ b/chatlas/_provider_openai_completions.py
@@ -17,6 +17,7 @@ from openai.types.chat import (
 from pydantic import BaseModel
 
 from ._chat import Chat
+from ._connect import connect_viewer_headers
 from ._content import (
     Content,
     ContentDocument,
@@ -35,7 +36,6 @@ from ._content import (
 from ._content_file import ensure_bytes
 from ._logging import log_model_default
 from ._merge import merge_dicts
-from ._connect import connect_viewer_headers
 from ._provider import StandardModelParamNames, StandardModelParams
 from ._provider_openai_generic import BatchResult, OpenAIAbstractProvider
 from ._tools import Tool, ToolBuiltIn, basemodel_to_param_schema

--- a/chatlas/data/bedrock_apis.json
+++ b/chatlas/data/bedrock_apis.json
@@ -6,6 +6,7 @@
   "google.gemma-4-e2b": "responses",
   "openai.gpt-5.4": "responses",
   "openai.gpt-5.5": "responses",
+  "openai.gpt-5.6-cyber": "responses",
   "openai.gpt-5.6-luna": "responses",
   "openai.gpt-5.6-sol": "responses",
   "openai.gpt-5.6-terra": "responses",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -613,6 +613,7 @@ def make_vcr_config(match_on: list[str] = VCR_MATCH_ON_DEFAULT) -> dict:
             "x-stainless-retry-count",
             "user-agent",
             "cookie",
+            "posit-connect-user-session-token",
             # AWS Bedrock headers
             "x-amz-sso_bearer_token",
             "X-Amz-Security-Token",

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -1,8 +1,6 @@
-import os
 from types import SimpleNamespace
 
 import pytest
-
 from chatlas import ChatAnthropic, ChatOpenAI
 from chatlas._connect import (
     CONNECT_VIEWER_TOKEN_HEADER,
@@ -51,6 +49,8 @@ def test_gateway_url_matching(connect_env):
     assert not _is_connect_gateway_url("https://connect.example.com/content/123")
     # Port must match
     assert not _is_connect_gateway_url("https://connect.example.com:8443/__gateway__/x")
+    # An explicit default port is equivalent to an omitted one
+    assert _is_connect_gateway_url("https://connect.example.com:443/__gateway__/x")
 
 
 def test_session_token_not_read_when_not_on_connect(monkeypatch):
@@ -68,6 +68,10 @@ def test_viewer_token_read_from_shiny_session(connect_env, monkeypatch):
         )
     )
     monkeypatch.setattr(shiny, "get_current_session", lambda: session)
+    assert _connect_viewer_token() == "shiny-token"
+
+    # Header containers that preserve original casing are also handled
+    session.http_conn.headers = {CONNECT_VIEWER_TOKEN_HEADER: "shiny-token"}
     assert _connect_viewer_token() == "shiny-token"
 
 

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -1,0 +1,107 @@
+import os
+from types import SimpleNamespace
+
+import pytest
+
+from chatlas import ChatAnthropic, ChatOpenAI
+from chatlas._connect import (
+    CONNECT_VIEWER_TOKEN_HEADER,
+    _connect_viewer_token,
+    _is_connect_gateway_url,
+    connect_viewer_headers,
+)
+
+GATEWAY_URL = "https://connect.example.com/__gateway__/anthropic/guid/v1"
+
+
+@pytest.fixture
+def connect_env(monkeypatch):
+    monkeypatch.setenv("CONNECT_SERVER", "https://connect.example.com/")
+    monkeypatch.setenv("RSTUDIO_PRODUCT", "CONNECT")
+
+
+@pytest.fixture
+def viewer_token(monkeypatch):
+    monkeypatch.setattr(
+        "chatlas._connect._connect_viewer_token", lambda: "token"
+    )
+
+
+def test_viewer_token_forwarded_only_to_connect_gateway(connect_env, viewer_token):
+    headers = connect_viewer_headers(GATEWAY_URL)
+    assert headers == {CONNECT_VIEWER_TOKEN_HEADER: "token"}
+
+    assert connect_viewer_headers("https://api.anthropic.com/v1") == {}
+    assert connect_viewer_headers("https://evil.example.com/__gateway__/anthropic/guid/v1") == {}
+    # A host that only shares a string prefix with the server is not the server.
+    assert connect_viewer_headers("https://connect.example.com.evil.com/__gateway__/x") == {}
+
+
+def test_viewer_token_never_sent_off_connect(monkeypatch, viewer_token):
+    monkeypatch.delenv("CONNECT_SERVER", raising=False)
+    assert connect_viewer_headers(GATEWAY_URL) == {}
+    assert not _is_connect_gateway_url(GATEWAY_URL)
+
+
+def test_gateway_url_matching(connect_env):
+    assert _is_connect_gateway_url(GATEWAY_URL)
+    # Case-insensitive scheme/host
+    assert _is_connect_gateway_url("HTTPS://CONNECT.EXAMPLE.COM/__gateway__/x")
+    # Path must be under /__gateway__/
+    assert not _is_connect_gateway_url("https://connect.example.com/content/123")
+    # Port must match
+    assert not _is_connect_gateway_url("https://connect.example.com:8443/__gateway__/x")
+
+
+def test_session_token_not_read_when_not_on_connect(monkeypatch):
+    monkeypatch.setenv("CONNECT_SERVER", "https://connect.example.com")
+    monkeypatch.delenv("RSTUDIO_PRODUCT", raising=False)
+    assert _connect_viewer_token() is None
+
+
+def test_viewer_token_read_from_shiny_session(connect_env, monkeypatch):
+    shiny = pytest.importorskip("shiny.session")
+
+    session = SimpleNamespace(
+        http_conn=SimpleNamespace(
+            headers={"posit-connect-user-session-token": "shiny-token"}
+        )
+    )
+    monkeypatch.setattr(shiny, "get_current_session", lambda: session)
+    assert _connect_viewer_token() == "shiny-token"
+
+
+def test_no_token_without_session(connect_env, monkeypatch):
+    shiny = pytest.importorskip("shiny.session")
+    monkeypatch.setattr(shiny, "get_current_session", lambda: None)
+    assert _connect_viewer_token() is None
+    assert connect_viewer_headers(GATEWAY_URL) == {}
+
+
+def test_chat_perform_args_include_viewer_header(connect_env, viewer_token):
+    chat = ChatAnthropic(
+        api_key="fake-key",
+        kwargs={"base_url": GATEWAY_URL},
+    )
+    kwargs = chat.provider._chat_perform_args(
+        stream=False, turns=[], tools={}, data_model=None, kwargs=None
+    )
+    assert kwargs["extra_headers"][CONNECT_VIEWER_TOKEN_HEADER] == "token"
+
+    with pytest.warns(UserWarning, match="Responses API"):
+        chat = ChatOpenAI(
+            api_key="fake-key",
+            base_url="https://connect.example.com/__gateway__/openai/guid/v1",
+        )
+    kwargs = chat.provider._chat_perform_args(
+        stream=False, turns=[], tools={}, data_model=None, kwargs=None
+    )
+    assert kwargs["extra_headers"][CONNECT_VIEWER_TOKEN_HEADER] == "token"
+
+
+def test_chat_perform_args_no_header_off_gateway(connect_env, viewer_token):
+    chat = ChatAnthropic(api_key="fake-key")
+    kwargs = chat.provider._chat_perform_args(
+        stream=False, turns=[], tools={}, data_model=None, kwargs=None
+    )
+    assert CONNECT_VIEWER_TOKEN_HEADER not in (kwargs.get("extra_headers") or {})


### PR DESCRIPTION
Port of [tidyverse/ellmer#1105](https://github.com/tidyverse/ellmer/pull/1105).

When chat traffic on Posit Connect goes through Connect's LLM gateway, this forwards the Shiny viewer's session token as a `Posit-Connect-User-Session-Token` header so Connect can attribute the call to the viewer. The header is:

- only added when running on Connect (`RSTUDIO_PRODUCT=CONNECT`) with an active Shiny session (token read from `session.http_conn.headers`),
- only sent to Connect's own gateway URL (scheme/host/port matching `CONNECT_SERVER`, path under `/__gateway__/`), so the token is never sent to a third-party endpoint.

Since `parallel_chat()` and friends route through the same `chat_perform()` path, they're covered automatically.

## Implementation notes

- New `chatlas/_connect.py` with `connect_viewer_headers(url)`, mirroring ellmer's `ellmer_req_connect_viewer()`.
- The header is merged into the `extra_headers` request argument of the OpenAI Responses, OpenAI Completions, and Anthropic providers (which also covers providers built on them, e.g. `ChatOpenRouter()`, `ChatGroq()`, `ChatGithub()`, Bedrock Messages/Responses).
- Not wired into `ChatGoogle()` (the google-genai SDK doesn't support per-request headers) or the raw-httpx Bedrock Converse provider (AWS SigV4-signed requests to bedrock-runtime, not a Connect gateway target). Happy to add either if there's a need.
- The header is added to the VCR `filter_headers` list so it can never be recorded in a cassette.
