### PR TITLE
fix(inspect): read system prompt text and normalize str message content in to_solver()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* `.to_solver()` no longer corrupts the system prompt or the prior turns it reads out of Inspect AI's message state. The system prompt was being set to the `repr()` of the `ChatMessageSystem` object rather than its text, and message content arriving in Inspect AI's `str` form (rather than as a list of `Content`) was iterated one character at a time. (#407)
 * `ChatGoogle()` no longer raises `ValueError: Unknown content type: ContentThinking` on the second and later turns when `reasoning` is enabled; thinking content is now replayed to the model as thought parts, and the `thought_signature` on thought parts is preserved (previously only tool-call parts kept it). (#403)
 * `ChatOllama()` now distinguishes a remote endpoint it can't reach from a genuinely missing local install, and validates a supplied `model` against `/api/tags` at construction time instead of only when `model` is omitted. (#393)
 

--- a/chatlas/_chat.py
+++ b/chatlas/_chat.py
@@ -1134,7 +1134,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
 
                 # Set the system prompt on the chat instance
                 if len(system_messages) == 1:
-                    chat_instance.system_prompt = str(system_messages[0])
+                    chat_instance.system_prompt = system_messages[0].text
                 elif len(system_messages) > 1:
                     raise ValueError(
                         "Multiple system prompts detected in `.to_solver()`, but chatlas only "

--- a/chatlas/_inspect.py
+++ b/chatlas/_inspect.py
@@ -121,6 +121,21 @@ def turn_as_inspect_messages(
     raise ValueError(f"Unknown turn role: {turn.role}")
 
 
+def message_contents(msg: ChatMessage) -> list[str | InspectContent]:
+    """
+    Get an InspectAI ChatMessage's content as a list.
+
+    InspectAI types `ChatMessage.content` as `str | list[Content]`, and a message
+    that InspectAI itself builds (from a dataset sample, or from a previous
+    solver) usually carries the `str` form. Iterating that directly yields one
+    character at a time, so normalize it here.
+    """
+    content = msg.content
+    if isinstance(content, str):
+        return [content]
+    return list(content)
+
+
 def inspect_messages_as_turns(messages: list[ChatMessage]) -> list[Turn]:
     """Translate InspectAI ChatMessages into chatlas Turns."""
     (imodel, _, _) = try_import_inspect()
@@ -128,10 +143,10 @@ def inspect_messages_as_turns(messages: list[ChatMessage]) -> list[Turn]:
     turns: list[Turn] = []
     for msg in messages:
         if isinstance(msg, imodel.ChatMessageSystem):
-            contents = [inspect_content_as_chatlas(x) for x in msg.content]
+            contents = [inspect_content_as_chatlas(x) for x in message_contents(msg)]
             turn = SystemTurn(contents=contents)
         elif isinstance(msg, imodel.ChatMessageUser):
-            contents = [inspect_content_as_chatlas(x) for x in msg.content]
+            contents = [inspect_content_as_chatlas(x) for x in message_contents(msg)]
             turn = UserTurn(contents=contents)
         elif isinstance(msg, imodel.ChatMessageAssistant):
             contents: list[Content] = []
@@ -140,7 +155,7 @@ def inspect_messages_as_turns(messages: list[ChatMessage]) -> list[Turn]:
                 contents.append(
                     ContentToolRequest(id=x.id, name=x.function, arguments=x.arguments)
                 )
-            for content in msg.content:
+            for content in message_contents(msg):
                 contents.append(inspect_content_as_chatlas(content))
             turn = AssistantTurn(contents=contents)
         elif isinstance(msg, imodel.ChatMessageTool):

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -1,3 +1,4 @@
+import asyncio
 import datetime
 import json
 import sys
@@ -32,10 +33,12 @@ def vcr_config():
 
 
 import inspect_ai.model as i_model
+import inspect_ai.tool as i_tool
 from inspect_ai import Task
 from inspect_ai import eval as inspect_eval
 from inspect_ai.dataset import Sample, json_dataset
 from inspect_ai.scorer import model_graded_qa
+from inspect_ai.solver import TaskState
 
 MODEL = "claude-haiku-4-5-20251001"
 SCORER_MODEL = f"anthropic/{MODEL}"
@@ -726,3 +729,125 @@ class TestExportEvalEdgeCases:
                 output_file,
                 turns=[AssistantTurn("Hello!")],
             )
+
+
+class TestStringMessageContent:
+    """
+    InspectAI types `ChatMessage.content` as `str | list[Content]`, and messages
+    that InspectAI itself builds carry the `str` form.
+    """
+
+    def test_str_content_is_not_split_into_characters(self):
+        messages = [
+            i_model.ChatMessageUser(content="What is 2+2?"),
+            i_model.ChatMessageAssistant(content="4"),
+        ]
+
+        turns = inspect_messages_as_turns(messages)
+
+        assert len(turns) == 2
+        assert [len(t.contents) for t in turns] == [1, 1]
+        assert turns[0].text == "What is 2+2?"
+        assert turns[1].text == "4"
+
+    def test_str_content_on_a_system_message(self):
+        turns = inspect_messages_as_turns(
+            [i_model.ChatMessageSystem(content="You are terse.")]
+        )
+
+        assert len(turns) == 1
+        assert len(turns[0].contents) == 1
+        assert turns[0].text == "You are terse."
+
+    def test_list_content_still_works(self):
+        messages = [
+            i_model.ChatMessageUser(content=[i_model.ContentText(text="What is 2+2?")]),
+        ]
+
+        turns = inspect_messages_as_turns(messages)
+
+        assert len(turns) == 1
+        assert len(turns[0].contents) == 1
+        assert turns[0].text == "What is 2+2?"
+
+    def test_str_content_alongside_a_tool_call(self):
+        messages = [
+            i_model.ChatMessageAssistant(
+                content="Let me look that up.",
+                tool_calls=[
+                    i_tool.ToolCall(
+                        id="call-1", function="get_weather", arguments={"city": "Paris"}
+                    )
+                ],
+            ),
+        ]
+
+        turns = inspect_messages_as_turns(messages)
+
+        assert len(turns) == 1
+        assert len(turns[0].contents) == 2
+        assert isinstance(turns[0].contents[0], ContentToolRequest)
+        assert turns[0].text == "Let me look that up."
+
+
+class TestSolverSystemPrompt:
+    """
+    `.to_solver()` reads a system prompt out of the InspectAI message state.
+    """
+
+    @staticmethod
+    def _recording_chat():
+        recorded = {}
+
+        class RecordingChat(Chat):
+            async def chat_async(self, *args, echo="output", stream=True, kwargs=None):
+                recorded["system_prompt"] = self.system_prompt
+                recorded["turn_texts"] = [
+                    t.text for t in self.get_turns(include_system_prompt=False)
+                ]
+                self.set_turns(
+                    self.get_turns(include_system_prompt=False)
+                    + [UserTurn(list(args)), AssistantTurn("4")]
+                )
+                return None
+
+        chat = RecordingChat(chat_func().provider)
+        return chat, recorded
+
+    @staticmethod
+    def _run(solver, messages):
+        state = TaskState(
+            model=SCORER_MODEL,
+            sample_id=1,
+            epoch=1,
+            input=messages,
+            messages=list(messages),
+        )
+        asyncio.run(solver(state, None))
+
+    def test_system_prompt_is_the_message_text(self):
+        chat, recorded = self._recording_chat()
+
+        self._run(
+            chat.to_solver(),
+            [
+                i_model.ChatMessageSystem(content=SYSTEM_DEFAULT),
+                i_model.ChatMessageUser(content="What is 2+2?"),
+            ],
+        )
+
+        assert recorded["system_prompt"] == SYSTEM_DEFAULT
+
+    def test_prior_turns_survive_str_content(self):
+        chat, recorded = self._recording_chat()
+
+        self._run(
+            chat.to_solver(),
+            [
+                i_model.ChatMessageUser(content="What is 2+2?"),
+                i_model.ChatMessageAssistant(content="It is 4."),
+                i_model.ChatMessageUser(content="And 3+3?"),
+            ],
+        )
+
+        assert recorded["turn_texts"] == ["What is 2+2?", "It is 4."]


### PR DESCRIPTION
Fixes #407.

`.to_solver()` reads the system prompt and any prior turns out of Inspect AI's message state. Inspect AI types `ChatMessage.content` as `str | list[Content]`, and messages that Inspect AI itself builds carry the `str` form, so two paths were wrong.

**1. `chatlas/_chat.py:1137` set the system prompt to the message's repr.** `str(system_messages[0])` on a `ChatMessageSystem` gives `"id='...' content='You are terse.' source='input' metadata=None role='system'"`, complete with a per-run id. Now `system_messages[0].text`.

**2. `chatlas/_inspect.py:131,134,143` iterated `msg.content` directly.** With the `str` form that walks characters, so `"What is 2+2?"` became 12 single-character `ContentText` objects and `turn.text` came back as `'What[empty string]is[empty string]2+2?'`. Added a small `message_contents()` helper that normalizes to a list, mirroring the guard `.to_solver()` already applies to the user prompt at `chatlas/_chat.py:1152-1154`.

The existing round-trip tests could not see either one: `turn_as_inspect_messages()` always emits the `list` form, so they only ever exercise that branch.

## Verification

Clean `python:3.12-slim` container on Linux, `pip install -e .`, inspect-ai 0.3.260, Python 3.12.14. No network calls. Base commit `6e0671bce38bb0c5e2488ae9f59c85167d1a8fb6`.

Five new tests, one per scenario named above plus a control:

| | base | this branch |
|---|---|---|
| `TestStringMessageContent` + `TestSolverSystemPrompt` (6 tests) | **5 failed, 1 passed** | **6 passed** |
| `TestContentTranslation` + `TestExportEval*` (21 tests) | 21 passed | 21 passed |

The one test that passes on base is `test_list_content_still_works`, the control for the branch that was already correct.

`ruff check chatlas --config pyproject.toml` passes, and `pyright chatlas/_inspect.py` reports 0 errors. `pyright chatlas/_chat.py` reports only the two pre-existing unresolved `shiny` / `shinychat` imports, which are absent from my container rather than caused by this change.

I did not run the live legs (`test-live`) or anything needing a cassette that does not exist yet, so nothing here is a claim about a real provider round trip.

## Scope note

`TestSolverSystemPrompt` drives the real `solve()` body and subclasses `Chat` to intercept `chat_async`, so the solver runs end to end without a provider call. Happy to reshape that if you would rather it went through a cassette.
