### PR TITLE
fix(huggingface): update default model to Qwen3-235B-A22B-Instruct-2507

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- `ChatHuggingFace()`'s default `model` is now `Qwen/Qwen3-235B-A22B-Instruct-2507` (previously `meta-llama/Llama-3.1-8B-Instruct`), matching ellmer's default. (#414)
 - `ChatBedrock()` now defaults `base_url` to the official AWS SDKs' endpoint override environment variables when set: `AWS_ENDPOINT_URL_BEDROCK_RUNTIME` for `api="converse"`, and `AWS_ENDPOINT_URL_BEDROCK_MANTLE` for `api="messages"` and `api="responses"`. Similarly, `ChatAnthropic()` respects the `ANTHROPIC_BASE_URL` environment variable (via the anthropic SDK). Setting these variables is enough to route requests through a proxy or gateway, so you don't have to pass `base_url` on every call.
 
 ### Bug fixes

--- a/chatlas/_provider_huggingface.py
+++ b/chatlas/_provider_huggingface.py
@@ -125,7 +125,7 @@ def ChatHuggingFace(
         api_key = os.getenv("HUGGINGFACE_API_KEY")
 
     if model is None:
-        model = log_model_default("meta-llama/Llama-3.1-8B-Instruct")
+        model = log_model_default("Qwen/Qwen3-235B-A22B-Instruct-2507")
 
     return Chat(
         provider=HuggingFaceProvider(

--- a/chatlas/data/bedrock_apis.json
+++ b/chatlas/data/bedrock_apis.json
@@ -10,5 +10,10 @@
   "openai.gpt-5.6-luna": "responses",
   "openai.gpt-5.6-sol": "responses",
   "openai.gpt-5.6-terra": "responses",
+  "us-gov-east-1/openai.gpt-5.4": "responses",
+  "us-gov-west-1/openai.gpt-5.4": "responses",
+  "us-gov-west-1/openai.gpt-5.6-luna": "responses",
+  "us-gov-west-1/openai.gpt-5.6-terra": "responses",
+  "us-gov-west-1/xai.grok-4.3": "responses",
   "xai.grok-4.3": "responses"
 }

--- a/chatlas/data/prices.json
+++ b/chatlas/data/prices.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "min_ellmer_version": "0.5.0",
-  "updated_at": "2026-08-24T06:42:01Z",
+  "updated_at": "2026-09-02T12:13:24Z",
   "data": [
     {
       "provider": "AWS/Bedrock",
@@ -63,6 +63,13 @@
     },
     {
       "provider": "AWS/Bedrock",
+      "model": "amazon.nova-2-sonic-v1:0",
+      "variant": "",
+      "input": 0.33,
+      "output": 2.75
+    },
+    {
+      "provider": "AWS/Bedrock",
       "model": "amazon.nova-lite-v1:0",
       "variant": "",
       "input": 0.06,
@@ -81,6 +88,13 @@
       "variant": "",
       "input": 0.8,
       "output": 3.2
+    },
+    {
+      "provider": "AWS/Bedrock",
+      "model": "amazon.nova-sonic-v1:0",
+      "variant": "",
+      "input": 0.06,
+      "output": 0.24
     },
     {
       "provider": "AWS/Bedrock",
@@ -218,6 +232,14 @@
       "input": 10,
       "output": 50,
       "cached_input": 1
+    },
+    {
+      "provider": "AWS/Bedrock",
+      "model": "anthropic.claude-fable-5-1",
+      "variant": "",
+      "input": 10,
+      "output": 50,
+      "cached_input": 0.25
     },
     {
       "provider": "AWS/Bedrock",
@@ -1106,6 +1128,14 @@
     },
     {
       "provider": "AWS/Bedrock",
+      "model": "eu.anthropic.claude-fable-5-1",
+      "variant": "",
+      "input": 11,
+      "output": 55,
+      "cached_input": 0.275
+    },
+    {
+      "provider": "AWS/Bedrock",
       "model": "eu.anthropic.claude-haiku-4-5-20251001-v1:0",
       "variant": "",
       "input": 1.1,
@@ -1289,6 +1319,14 @@
     },
     {
       "provider": "AWS/Bedrock",
+      "model": "global.anthropic.claude-fable-5-1",
+      "variant": "",
+      "input": 10,
+      "output": 50,
+      "cached_input": 0.25
+    },
+    {
+      "provider": "AWS/Bedrock",
       "model": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
       "variant": "",
       "input": 1,
@@ -1417,17 +1455,17 @@
       "provider": "AWS/Bedrock",
       "model": "global.openai.gpt-5.6-sol",
       "variant": "",
-      "input": 5,
-      "output": 30,
-      "cached_input": 0.5
+      "input": 4,
+      "output": 20,
+      "cached_input": 0.4
     },
     {
       "provider": "AWS/Bedrock",
       "model": "global.openai.gpt-5.6-sol",
       "variant": "above_272k_tokens",
-      "input": 10,
-      "output": 45,
-      "cached_input": 1
+      "input": 8,
+      "output": 30,
+      "cached_input": 0.8
     },
     {
       "provider": "AWS/Bedrock",
@@ -1864,11 +1902,35 @@
     },
     {
       "provider": "AWS/Bedrock",
+      "model": "openai.gpt-5.4",
+      "variant": "above_272k_tokens",
+      "input": 5.5,
+      "output": 24.75,
+      "cached_input": 0.55
+    },
+    {
+      "provider": "AWS/Bedrock",
       "model": "openai.gpt-5.5",
       "variant": "",
       "input": 5.5,
       "output": 33,
       "cached_input": 0.55
+    },
+    {
+      "provider": "AWS/Bedrock",
+      "model": "openai.gpt-5.5",
+      "variant": "above_272k_tokens",
+      "input": 11,
+      "output": 49.5,
+      "cached_input": 1.1
+    },
+    {
+      "provider": "AWS/Bedrock",
+      "model": "openai.gpt-5.6-cyber",
+      "variant": "",
+      "input": 13.75,
+      "output": 82.5,
+      "cached_input": 1.375
     },
     {
       "provider": "AWS/Bedrock",
@@ -2663,6 +2725,14 @@
     },
     {
       "provider": "AWS/Bedrock",
+      "model": "us.anthropic.claude-fable-5-1",
+      "variant": "",
+      "input": 11,
+      "output": 55,
+      "cached_input": 0.275
+    },
+    {
+      "provider": "AWS/Bedrock",
       "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
       "variant": "",
       "input": 1.1,
@@ -2912,17 +2982,17 @@
       "provider": "AWS/Bedrock",
       "model": "us.openai.gpt-5.6-sol",
       "variant": "",
-      "input": 5.5,
-      "output": 33,
-      "cached_input": 0.55
+      "input": 4.4,
+      "output": 22,
+      "cached_input": 0.44
     },
     {
       "provider": "AWS/Bedrock",
       "model": "us.openai.gpt-5.6-sol",
       "variant": "above_272k_tokens",
-      "input": 11,
-      "output": 49.5,
-      "cached_input": 1.1
+      "input": 8.8,
+      "output": 33,
+      "cached_input": 0.88
     },
     {
       "provider": "AWS/Bedrock",
@@ -3081,6 +3151,14 @@
       "input": 10,
       "output": 50,
       "cached_input": 1
+    },
+    {
+      "provider": "Anthropic",
+      "model": "claude-fable-5-1",
+      "variant": "",
+      "input": 10,
+      "output": 50,
+      "cached_input": 0.25
     },
     {
       "provider": "Anthropic",
@@ -3497,10 +3575,18 @@
     {
       "provider": "Azure/OpenAI",
       "model": "eu/gpt-5.6",
+      "variant": "above_272k_tokens_priority",
+      "input": 22,
+      "output": 99,
+      "cached_input": 2.2
+    },
+    {
+      "provider": "Azure/OpenAI",
+      "model": "eu/gpt-5.6",
       "variant": "priority",
-      "input": 13.75,
-      "output": 82.5,
-      "cached_input": 1.375
+      "input": 11,
+      "output": 66,
+      "cached_input": 1.1
     },
     {
       "provider": "Azure/OpenAI",
@@ -3521,10 +3607,18 @@
     {
       "provider": "Azure/OpenAI",
       "model": "eu/gpt-5.6-luna",
+      "variant": "above_272k_tokens_priority",
+      "input": 0.88,
+      "output": 3.96,
+      "cached_input": 0.088
+    },
+    {
+      "provider": "Azure/OpenAI",
+      "model": "eu/gpt-5.6-luna",
       "variant": "priority",
-      "input": 0.55,
-      "output": 3.3,
-      "cached_input": 0.055
+      "input": 0.44,
+      "output": 2.64,
+      "cached_input": 0.044
     },
     {
       "provider": "Azure/OpenAI",
@@ -3545,10 +3639,18 @@
     {
       "provider": "Azure/OpenAI",
       "model": "eu/gpt-5.6-sol",
+      "variant": "above_272k_tokens_priority",
+      "input": 22,
+      "output": 99,
+      "cached_input": 2.2
+    },
+    {
+      "provider": "Azure/OpenAI",
+      "model": "eu/gpt-5.6-sol",
       "variant": "priority",
-      "input": 13.75,
-      "output": 82.5,
-      "cached_input": 1.375
+      "input": 11,
+      "output": 66,
+      "cached_input": 1.1
     },
     {
       "provider": "Azure/OpenAI",
@@ -3569,10 +3671,18 @@
     {
       "provider": "Azure/OpenAI",
       "model": "eu/gpt-5.6-terra",
+      "variant": "above_272k_tokens_priority",
+      "input": 8.8,
+      "output": 39.6,
+      "cached_input": 0.88
+    },
+    {
+      "provider": "Azure/OpenAI",
+      "model": "eu/gpt-5.6-terra",
       "variant": "priority",
-      "input": 5.5,
-      "output": 33,
-      "cached_input": 0.55
+      "input": 4.4,
+      "output": 26.4,
+      "cached_input": 0.44
     },
     {
       "provider": "Azure/OpenAI",
@@ -5176,10 +5286,18 @@
     {
       "provider": "Azure/OpenAI",
       "model": "us/gpt-5.6",
+      "variant": "above_272k_tokens_priority",
+      "input": 22,
+      "output": 99,
+      "cached_input": 2.2
+    },
+    {
+      "provider": "Azure/OpenAI",
+      "model": "us/gpt-5.6",
       "variant": "priority",
-      "input": 13.75,
-      "output": 82.5,
-      "cached_input": 1.375
+      "input": 11,
+      "output": 66,
+      "cached_input": 1.1
     },
     {
       "provider": "Azure/OpenAI",
@@ -5200,10 +5318,18 @@
     {
       "provider": "Azure/OpenAI",
       "model": "us/gpt-5.6-luna",
+      "variant": "above_272k_tokens_priority",
+      "input": 0.88,
+      "output": 3.96,
+      "cached_input": 0.088
+    },
+    {
+      "provider": "Azure/OpenAI",
+      "model": "us/gpt-5.6-luna",
       "variant": "priority",
-      "input": 0.55,
-      "output": 3.3,
-      "cached_input": 0.055
+      "input": 0.44,
+      "output": 2.64,
+      "cached_input": 0.044
     },
     {
       "provider": "Azure/OpenAI",
@@ -5224,10 +5350,18 @@
     {
       "provider": "Azure/OpenAI",
       "model": "us/gpt-5.6-sol",
+      "variant": "above_272k_tokens_priority",
+      "input": 22,
+      "output": 99,
+      "cached_input": 2.2
+    },
+    {
+      "provider": "Azure/OpenAI",
+      "model": "us/gpt-5.6-sol",
       "variant": "priority",
-      "input": 13.75,
-      "output": 82.5,
-      "cached_input": 1.375
+      "input": 11,
+      "output": 66,
+      "cached_input": 1.1
     },
     {
       "provider": "Azure/OpenAI",
@@ -5248,10 +5382,18 @@
     {
       "provider": "Azure/OpenAI",
       "model": "us/gpt-5.6-terra",
+      "variant": "above_272k_tokens_priority",
+      "input": 8.8,
+      "output": 39.6,
+      "cached_input": 0.88
+    },
+    {
+      "provider": "Azure/OpenAI",
+      "model": "us/gpt-5.6-terra",
       "variant": "priority",
-      "input": 5.5,
-      "output": 33,
-      "cached_input": 0.55
+      "input": 4.4,
+      "output": 26.4,
+      "cached_input": 0.44
     },
     {
       "provider": "Azure/OpenAI",
@@ -5418,7 +5560,7 @@
       "variant": "",
       "input": 0.1,
       "output": 0.4,
-      "cached_input": 0.025
+      "cached_input": 0.01
     },
     {
       "provider": "Google/Gemini",
@@ -5432,22 +5574,22 @@
       "provider": "Google/Gemini",
       "model": "gemini-2.5-flash-native-audio-latest",
       "variant": "",
-      "input": 0.3,
-      "output": 2.5
+      "input": 0.5,
+      "output": 2
     },
     {
       "provider": "Google/Gemini",
       "model": "gemini-2.5-flash-native-audio-preview-09-2025",
       "variant": "",
-      "input": 0.3,
-      "output": 2.5
+      "input": 0.5,
+      "output": 2
     },
     {
       "provider": "Google/Gemini",
       "model": "gemini-2.5-flash-native-audio-preview-12-2025",
       "variant": "",
-      "input": 0.3,
-      "output": 2.5
+      "input": 0.5,
+      "output": 2
     },
     {
       "provider": "Google/Gemini",
@@ -5455,14 +5597,14 @@
       "variant": "",
       "input": 0.3,
       "output": 2.5,
-      "cached_input": 0.075
+      "cached_input": 0.03
     },
     {
       "provider": "Google/Gemini",
       "model": "gemini-2.5-flash-preview-tts",
       "variant": "",
-      "input": 0.3,
-      "output": 2.5
+      "input": 0.5,
+      "output": 10
     },
     {
       "provider": "Google/Gemini",
@@ -5498,17 +5640,9 @@
       "provider": "Google/Gemini",
       "model": "gemini-2.5-pro-preview-tts",
       "variant": "",
-      "input": 1.25,
-      "output": 10,
+      "input": 1,
+      "output": 20,
       "cached_input": 0.125
-    },
-    {
-      "provider": "Google/Gemini",
-      "model": "gemini-2.5-pro-preview-tts",
-      "variant": "above_200k_tokens",
-      "input": 2.5,
-      "output": 15,
-      "cached_input": 0.25
     },
     {
       "provider": "Google/Gemini",
@@ -5837,6 +5971,20 @@
     },
     {
       "provider": "Google/Gemini",
+      "model": "gemini-3.5-transcribe",
+      "variant": "",
+      "input": 2,
+      "output": 12
+    },
+    {
+      "provider": "Google/Gemini",
+      "model": "gemini-3.5-transcribe-live",
+      "variant": "",
+      "input": 3.5,
+      "output": 21
+    },
+    {
+      "provider": "Google/Gemini",
       "model": "gemini-3.6-flash",
       "variant": "",
       "input": 0.75,
@@ -5960,9 +6108,16 @@
       "provider": "Google/Gemini",
       "model": "gemini-live-2.5-flash-preview-native-audio-09-2025",
       "variant": "",
-      "input": 0.3,
+      "input": 0.5,
       "output": 2,
       "cached_input": 0.075
+    },
+    {
+      "provider": "Google/Gemini",
+      "model": "gemini-omni-1.1-flash",
+      "variant": "",
+      "input": 1.5,
+      "output": 9
     },
     {
       "provider": "Google/Gemini",
@@ -6016,6 +6171,20 @@
       "variant": "",
       "input": 2,
       "output": 10
+    },
+    {
+      "provider": "Google/Gemini",
+      "model": "nano-banana-pro-preview",
+      "variant": "",
+      "input": 2,
+      "output": 12
+    },
+    {
+      "provider": "Google/Gemini",
+      "model": "nano-banana-pro-preview",
+      "variant": "batches",
+      "input": 1,
+      "output": 6
     },
     {
       "provider": "Google/Vertex",
@@ -6107,7 +6276,7 @@
       "variant": "",
       "input": 0.1,
       "output": 0.4,
-      "cached_input": 0.025
+      "cached_input": 0.01
     },
     {
       "provider": "Google/Vertex",
@@ -6123,7 +6292,7 @@
       "variant": "",
       "input": 0.3,
       "output": 2.5,
-      "cached_input": 0.075
+      "cached_input": 0.03
     },
     {
       "provider": "Google/Vertex",
@@ -6145,17 +6314,9 @@
       "provider": "Google/Vertex",
       "model": "gemini-2.5-pro-preview-tts",
       "variant": "",
-      "input": 1.25,
-      "output": 10,
+      "input": 1,
+      "output": 20,
       "cached_input": 0.125
-    },
-    {
-      "provider": "Google/Vertex",
-      "model": "gemini-2.5-pro-preview-tts",
-      "variant": "above_200k_tokens",
-      "input": 2.5,
-      "output": 15,
-      "cached_input": 0.25
     },
     {
       "provider": "Google/Vertex",
@@ -6422,7 +6583,7 @@
       "variant": "flex",
       "input": 0.15,
       "output": 1.25,
-      "cached_input": 0.02
+      "cached_input": 0.015
     },
     {
       "provider": "Google/Vertex",
@@ -6496,9 +6657,16 @@
     },
     {
       "provider": "Google/Vertex",
+      "model": "gemini-live-2.5-flash-native-audio",
+      "variant": "",
+      "input": 0.5,
+      "output": 2
+    },
+    {
+      "provider": "Google/Vertex",
       "model": "gemini-live-2.5-flash-preview-native-audio-09-2025",
       "variant": "",
-      "input": 0.3,
+      "input": 0.5,
       "output": 2,
       "cached_input": 0.075
     },
@@ -6656,7 +6824,7 @@
       "variant": "flex",
       "input": 0.15,
       "output": 1.25,
-      "cached_input": 0.02
+      "cached_input": 0.015
     },
     {
       "provider": "Google/Vertex",
@@ -6769,6 +6937,13 @@
       "output": 3
     },
     {
+      "provider": "Groq",
+      "model": "qwen/qwen3.8-27b",
+      "variant": "",
+      "input": 0.8,
+      "output": 4
+    },
+    {
       "provider": "Mistral",
       "model": "codestral-2405",
       "variant": "",
@@ -6780,26 +6955,30 @@
       "model": "codestral-2508",
       "variant": "",
       "input": 0.3,
-      "output": 0.9
+      "output": 0.9,
+      "cached_input": 0.03
     },
     {
       "provider": "Mistral",
       "model": "codestral-embed",
       "variant": "",
-      "input": 0.15
+      "input": 0.15,
+      "cached_input": 0.015
     },
     {
       "provider": "Mistral",
       "model": "codestral-embed-2505",
       "variant": "",
-      "input": 0.15
+      "input": 0.15,
+      "cached_input": 0.015
     },
     {
       "provider": "Mistral",
       "model": "codestral-latest",
       "variant": "",
       "input": 0.3,
-      "output": 0.9
+      "output": 0.9,
+      "cached_input": 0.03
     },
     {
       "provider": "Mistral",
@@ -6923,42 +7102,104 @@
     },
     {
       "provider": "Mistral",
-      "model": "ministral-3-14b-2512",
+      "model": "ministral-14b-2512",
       "variant": "",
       "input": 0.2,
       "output": 0.2
     },
     {
       "provider": "Mistral",
+      "model": "ministral-14b-latest",
+      "variant": "",
+      "input": 0.2,
+      "output": 0.2
+    },
+    {
+      "provider": "Mistral",
+      "model": "ministral-3-14b-2512",
+      "variant": "",
+      "input": 0.2,
+      "output": 0.2,
+      "cached_input": 0.02
+    },
+    {
+      "provider": "Mistral",
       "model": "ministral-3-3b-2512",
       "variant": "",
       "input": 0.1,
-      "output": 0.1
+      "output": 0.1,
+      "cached_input": 0.01
     },
     {
       "provider": "Mistral",
       "model": "ministral-3-8b-2512",
       "variant": "",
       "input": 0.15,
-      "output": 0.15
+      "output": 0.15,
+      "cached_input": 0.015
+    },
+    {
+      "provider": "Mistral",
+      "model": "ministral-3b-2512",
+      "variant": "",
+      "input": 0.1,
+      "output": 0.1
+    },
+    {
+      "provider": "Mistral",
+      "model": "ministral-3b-latest",
+      "variant": "",
+      "input": 0.1,
+      "output": 0.1
     },
     {
       "provider": "Mistral",
       "model": "ministral-8b-2512",
       "variant": "",
       "input": 0.15,
-      "output": 0.15
+      "output": 0.15,
+      "cached_input": 0.015
     },
     {
       "provider": "Mistral",
       "model": "ministral-8b-latest",
       "variant": "",
       "input": 0.15,
-      "output": 0.15
+      "output": 0.15,
+      "cached_input": 0.015
+    },
+    {
+      "provider": "Mistral",
+      "model": "mistral-code-agent-latest",
+      "variant": "",
+      "input": 0.4,
+      "output": 2
+    },
+    {
+      "provider": "Mistral",
+      "model": "mistral-code-fim-latest",
+      "variant": "",
+      "input": 0.3,
+      "output": 0.9,
+      "cached_input": 0.03
+    },
+    {
+      "provider": "Mistral",
+      "model": "mistral-code-latest",
+      "variant": "",
+      "input": 0.3,
+      "output": 0.9,
+      "cached_input": 0.03
     },
     {
       "provider": "Mistral",
       "model": "mistral-embed",
+      "variant": "",
+      "input": 0.1
+    },
+    {
+      "provider": "Mistral",
+      "model": "mistral-embed-2312",
       "variant": "",
       "input": 0.1
     },
@@ -6988,21 +7229,24 @@
       "model": "mistral-large-2512",
       "variant": "",
       "input": 0.5,
-      "output": 1.5
+      "output": 1.5,
+      "cached_input": 0.05
     },
     {
       "provider": "Mistral",
       "model": "mistral-large-3",
       "variant": "",
       "input": 0.5,
-      "output": 1.5
+      "output": 1.5,
+      "cached_input": 0.05
     },
     {
       "provider": "Mistral",
       "model": "mistral-large-latest",
       "variant": "",
       "input": 0.5,
-      "output": 1.5
+      "output": 1.5,
+      "cached_input": 0.05
     },
     {
       "provider": "Mistral",
@@ -7037,6 +7281,14 @@
       "model": "mistral-medium-2604",
       "variant": "",
       "input": 1.5,
+      "output": 7.5,
+      "cached_input": 0.15
+    },
+    {
+      "provider": "Mistral",
+      "model": "mistral-medium-3",
+      "variant": "",
+      "input": 1.5,
       "output": 7.5
     },
     {
@@ -7051,14 +7303,24 @@
       "model": "mistral-medium-3-5",
       "variant": "",
       "input": 1.5,
-      "output": 7.5
+      "output": 7.5,
+      "cached_input": 0.15
+    },
+    {
+      "provider": "Mistral",
+      "model": "mistral-medium-3.5",
+      "variant": "",
+      "input": 1.5,
+      "output": 7.5,
+      "cached_input": 0.15
     },
     {
       "provider": "Mistral",
       "model": "mistral-medium-latest",
       "variant": "",
       "input": 1.5,
-      "output": 7.5
+      "output": 7.5,
+      "cached_input": 0.15
     },
     {
       "provider": "Mistral",
@@ -7072,7 +7334,8 @@
       "model": "mistral-small-2603",
       "variant": "",
       "input": 0.15,
-      "output": 0.6
+      "output": 0.6,
+      "cached_input": 0.015
     },
     {
       "provider": "Mistral",
@@ -7086,7 +7349,8 @@
       "model": "mistral-small-latest",
       "variant": "",
       "input": 0.15,
-      "output": 0.6
+      "output": 0.6,
+      "cached_input": 0.015
     },
     {
       "provider": "Mistral",
@@ -7094,6 +7358,30 @@
       "variant": "",
       "input": 0.25,
       "output": 0.25
+    },
+    {
+      "provider": "Mistral",
+      "model": "mistral-vibe-cli-fast",
+      "variant": "",
+      "input": 0.15,
+      "output": 0.6,
+      "cached_input": 0.015
+    },
+    {
+      "provider": "Mistral",
+      "model": "mistral-vibe-cli-latest",
+      "variant": "",
+      "input": 1.5,
+      "output": 7.5,
+      "cached_input": 0.15
+    },
+    {
+      "provider": "Mistral",
+      "model": "mistral-vibe-cli-with-tools",
+      "variant": "",
+      "input": 1.5,
+      "output": 7.5,
+      "cached_input": 0.15
     },
     {
       "provider": "Mistral",
@@ -7157,6 +7445,20 @@
       "variant": "",
       "input": 2,
       "output": 6
+    },
+    {
+      "provider": "Mistral",
+      "model": "voxtral-small-2507",
+      "variant": "",
+      "input": 0.1,
+      "output": 0.4
+    },
+    {
+      "provider": "Mistral",
+      "model": "voxtral-small-latest",
+      "variant": "",
+      "input": 0.1,
+      "output": 0.4
     },
     {
       "provider": "Mistral",

--- a/chatlas/types/anthropic/_submit.py
+++ b/chatlas/types/anthropic/_submit.py
@@ -46,6 +46,8 @@ class SubmitInputArgs(TypedDict, total=False):
     messages: Iterable[anthropic.types.message_param.MessageParam]
     model: Union[
         Literal[
+            "claude-fable-5-1",
+            "claude-mythos-5-1",
             "claude-sonnet-5",
             "claude-fable-5",
             "claude-mythos-5",

--- a/chatlas/types/openai/_submit.py
+++ b/chatlas/types/openai/_submit.py
@@ -41,6 +41,7 @@ class SubmitInputArgs(TypedDict, total=False):
     model: Union[
         str,
         Literal[
+            "gpt-6-astra",
             "gpt-5.6-sol",
             "gpt-5.6-terra",
             "gpt-5.6-luna",

--- a/chatlas/types/openai/_submit_responses.py
+++ b/chatlas/types/openai/_submit_responses.py
@@ -18,6 +18,7 @@ import openai.types.responses.namespace_tool_param
 import openai.types.responses.response_code_interpreter_tool_call_param
 import openai.types.responses.response_compaction_item_param_param
 import openai.types.responses.response_computer_tool_call_param
+import openai.types.responses.response_configuration_update_item_param_param
 import openai.types.responses.response_conversation_param_param
 import openai.types.responses.response_create_params
 import openai.types.responses.response_custom_tool_call_output_param
@@ -90,6 +91,7 @@ class SubmitInputArgs(TypedDict, total=False):
                 openai.types.responses.response_input_param.ToolSearchCall,
                 openai.types.responses.response_tool_search_output_item_param_param.ResponseToolSearchOutputItemParamParam,
                 openai.types.responses.response_input_param.AdditionalTools,
+                openai.types.responses.response_configuration_update_item_param_param.ResponseConfigurationUpdateItemParamParam,
                 openai.types.responses.response_reasoning_item_param.ResponseReasoningItemParam,
                 openai.types.responses.response_compaction_item_param_param.ResponseCompactionItemParamParam,
                 openai.types.responses.response_input_param.ImageGenerationCall,
@@ -121,6 +123,7 @@ class SubmitInputArgs(TypedDict, total=False):
     model: Union[
         str,
         Literal[
+            "gpt-6-astra",
             "gpt-5.6-sol",
             "gpt-5.6-terra",
             "gpt-5.6-luna",

--- a/tests/_vcr/test_provider_huggingface/test_huggingface_respects_turns_interface.yaml
+++ b/tests/_vcr/test_provider_huggingface/test_huggingface_respects_turns_interface.yaml
@@ -2,22 +2,22 @@ interactions:
 - request:
     body: '{"messages": [{"content": "Return very minimal output, AND ONLY USE UPPERCASE.",
       "role": "system"}, {"content": [{"type": "text", "text": "What is the name of
-      Winnie the Pooh''s human friend?"}], "role": "user"}], "model": "meta-llama/Llama-3.1-8B-Instruct",
+      Winnie the Pooh''s human friend?"}], "role": "user"}], "model": "Qwen/Qwen3-235B-A22B-Instruct-2507",
       "stream": true, "stream_options": {"include_usage": true}}'
     headers:
-      Accept:
+      accept:
       - application/json
-      Accept-Encoding:
+      accept-encoding:
       - gzip, deflate
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '298'
-      Content-Type:
+      content-length:
+      - '300'
+      content-type:
       - application/json
-      Host:
+      host:
       - router.huggingface.co
-      X-Stainless-Async:
+      x-stainless-async:
       - 'false'
       x-stainless-read-timeout:
       - '600'
@@ -25,97 +25,120 @@ interactions:
     uri: https://router.huggingface.co/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-3938b3f3-b067-4dfa-989b-70e58dd89e80","choices":[{"delta":{"role":"assistant"},"index":0}],"created":1767213634,"model":"llama3.1-8b","system_fingerprint":"fp_2df2c50ce520692a7dce","object":"chat.completion.chunk"}
+      string: 'data: {"id":"chatcmpl-795d4206-5da9-4b77-a50e-eb833ea4f2a0","object":"chat.completion.chunk","created":1788482532,"model":"qwen3-235b-a22b-instruct-2507","choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning_content":null},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-3938b3f3-b067-4dfa-989b-70e58dd89e80","choices":[{"delta":{"content":"CHR"},"index":0}],"created":1767213634,"model":"llama3.1-8b","system_fingerprint":"fp_2df2c50ce520692a7dce","object":"chat.completion.chunk"}
+        data: {"id":"chatcmpl-795d4206-5da9-4b77-a50e-eb833ea4f2a0","object":"chat.completion.chunk","created":1788482532,"model":"qwen3-235b-a22b-instruct-2507","choices":[{"index":0,"delta":{"content":"CHR","reasoning_content":null},"logprobs":null,"finish_reason":null,"token_ids":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-3938b3f3-b067-4dfa-989b-70e58dd89e80","choices":[{"delta":{"content":"ISTOPHER
-        ROBIN."},"index":0}],"created":1767213634,"model":"llama3.1-8b","system_fingerprint":"fp_2df2c50ce520692a7dce","object":"chat.completion.chunk"}
+        data: {"id":"chatcmpl-795d4206-5da9-4b77-a50e-eb833ea4f2a0","object":"chat.completion.chunk","created":1788482532,"model":"qwen3-235b-a22b-instruct-2507","choices":[{"index":0,"delta":{"content":"IST","reasoning_content":null},"logprobs":null,"finish_reason":null,"token_ids":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-3938b3f3-b067-4dfa-989b-70e58dd89e80","choices":[{"delta":{},"finish_reason":"stop","index":0}],"created":1767213634,"model":"llama3.1-8b","system_fingerprint":"fp_2df2c50ce520692a7dce","object":"chat.completion.chunk","usage":{"total_tokens":70,"completion_tokens":8,"prompt_tokens":62,"prompt_tokens_details":{"cached_tokens":0}},"time_info":{"queue_time":0.0000397,"prompt_time":0.003675159,"completion_time":0.00311883,"total_time":0.00815582275390625,"created":1767213634.068277}}
+        data: {"id":"chatcmpl-795d4206-5da9-4b77-a50e-eb833ea4f2a0","object":"chat.completion.chunk","created":1788482532,"model":"qwen3-235b-a22b-instruct-2507","choices":[{"index":0,"delta":{"content":"OP","reasoning_content":null},"logprobs":null,"finish_reason":null,"token_ids":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-795d4206-5da9-4b77-a50e-eb833ea4f2a0","object":"chat.completion.chunk","created":1788482532,"model":"qwen3-235b-a22b-instruct-2507","choices":[{"index":0,"delta":{"content":"HER","reasoning_content":null},"logprobs":null,"finish_reason":null,"token_ids":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-795d4206-5da9-4b77-a50e-eb833ea4f2a0","object":"chat.completion.chunk","created":1788482532,"model":"qwen3-235b-a22b-instruct-2507","choices":[{"index":0,"delta":{"content":"
+        RO","reasoning_content":null},"logprobs":null,"finish_reason":null,"token_ids":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-795d4206-5da9-4b77-a50e-eb833ea4f2a0","object":"chat.completion.chunk","created":1788482532,"model":"qwen3-235b-a22b-instruct-2507","choices":[{"index":0,"delta":{"content":"BIN","reasoning_content":null},"logprobs":null,"finish_reason":null,"token_ids":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-795d4206-5da9-4b77-a50e-eb833ea4f2a0","object":"chat.completion.chunk","created":1788482532,"model":"qwen3-235b-a22b-instruct-2507","choices":[{"index":0,"delta":{"content":"","reasoning_content":null},"logprobs":null,"finish_reason":"stop","stop_reason":null,"token_ids":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-795d4206-5da9-4b77-a50e-eb833ea4f2a0","object":"chat.completion.chunk","created":1788482532,"model":"qwen3-235b-a22b-instruct-2507","choices":[],"usage":{"prompt_tokens":40,"total_tokens":47,"completion_tokens":7}}
+
+
+        data: [DONE]
 
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-credentials:
+      - 'true'
+      access-control-allow-headers:
+      - User-Agent,X-Requested-With,X-Forwarded-For,If-Modified-Since,Cache-Control,Content-Type,
+        Range,Authorization,Access-Control-Allow-Origin,Referer,X-Stainless-Os,X-Stainless-Runtime,
+        X-Stainless-Runtime-Version,X-Stainless-Arch,X-Stainless-Lang,X-Stainless-Package-Version,
+        X-Stainless-Retry-Count,X-Stainless-Timeout
+      access-control-allow-methods:
+      - GET, POST, OPTIONS
+      access-control-allow-origin:
       - '*'
-      Access-Control-Expose-Headers:
+      access-control-expose-headers:
       - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,X-Total-Count,ETag,Link,Accept-Ranges,Content-Range,X-Linked-Size,X-Linked-ETag,X-Xet-Hash
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-type:
       - text/event-stream; charset=utf-8
-      Date:
-      - Wed, 31 Dec 2025 20:40:32 GMT
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Origin
-      Via:
-      - 1.1 43d5c5ecf18f23d15311f4b123f7fa1e.cloudfront.net (CloudFront)
-      X-Amz-Cf-Id:
-      - UrGNgJgoLn-zcUhgbdpUT0jQZ0mLAcu-KduomXhRKs4fbpQXiZ7xrQ==
-      X-Amz-Cf-Pop:
-      - MSP50-P2
-      X-Cache:
-      - Miss from cloudfront
-      X-Powered-By:
-      - huggingface-moon
-      X-Robots-Tag:
-      - none
-      cf-cache-status:
-      - DYNAMIC
       cross-origin-opener-policy:
       - same-origin
-      inference-id:
-      - chatcmpl-3938b3f3-b067-4dfa-989b-70e58dd89e80
+      date:
+      - Fri, 04 Sep 2026 00:42:12 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
       server:
-      - cloudflare
+      - envoy
       strict-transport-security:
-      - max-age=3600; includeSubDomains
-      x-content-type-options:
-      - nosniff
+      - max-age=31536000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      via:
+      - 1.1 990606ab91bf6503d073ad5fee40784c.cloudfront.net (CloudFront)
+      x-amz-cf-id:
+      - i-OyPw11KVGuVebXOYeMNgmckPIVKkR_wUBaUfu4NF52tWzdw5rQcg==
+      x-amz-cf-pop:
+      - MSP50-P2
+      x-cache:
+      - Miss from cloudfront
+      x-envoy-upstream-service-time:
+      - '67'
       x-inference-provider:
-      - cerebras
-      x-ratelimit-remaining-requests-day:
-      - '2879997'
-      x-ratelimit-remaining-requests-hour:
-      - '119997'
-      x-ratelimit-remaining-requests-minute:
-      - '1997'
-      x-ratelimit-remaining-tokens-day:
-      - '9223372036854767616'
-      x-ratelimit-remaining-tokens-hour:
-      - '9223372036854767616'
-      x-ratelimit-remaining-tokens-minute:
-      - '9223372036854767616'
+      - scaleway
+      x-powered-by:
+      - huggingface-moon
+      x-ratelimit-limit-requests:
+      - '600'
+      x-ratelimit-limit-tokens:
+      - '1000000'
+      x-ratelimit-remaining-requests:
+      - '299'
+      x-ratelimit-remaining-tokens:
+      - '499999'
+      x-ratelimit-reset-requests:
+      - 100ms
+      x-ratelimit-reset-tokens:
+      - 0ms
+      x-robots-tag:
+      - none
     status:
       code: 200
       message: OK
 - request:
     body: '{"messages": [{"content": "Return very minimal output, AND ONLY USE UPPERCASE.",
       "role": "system"}, {"content": [{"type": "text", "text": "What is the name of
-      Winnie the Pooh''s human friend?"}], "role": "user"}], "model": "meta-llama/Llama-3.1-8B-Instruct",
+      Winnie the Pooh''s human friend?"}], "role": "user"}], "model": "Qwen/Qwen3-235B-A22B-Instruct-2507",
       "stream": true, "stream_options": {"include_usage": true}}'
     headers:
-      Accept:
+      accept:
       - application/json
-      Accept-Encoding:
+      accept-encoding:
       - gzip, deflate
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '298'
-      Content-Type:
+      content-length:
+      - '300'
+      content-type:
       - application/json
-      Host:
+      host:
       - router.huggingface.co
-      X-Stainless-Async:
+      x-stainless-async:
       - 'false'
       x-stainless-read-timeout:
       - '600'
@@ -123,75 +146,98 @@ interactions:
     uri: https://router.huggingface.co/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-770494fa-4f97-4a6a-94f7-b46a99c3b7ec","choices":[{"delta":{"role":"assistant"},"index":0}],"created":1767213634,"model":"llama3.1-8b","system_fingerprint":"fp_2df2c50ce520692a7dce","object":"chat.completion.chunk"}
+      string: 'data: {"id":"chatcmpl-c1d45839-f939-4b8e-b22d-ca00a4f53b08","object":"chat.completion.chunk","created":1788482532,"model":"qwen3-235b-a22b-instruct-2507","choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning_content":null},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-770494fa-4f97-4a6a-94f7-b46a99c3b7ec","choices":[{"delta":{"content":"CHR"},"index":0}],"created":1767213634,"model":"llama3.1-8b","system_fingerprint":"fp_2df2c50ce520692a7dce","object":"chat.completion.chunk"}
+        data: {"id":"chatcmpl-c1d45839-f939-4b8e-b22d-ca00a4f53b08","object":"chat.completion.chunk","created":1788482532,"model":"qwen3-235b-a22b-instruct-2507","choices":[{"index":0,"delta":{"content":"CHR","reasoning_content":null},"logprobs":null,"finish_reason":null,"token_ids":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-770494fa-4f97-4a6a-94f7-b46a99c3b7ec","choices":[{"delta":{"content":"ISTOPHER
-        ROBIN."},"index":0}],"created":1767213634,"model":"llama3.1-8b","system_fingerprint":"fp_2df2c50ce520692a7dce","object":"chat.completion.chunk"}
+        data: {"id":"chatcmpl-c1d45839-f939-4b8e-b22d-ca00a4f53b08","object":"chat.completion.chunk","created":1788482532,"model":"qwen3-235b-a22b-instruct-2507","choices":[{"index":0,"delta":{"content":"IST","reasoning_content":null},"logprobs":null,"finish_reason":null,"token_ids":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-770494fa-4f97-4a6a-94f7-b46a99c3b7ec","choices":[{"delta":{},"finish_reason":"stop","index":0}],"created":1767213634,"model":"llama3.1-8b","system_fingerprint":"fp_2df2c50ce520692a7dce","object":"chat.completion.chunk","usage":{"total_tokens":70,"completion_tokens":8,"prompt_tokens":62,"prompt_tokens_details":{"cached_tokens":0}},"time_info":{"queue_time":0.000162471,"prompt_time":0.00275803,"completion_time":0.003120066,"total_time":0.007386922836303711,"created":1767213634.6693082}}
+        data: {"id":"chatcmpl-c1d45839-f939-4b8e-b22d-ca00a4f53b08","object":"chat.completion.chunk","created":1788482532,"model":"qwen3-235b-a22b-instruct-2507","choices":[{"index":0,"delta":{"content":"OP","reasoning_content":null},"logprobs":null,"finish_reason":null,"token_ids":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-c1d45839-f939-4b8e-b22d-ca00a4f53b08","object":"chat.completion.chunk","created":1788482532,"model":"qwen3-235b-a22b-instruct-2507","choices":[{"index":0,"delta":{"content":"HER","reasoning_content":null},"logprobs":null,"finish_reason":null,"token_ids":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-c1d45839-f939-4b8e-b22d-ca00a4f53b08","object":"chat.completion.chunk","created":1788482532,"model":"qwen3-235b-a22b-instruct-2507","choices":[{"index":0,"delta":{"content":"
+        RO","reasoning_content":null},"logprobs":null,"finish_reason":null,"token_ids":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-c1d45839-f939-4b8e-b22d-ca00a4f53b08","object":"chat.completion.chunk","created":1788482532,"model":"qwen3-235b-a22b-instruct-2507","choices":[{"index":0,"delta":{"content":"BIN","reasoning_content":null},"logprobs":null,"finish_reason":null,"token_ids":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-c1d45839-f939-4b8e-b22d-ca00a4f53b08","object":"chat.completion.chunk","created":1788482532,"model":"qwen3-235b-a22b-instruct-2507","choices":[{"index":0,"delta":{"content":"","reasoning_content":null},"logprobs":null,"finish_reason":"stop","stop_reason":null,"token_ids":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-c1d45839-f939-4b8e-b22d-ca00a4f53b08","object":"chat.completion.chunk","created":1788482532,"model":"qwen3-235b-a22b-instruct-2507","choices":[],"usage":{"prompt_tokens":40,"total_tokens":47,"completion_tokens":7}}
+
+
+        data: [DONE]
 
 
         '
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-credentials:
+      - 'true'
+      access-control-allow-headers:
+      - User-Agent,X-Requested-With,X-Forwarded-For,If-Modified-Since,Cache-Control,Content-Type,
+        Range,Authorization,Access-Control-Allow-Origin,Referer,X-Stainless-Os,X-Stainless-Runtime,
+        X-Stainless-Runtime-Version,X-Stainless-Arch,X-Stainless-Lang,X-Stainless-Package-Version,
+        X-Stainless-Retry-Count,X-Stainless-Timeout
+      access-control-allow-methods:
+      - GET, POST, OPTIONS
+      access-control-allow-origin:
       - '*'
-      Access-Control-Expose-Headers:
+      access-control-expose-headers:
       - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,X-Total-Count,ETag,Link,Accept-Ranges,Content-Range,X-Linked-Size,X-Linked-ETag,X-Xet-Hash
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-type:
       - text/event-stream; charset=utf-8
-      Date:
-      - Wed, 31 Dec 2025 20:40:32 GMT
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Origin
-      Via:
-      - 1.1 8668391dce76a5e01d23980e8e8d3454.cloudfront.net (CloudFront)
-      X-Amz-Cf-Id:
-      - XZrk9wVTFah0nlBBBzgAU4glR5CV1Sh_9HbQ7EBONgg1ffCwZA12pw==
-      X-Amz-Cf-Pop:
-      - MSP50-P2
-      X-Cache:
-      - Miss from cloudfront
-      X-Powered-By:
-      - huggingface-moon
-      X-Robots-Tag:
-      - none
-      cf-cache-status:
-      - DYNAMIC
       cross-origin-opener-policy:
       - same-origin
-      inference-id:
-      - chatcmpl-770494fa-4f97-4a6a-94f7-b46a99c3b7ec
+      date:
+      - Fri, 04 Sep 2026 00:42:12 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
       server:
-      - cloudflare
+      - envoy
       strict-transport-security:
-      - max-age=3600; includeSubDomains
-      x-content-type-options:
-      - nosniff
+      - max-age=31536000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      via:
+      - 1.1 48a0ac8b67842a09a9b585c294dc3108.cloudfront.net (CloudFront)
+      x-amz-cf-id:
+      - R7Cg5FA8R18vIH8pb2QvD4MWmhAwo8jAAbAmnRS5A4u2GvsTrd23mQ==
+      x-amz-cf-pop:
+      - MSP50-P2
+      x-cache:
+      - Miss from cloudfront
+      x-envoy-upstream-service-time:
+      - '63'
       x-inference-provider:
-      - cerebras
-      x-ratelimit-remaining-requests-day:
-      - '2879996'
-      x-ratelimit-remaining-requests-hour:
-      - '119996'
-      x-ratelimit-remaining-requests-minute:
-      - '1996'
-      x-ratelimit-remaining-tokens-day:
-      - '9223372036854767616'
-      x-ratelimit-remaining-tokens-hour:
-      - '9223372036854767616'
-      x-ratelimit-remaining-tokens-minute:
-      - '9223372036854767616'
+      - scaleway
+      x-powered-by:
+      - huggingface-moon
+      x-ratelimit-limit-requests:
+      - '600'
+      x-ratelimit-limit-tokens:
+      - '1000000'
+      x-ratelimit-remaining-requests:
+      - '299'
+      x-ratelimit-remaining-tokens:
+      - '499999'
+      x-ratelimit-reset-requests:
+      - 100ms
+      x-ratelimit-reset-tokens:
+      - 0ms
+      x-robots-tag:
+      - none
     status:
       code: 200
       message: OK
@@ -199,22 +245,22 @@ interactions:
     body: '{"messages": [{"content": [{"type": "text", "text": "My name is Steve"}],
       "role": "user"}, {"role": "assistant", "content": [{"type": "text", "text":
       "Hello Steve, how can I help you today?"}]}, {"content": [{"type": "text", "text":
-      "What is my name?"}], "role": "user"}], "model": "meta-llama/Llama-3.1-8B-Instruct",
+      "What is my name?"}], "role": "user"}], "model": "Qwen/Qwen3-235B-A22B-Instruct-2507",
       "stream": true, "stream_options": {"include_usage": true}}'
     headers:
-      Accept:
+      accept:
       - application/json
-      Accept-Encoding:
+      accept-encoding:
       - gzip, deflate
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
-      - '348'
-      Content-Type:
+      content-length:
+      - '350'
+      content-type:
       - application/json
-      Host:
+      host:
       - router.huggingface.co
-      X-Stainless-Async:
+      x-stainless-async:
       - 'false'
       x-stainless-read-timeout:
       - '600'
@@ -222,75 +268,81 @@ interactions:
     uri: https://router.huggingface.co/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-6bda916f-edda-4aa4-afbb-721ae7e5f169","choices":[{"delta":{"role":"assistant"},"index":0}],"created":1767213635,"model":"llama3.1-8b","system_fingerprint":"fp_2df2c50ce520692a7dce","object":"chat.completion.chunk"}
-
-
-        data: {"id":"chatcmpl-6bda916f-edda-4aa4-afbb-721ae7e5f169","choices":[{"delta":{"content":"Your"},"index":0}],"created":1767213635,"model":"llama3.1-8b","system_fingerprint":"fp_2df2c50ce520692a7dce","object":"chat.completion.chunk"}
-
-
-        data: {"id":"chatcmpl-6bda916f-edda-4aa4-afbb-721ae7e5f169","choices":[{"delta":{"content":"
-        name is Steve."},"index":0}],"created":1767213635,"model":"llama3.1-8b","system_fingerprint":"fp_2df2c50ce520692a7dce","object":"chat.completion.chunk"}
-
-
-        data: {"id":"chatcmpl-6bda916f-edda-4aa4-afbb-721ae7e5f169","choices":[{"delta":{},"finish_reason":"stop","index":0}],"created":1767213635,"model":"llama3.1-8b","system_fingerprint":"fp_2df2c50ce520692a7dce","object":"chat.completion.chunk","usage":{"total_tokens":70,"completion_tokens":6,"prompt_tokens":64,"prompt_tokens_details":{"cached_tokens":0}},"time_info":{"queue_time":0.00013735,"prompt_time":0.003542346,"completion_time":0.002342371,"total_time":0.00757908821105957,"created":1767213635.3406544}}
-
-
-        '
+      string: "data: {\"id\":\"chatcmpl-b38b34f5-7d71-4814-bf0f-d27ff16b712f\",\"object\":\"chat.completion.chunk\",\"created\":1788482532,\"model\":\"qwen3-235b-a22b-instruct-2507\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\",\"reasoning_content\":null},\"logprobs\":null,\"finish_reason\":null}],\"usage\":null}\n\ndata:
+        {\"id\":\"chatcmpl-b38b34f5-7d71-4814-bf0f-d27ff16b712f\",\"object\":\"chat.completion.chunk\",\"created\":1788482532,\"model\":\"qwen3-235b-a22b-instruct-2507\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Your\",\"reasoning_content\":null},\"logprobs\":null,\"finish_reason\":null,\"token_ids\":null}],\"usage\":null}\n\ndata:
+        {\"id\":\"chatcmpl-b38b34f5-7d71-4814-bf0f-d27ff16b712f\",\"object\":\"chat.completion.chunk\",\"created\":1788482532,\"model\":\"qwen3-235b-a22b-instruct-2507\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
+        name\",\"reasoning_content\":null},\"logprobs\":null,\"finish_reason\":null,\"token_ids\":null}],\"usage\":null}\n\ndata:
+        {\"id\":\"chatcmpl-b38b34f5-7d71-4814-bf0f-d27ff16b712f\",\"object\":\"chat.completion.chunk\",\"created\":1788482532,\"model\":\"qwen3-235b-a22b-instruct-2507\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
+        is\",\"reasoning_content\":null},\"logprobs\":null,\"finish_reason\":null,\"token_ids\":null}],\"usage\":null}\n\ndata:
+        {\"id\":\"chatcmpl-b38b34f5-7d71-4814-bf0f-d27ff16b712f\",\"object\":\"chat.completion.chunk\",\"created\":1788482532,\"model\":\"qwen3-235b-a22b-instruct-2507\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
+        Steve\",\"reasoning_content\":null},\"logprobs\":null,\"finish_reason\":null,\"token_ids\":null}],\"usage\":null}\n\ndata:
+        {\"id\":\"chatcmpl-b38b34f5-7d71-4814-bf0f-d27ff16b712f\",\"object\":\"chat.completion.chunk\",\"created\":1788482532,\"model\":\"qwen3-235b-a22b-instruct-2507\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\".\",\"reasoning_content\":null},\"logprobs\":null,\"finish_reason\":null,\"token_ids\":null}],\"usage\":null}\n\ndata:
+        {\"id\":\"chatcmpl-b38b34f5-7d71-4814-bf0f-d27ff16b712f\",\"object\":\"chat.completion.chunk\",\"created\":1788482532,\"model\":\"qwen3-235b-a22b-instruct-2507\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"\",\"reasoning_content\":null},\"logprobs\":null,\"finish_reason\":null,\"token_ids\":null}],\"usage\":null}\n\ndata:
+        {\"id\":\"chatcmpl-b38b34f5-7d71-4814-bf0f-d27ff16b712f\",\"object\":\"chat.completion.chunk\",\"created\":1788482532,\"model\":\"qwen3-235b-a22b-instruct-2507\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"
+        \U0001F60A\",\"reasoning_content\":null},\"logprobs\":null,\"finish_reason\":null,\"token_ids\":null}],\"usage\":null}\n\ndata:
+        {\"id\":\"chatcmpl-b38b34f5-7d71-4814-bf0f-d27ff16b712f\",\"object\":\"chat.completion.chunk\",\"created\":1788482532,\"model\":\"qwen3-235b-a22b-instruct-2507\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"\",\"reasoning_content\":null},\"logprobs\":null,\"finish_reason\":\"stop\",\"stop_reason\":null,\"token_ids\":null}],\"usage\":null}\n\ndata:
+        {\"id\":\"chatcmpl-b38b34f5-7d71-4814-bf0f-d27ff16b712f\",\"object\":\"chat.completion.chunk\",\"created\":1788482532,\"model\":\"qwen3-235b-a22b-instruct-2507\",\"choices\":[],\"usage\":{\"prompt_tokens\":37,\"total_tokens\":45,\"completion_tokens\":8}}\n\ndata:
+        [DONE]\n\n"
     headers:
-      Access-Control-Allow-Origin:
+      access-control-allow-credentials:
+      - 'true'
+      access-control-allow-headers:
+      - User-Agent,X-Requested-With,X-Forwarded-For,If-Modified-Since,Cache-Control,Content-Type,
+        Range,Authorization,Access-Control-Allow-Origin,Referer,X-Stainless-Os,X-Stainless-Runtime,
+        X-Stainless-Runtime-Version,X-Stainless-Arch,X-Stainless-Lang,X-Stainless-Package-Version,
+        X-Stainless-Retry-Count,X-Stainless-Timeout
+      access-control-allow-methods:
+      - GET, POST, OPTIONS
+      access-control-allow-origin:
       - '*'
-      Access-Control-Expose-Headers:
+      access-control-expose-headers:
       - X-Repo-Commit,X-Request-Id,X-Error-Code,X-Error-Message,X-Total-Count,ETag,Link,Accept-Ranges,Content-Range,X-Linked-Size,X-Linked-ETag,X-Xet-Hash
-      Connection:
+      connection:
       - keep-alive
-      Content-Type:
+      content-type:
       - text/event-stream; charset=utf-8
-      Date:
-      - Wed, 31 Dec 2025 20:40:33 GMT
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Origin
-      Via:
-      - 1.1 24f41ad6cec46a6e94a3e850d746e294.cloudfront.net (CloudFront)
-      X-Amz-Cf-Id:
-      - iMln4YNOYhYEEYPjtv0dHYrDUjBdb0FdSNKkixC9aERUEhAIoTr8Kw==
-      X-Amz-Cf-Pop:
-      - MSP50-P2
-      X-Cache:
-      - Miss from cloudfront
-      X-Powered-By:
-      - huggingface-moon
-      X-Robots-Tag:
-      - none
-      cf-cache-status:
-      - DYNAMIC
       cross-origin-opener-policy:
       - same-origin
-      inference-id:
-      - chatcmpl-6bda916f-edda-4aa4-afbb-721ae7e5f169
+      date:
+      - Fri, 04 Sep 2026 00:42:13 GMT
       referrer-policy:
       - strict-origin-when-cross-origin
       server:
-      - cloudflare
+      - envoy
       strict-transport-security:
-      - max-age=3600; includeSubDomains
-      x-content-type-options:
-      - nosniff
+      - max-age=31536000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin
+      via:
+      - 1.1 ecac0584adf202eebfc7cd3800ff47ae.cloudfront.net (CloudFront)
+      x-amz-cf-id:
+      - imy3Nn0CnRlguV4sED_PFVEgSGNlDWW4dCOR9FPbTOk9vru846EI8g==
+      x-amz-cf-pop:
+      - MSP50-P2
+      x-cache:
+      - Miss from cloudfront
+      x-envoy-upstream-service-time:
+      - '44'
       x-inference-provider:
-      - cerebras
-      x-ratelimit-remaining-requests-day:
-      - '2879999'
-      x-ratelimit-remaining-requests-hour:
-      - '119999'
-      x-ratelimit-remaining-requests-minute:
-      - '1999'
-      x-ratelimit-remaining-tokens-day:
-      - '9223372036854767616'
-      x-ratelimit-remaining-tokens-hour:
-      - '9223372036854767616'
-      x-ratelimit-remaining-tokens-minute:
-      - '9223372036854767616'
+      - scaleway
+      x-powered-by:
+      - huggingface-moon
+      x-ratelimit-limit-requests:
+      - '600'
+      x-ratelimit-limit-tokens:
+      - '1000000'
+      x-ratelimit-remaining-requests:
+      - '299'
+      x-ratelimit-remaining-tokens:
+      - '499999'
+      x-ratelimit-reset-requests:
+      - 100ms
+      x-ratelimit-reset-tokens:
+      - 0ms
+      x-robots-tag:
+      - none
     status:
       code: 200
       message: OK


### PR DESCRIPTION
Closes #414.

Updates `ChatHuggingFace()`'s default model from `meta-llama/Llama-3.1-8B-Instruct` to `Qwen/Qwen3-235B-A22B-Instruct-2507`, matching ellmer's updated default (tidyverse/ellmer#1094).

Re-recorded the one VCR cassette that embeds the default model name in its request bodies (`test_huggingface_respects_turns_interface`). All HuggingFace provider tests pass.