### PR TITLE
fix(databricks): normalize typed streaming content before merging chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug fixes
 
+* `ChatDatabricks()` no longer drops the assistant's reply from the conversation when a GPT-OSS endpoint streams typed content. The typed part array was merged into the accumulated completion before it was normalized, so every later text delta was appended to it one character at a time and the finished turn came back empty. (#409)
 * `.to_solver()` no longer corrupts the system prompt or the prior turns it reads out of Inspect AI's message state. The system prompt was being set to the `repr()` of the `ChatMessageSystem` object rather than its text, and message content arriving in Inspect AI's `str` form (rather than as a list of `Content`) was iterated one character at a time. (#407)
 * `ChatGoogle()` no longer raises `ValueError: Unknown content type: ContentThinking` on the second and later turns when `reasoning` is enabled; thinking content is now replayed to the model as thought parts, and the `thought_signature` on thought parts is preserved (previously only tool-call parts kept it). (#403)
 * `ChatOllama()` now distinguishes a remote endpoint it can't reach from a genuinely missing local install, and validates a supplied `model` against `/api/tags` at construction time instead of only when `model` is omitted. (#393)

--- a/chatlas/_provider_databricks.py
+++ b/chatlas/_provider_databricks.py
@@ -196,6 +196,17 @@ class DatabricksProvider(OpenAICompletionsProvider):
                 setattr(delta, "reasoning", reasoning)
         return super().stream_content(chunk, completion, turns)
 
+    # The streaming loop merges each chunk before it yields its content, so the
+    # typed array reaches `model_dump()` unless it is normalized here as well.
+    def stream_merge_chunks(self, completion, chunk):
+        delta = chunk.choices[0].delta if chunk.choices else None
+        if delta is not None and isinstance(delta.content, list):
+            text, reasoning = _normalize_content_parts(delta.content)
+            delta.content = text
+            if reasoning:
+                setattr(delta, "reasoning", reasoning)
+        return super().stream_merge_chunks(completion, chunk)
+
     # Same normalization for the non-streaming/completed-response path.
     @staticmethod
     def _response_as_turn(

--- a/tests/test_provider_databricks.py
+++ b/tests/test_provider_databricks.py
@@ -1,4 +1,5 @@
 import asyncio
+import warnings
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import Mock
@@ -9,6 +10,9 @@ from chatlas import ChatDatabricks
 from chatlas._content import ContentText, ContentThinking, ContentThinkingDelta
 from chatlas._provider_databricks import DatabricksProvider
 from openai import OpenAI
+from openai.types.chat import ChatCompletionChunk
+from openai.types.chat.chat_completion_chunk import Choice as ChunkChoice
+from openai.types.chat.chat_completion_chunk import ChoiceDelta
 
 from .conftest import (
     assert_data_extraction,
@@ -283,5 +287,80 @@ def test_stream_content_preserves_plain_string_content():
 
         result = provider.stream_content(chunk, None)
         assert result == [ContentText(text="partial text")]
+    finally:
+        provider._client.close()
+
+
+def _stream_chunk(content: Any) -> ChatCompletionChunk:
+    """A chunk shaped like the ones a real stream carries, with choices[].index."""
+    return ChatCompletionChunk.model_construct(
+        id="c",
+        model="gpt-oss",
+        object="chat.completion.chunk",
+        created=0,
+        choices=[
+            ChunkChoice.model_construct(
+                index=0,
+                delta=ChoiceDelta.model_construct(role="assistant", content=content),
+                finish_reason=None,
+            )
+        ],
+    )
+
+
+def test_stream_merge_chunks_normalizes_typed_content_array():
+    """The accumulated completion holds text, not the typed part array (#409)."""
+    provider = _databricks_provider()
+    try:
+        chunks = [
+            _stream_chunk(
+                [
+                    {
+                        "type": "reasoning",
+                        "summary": [{"type": "summary_text", "text": "thinking"}],
+                    }
+                ]
+            ),
+            _stream_chunk("Hello"),
+            _stream_chunk(" world"),
+        ]
+
+        result = None
+        streamed = []
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            for chunk in chunks:
+                result = provider.stream_merge_chunks(result, chunk)
+                streamed.extend(provider.stream_content(chunk, result))
+
+        delta = result["choices"][0]["delta"]
+        assert delta["content"] == "Hello world"
+        assert delta["reasoning"] == "thinking"
+        assert [
+            w
+            for w in caught
+            if "PydanticSerializationUnexpectedValue" in str(w.message)
+        ] == []
+        assert streamed == [
+            ContentThinkingDelta(thinking="thinking"),
+            ContentText(text="Hello"),
+            ContentText(text=" world"),
+        ]
+
+        turn = provider.stream_turn(result, has_data_model=False)
+        assert turn.text == "Hello world"
+    finally:
+        provider._client.close()
+
+
+def test_stream_merge_chunks_preserves_plain_string_content():
+    """Non-array content (the common case) is untouched by the normalization."""
+    provider = _databricks_provider()
+    try:
+        result = None
+        for chunk in [_stream_chunk("Hello"), _stream_chunk(" world")]:
+            result = provider.stream_merge_chunks(result, chunk)
+
+        assert result["choices"][0]["delta"]["content"] == "Hello world"
     finally:
         provider._client.close()


### PR DESCRIPTION
Does what you suggested: normalizes the delta in `stream_merge_chunks()` before handing it to the inherited merger, reusing `_normalize_content_parts()` so `stream_content()` and its direct callers are untouched.

Two things worth flagging.

The accumulated completion now carries `reasoning` as well, so a streamed turn comes back with a `ContentThinking` next to the text. That's what `_response_as_turn()` already produces on the non-streaming path, so I left it that way rather than dropping it.

Small correction to the repro: as written it doesn't split the string, because the choice dicts have no `index`. The second chunk lands as `choices[1]` and the reasoning list is left alone. Add `index=0` and you get the character expansion you describe. The test builds its chunks that way.

The test merges a typed reasoning chunk followed by two string chunks, then checks the accumulated `content` and `reasoning`, that no serializer warning is emitted, and the text of the finished turn. It fails on main. I ran the databricks file on 3.10 and 3.14, plus ruff and pyright.

I haven't pointed this at a live Databricks endpoint, and the cassettes here only cover plain-string streaming, so the typed path is covered by the unit tests only.

The two overrides now share five lines. Happy to pull them into a helper if you'd rather, I left it alone as the smaller diff.

Fixes #409
