### PR TITLE
Default `ChatBedrock` base_url to `AWS_ENDPOINT_URL_BEDROCK_RUNTIME`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
-- `ChatBedrock()` with `api="converse"` now defaults `base_url` to the `AWS_ENDPOINT_URL_BEDROCK_RUNTIME` environment variable when set, matching the official AWS SDKs. Similarly, `ChatAnthropic()` respects the `ANTHROPIC_BASE_URL` environment variable (via the anthropic SDK). Setting these variables is enough to route requests through a proxy or gateway, so you don't have to pass `base_url` on every call.
+- `ChatBedrock()` now defaults `base_url` to the official AWS SDKs' endpoint override environment variables when set: `AWS_ENDPOINT_URL_BEDROCK_RUNTIME` for `api="converse"`, and `AWS_ENDPOINT_URL_BEDROCK_MANTLE` for `api="messages"` and `api="responses"`. Similarly, `ChatAnthropic()` respects the `ANTHROPIC_BASE_URL` environment variable (via the anthropic SDK). Setting these variables is enough to route requests through a proxy or gateway, so you don't have to pass `base_url` on every call.
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changes
+
+- `ChatBedrock()` with `api="converse"` now defaults `base_url` to the `AWS_ENDPOINT_URL_BEDROCK_RUNTIME` environment variable when set, matching the official AWS SDKs. Similarly, `ChatAnthropic()` respects the `ANTHROPIC_BASE_URL` environment variable (via the anthropic SDK). Setting these variables is enough to route requests through a proxy or gateway, so you don't have to pass `base_url` on every call.
+
 ### Bug fixes
 
 * `ChatOllama()` now distinguishes a remote endpoint it can't reach from a genuinely missing local install, and validates a supplied `model` against `/api/tags` at construction time instead of only when `model` is omitted. (#393)

--- a/chatlas/_provider_anthropic.py
+++ b/chatlas/_provider_anthropic.py
@@ -210,7 +210,10 @@ def ChatAnthropic(
         variable.
     kwargs
         Additional arguments to pass to the `anthropic.Anthropic()` client
-        constructor.
+        constructor. Note that the client defaults `base_url` to the
+        `ANTHROPIC_BASE_URL` environment variable when it is set, so setting
+        that variable is enough to route requests through a proxy or
+        gateway.
 
     Returns
     -------

--- a/chatlas/_provider_bedrock.py
+++ b/chatlas/_provider_bedrock.py
@@ -107,9 +107,13 @@ def ChatBedrock(
     aws_region
         The AWS region to use. Defaults to the region from your AWS config.
     base_url
-        Override the endpoint URL. Needed to reach mantle's other
-        OpenAI-compatible path, `/v1`, which serves older open-weight models
-        like `gpt-oss` and rejects the models `/openai/v1` serves.
+        Override the endpoint URL. For `api="converse"`, the default is the
+        `AWS_ENDPOINT_URL_BEDROCK_RUNTIME` environment variable if set
+        (matching the official AWS SDKs), and the standard
+        `bedrock-runtime` endpoint for your region otherwise. For the mantle
+        APIs, an override is needed to reach mantle's other OpenAI-compatible
+        path, `/v1`, which serves older open-weight models like `gpt-oss` and
+        rejects the models `/openai/v1` serves.
     max_tokens
         Maximum number of tokens to generate, defaulting to 4096 when
         `api="converse"` or `api="messages"`. Passing this when `api="responses"` raises, since
@@ -453,7 +457,12 @@ def bedrock_api_for_model(model: Optional[str]) -> BedrockAPI:
 
 def bedrock_base_url(api: BedrockAPI, region: str) -> str:
     if api == "converse":
-        return f"https://bedrock-runtime.{region}.amazonaws.com"
+        # Match the official AWS SDKs, which read the service-specific
+        # endpoint override AWS_ENDPOINT_URL_BEDROCK_RUNTIME.
+        return os.environ.get(
+            "AWS_ENDPOINT_URL_BEDROCK_RUNTIME",
+            f"https://bedrock-runtime.{region}.amazonaws.com",
+        )
 
     host = MANTLE_HOST.format(region=region)
     if api == "messages":

--- a/chatlas/_provider_bedrock.py
+++ b/chatlas/_provider_bedrock.py
@@ -107,13 +107,15 @@ def ChatBedrock(
     aws_region
         The AWS region to use. Defaults to the region from your AWS config.
     base_url
-        Override the endpoint URL. For `api="converse"`, the default is the
-        `AWS_ENDPOINT_URL_BEDROCK_RUNTIME` environment variable if set
-        (matching the official AWS SDKs), and the standard
-        `bedrock-runtime` endpoint for your region otherwise. For the mantle
-        APIs, an override is needed to reach mantle's other OpenAI-compatible
-        path, `/v1`, which serves older open-weight models like `gpt-oss` and
-        rejects the models `/openai/v1` serves.
+        Override the endpoint URL. The default is the standard endpoint for
+        the selected `api` and your region, honoring the official AWS SDKs'
+        endpoint override environment variables:
+        `AWS_ENDPOINT_URL_BEDROCK_RUNTIME` for `"converse"`, and
+        `AWS_ENDPOINT_URL_BEDROCK_MANTLE` for `"messages"` and `"responses"`
+        (which append their API-specific path to the override). For the
+        mantle APIs, an override is also needed to reach mantle's other
+        OpenAI-compatible path, `/v1`, which serves older open-weight models
+        like `gpt-oss` and rejects the models `/openai/v1` serves.
     max_tokens
         Maximum number of tokens to generate, defaulting to 4096 when
         `api="converse"` or `api="messages"`. Passing this when `api="responses"` raises, since
@@ -455,16 +457,25 @@ def bedrock_api_for_model(model: Optional[str]) -> BedrockAPI:
     return MODEL_APIS.get(CROSS_REGION_PREFIX.sub("", model), "converse")
 
 
+def aws_endpoint_url(var: str, default: str) -> str:
+    """An AWS service endpoint override env var, or `default` when unset."""
+    url = os.environ.get(var, "")
+    return url.rstrip("/") if url else default
+
+
 def bedrock_base_url(api: BedrockAPI, region: str) -> str:
+    # Match the official AWS SDKs, which read service-specific endpoint
+    # overrides: AWS_ENDPOINT_URL_BEDROCK_RUNTIME for the runtime (converse)
+    # service and AWS_ENDPOINT_URL_BEDROCK_MANTLE for mantle.
     if api == "converse":
-        # Match the official AWS SDKs, which read the service-specific
-        # endpoint override AWS_ENDPOINT_URL_BEDROCK_RUNTIME.
-        return os.environ.get(
+        return aws_endpoint_url(
             "AWS_ENDPOINT_URL_BEDROCK_RUNTIME",
             f"https://bedrock-runtime.{region}.amazonaws.com",
         )
 
-    host = MANTLE_HOST.format(region=region)
+    host = aws_endpoint_url(
+        "AWS_ENDPOINT_URL_BEDROCK_MANTLE", MANTLE_HOST.format(region=region)
+    )
     if api == "messages":
         # The Anthropic SDK appends "/v1/messages" itself, so the "/v1" is
         # deliberately absent here.

--- a/chatlas/data/bedrock_apis.json
+++ b/chatlas/data/bedrock_apis.json
@@ -6,6 +6,7 @@
   "google.gemma-4-e2b": "responses",
   "openai.gpt-5.4": "responses",
   "openai.gpt-5.5": "responses",
+  "openai.gpt-5.6-cyber": "responses",
   "openai.gpt-5.6-luna": "responses",
   "openai.gpt-5.6-sol": "responses",
   "openai.gpt-5.6-terra": "responses",

--- a/tests/test_provider_bedrock_converse.py
+++ b/tests/test_provider_bedrock_converse.py
@@ -1094,7 +1094,7 @@ class TestConverseDispatch:
 
         assert str(provider._client.base_url) == "https://explicit.example.com"
 
-    def test_mantle_base_url_ignores_endpoint_env_var(self, monkeypatch):
+    def test_mantle_base_url_ignores_runtime_endpoint_env_var(self, monkeypatch):
         from chatlas._provider_bedrock import bedrock_base_url
 
         monkeypatch.setenv(
@@ -1107,6 +1107,45 @@ class TestConverseDispatch:
         assert bedrock_base_url("responses", "us-west-2") == (
             "https://bedrock-mantle.us-west-2.api.aws/openai/v1"
         )
+
+    def test_mantle_base_url_defaults_to_mantle_endpoint_env_var(
+        self, monkeypatch
+    ):
+        from chatlas._provider_bedrock import bedrock_base_url
+
+        # Trailing slash is stripped before the API-specific path is appended.
+        monkeypatch.setenv(
+            "AWS_ENDPOINT_URL_BEDROCK_MANTLE", "https://mantle.example.com/"
+        )
+
+        assert bedrock_base_url("messages", "us-west-2") == (
+            "https://mantle.example.com/anthropic"
+        )
+        assert bedrock_base_url("responses", "us-west-2") == (
+            "https://mantle.example.com/openai/v1"
+        )
+        # The runtime (converse) endpoint is a different AWS service, so it
+        # ignores the mantle override.
+        assert bedrock_base_url("converse", "us-west-2") == (
+            "https://bedrock-runtime.us-west-2.amazonaws.com"
+        )
+
+    def test_models_base_url_follows_mantle_endpoint_env_var(self, monkeypatch):
+        from chatlas._provider_bedrock import (
+            bedrock_base_url,
+            bedrock_models_base_url,
+        )
+
+        monkeypatch.setenv(
+            "AWS_ENDPOINT_URL_BEDROCK_MANTLE", "https://mantle.example.com"
+        )
+
+        assert bedrock_models_base_url(
+            bedrock_base_url("responses", "us-west-2")
+        ) == "https://mantle.example.com/v1"
+        assert bedrock_models_base_url(
+            bedrock_base_url("messages", "us-west-2")
+        ) == "https://mantle.example.com/v1"
 
     def test_explicit_converse_forwards_config_without_validating_credentials(
         self, monkeypatch

--- a/tests/test_provider_bedrock_converse.py
+++ b/tests/test_provider_bedrock_converse.py
@@ -1066,6 +1066,48 @@ class TestConverseDispatch:
             provider._client.base_url
         )
 
+    def test_converse_base_url_defaults_to_endpoint_env_var(self, monkeypatch):
+        from chatlas import ChatBedrock
+        from chatlas._provider_bedrock_converse import BedrockConverseProvider
+
+        monkeypatch.setenv(
+            "AWS_ENDPOINT_URL_BEDROCK_RUNTIME", "https://bedrock.example.com"
+        )
+        chat = ChatBedrock(model="amazon.nova-pro-v1:0", aws_region="us-west-2")
+        provider = cast(BedrockConverseProvider, chat.provider)
+
+        assert str(provider._client.base_url) == "https://bedrock.example.com"
+
+    def test_explicit_base_url_outranks_endpoint_env_var(self, monkeypatch):
+        from chatlas import ChatBedrock
+        from chatlas._provider_bedrock_converse import BedrockConverseProvider
+
+        monkeypatch.setenv(
+            "AWS_ENDPOINT_URL_BEDROCK_RUNTIME", "https://bedrock.example.com"
+        )
+        chat = ChatBedrock(
+            model="amazon.nova-pro-v1:0",
+            aws_region="us-west-2",
+            base_url="https://explicit.example.com",
+        )
+        provider = cast(BedrockConverseProvider, chat.provider)
+
+        assert str(provider._client.base_url) == "https://explicit.example.com"
+
+    def test_mantle_base_url_ignores_endpoint_env_var(self, monkeypatch):
+        from chatlas._provider_bedrock import bedrock_base_url
+
+        monkeypatch.setenv(
+            "AWS_ENDPOINT_URL_BEDROCK_RUNTIME", "https://bedrock.example.com"
+        )
+
+        assert bedrock_base_url("messages", "us-west-2") == (
+            "https://bedrock-mantle.us-west-2.api.aws/anthropic"
+        )
+        assert bedrock_base_url("responses", "us-west-2") == (
+            "https://bedrock-mantle.us-west-2.api.aws/openai/v1"
+        )
+
     def test_explicit_converse_forwards_config_without_validating_credentials(
         self, monkeypatch
     ):


### PR DESCRIPTION
Ports tidyverse/ellmer#1104 to chatlas.

`ChatBedrock()` now defaults `base_url` to the official AWS SDKs' endpoint override environment variables when set: `AWS_ENDPOINT_URL_BEDROCK_RUNTIME` for `api="converse"`, and `AWS_ENDPOINT_URL_BEDROCK_MANTLE` for `api="messages"` and `api="responses"` (which append their API-specific path to the override). Setting the variable is enough to route Bedrock through a proxy or gateway, so you don't have to pass `base_url` on every call. An explicit `base_url` still wins.

Two spots needed no code change because the underlying SDKs already honor their respective variables:

- `ChatAnthropic()` passes client arguments straight through to `anthropic.Anthropic()`, which reads `ANTHROPIC_BASE_URL` when `base_url` isn't supplied. Documented in the `kwargs` parameter.
- Converse `list_models()` goes through boto3's `bedrock` control-plane client, which natively reads `AWS_ENDPOINT_URL_BEDROCK` (and, like the official SDKs, ignores the runtime override).

Tests cover: the runtime and mantle env var defaults, trailing-slash handling, explicit `base_url` taking precedence, each service ignoring the other's variable, and the models listing following the mantle override.