### PR TITLE
fix(databricks): normalize typed delta.content before merging stream chunks

### DIFF
--- a/chatlas/_provider_databricks.py
+++ b/chatlas/_provider_databricks.py
@@ -187,14 +187,28 @@ class DatabricksProvider(OpenAICompletionsProvider):
     # GPT-OSS endpoints can return delta.content as a list of typed parts
     # instead of a plain string; normalize it in place, then reuse the base
     # class's existing string/reasoning handling.
+    @staticmethod
+    def _normalize_delta_content(delta: Any) -> None:
+        if delta is None or not isinstance(delta.content, list):
+            return
+        text, reasoning = _normalize_content_parts(delta.content)
+        delta.content = text
+        if reasoning:
+            setattr(delta, "reasoning", reasoning)
+
     def stream_content(self, chunk, completion, turns=()) -> list[Content]:
-        delta = chunk.choices[0].delta if chunk.choices else None
-        if delta is not None and isinstance(delta.content, list):
-            text, reasoning = _normalize_content_parts(delta.content)
-            delta.content = text
-            if reasoning:
-                setattr(delta, "reasoning", reasoning)
+        if chunk.choices:
+            self._normalize_delta_content(chunk.choices[0].delta)
         return super().stream_content(chunk, completion, turns)
+
+    # The streaming loop merges chunks before extracting content, so the same
+    # normalization must happen here too. Otherwise the inherited merger would
+    # serialize the typed list (emitting a PydanticSerializationUnexpectedValue
+    # warning) and let it pollute the accumulated completion.
+    def stream_merge_chunks(self, completion, chunk):
+        if chunk.choices:
+            self._normalize_delta_content(chunk.choices[0].delta)
+        return super().stream_merge_chunks(completion, chunk)
 
     # Same normalization for the non-streaming/completed-response path.
     @staticmethod

--- a/tests/test_provider_databricks.py
+++ b/tests/test_provider_databricks.py
@@ -285,3 +285,46 @@ def test_stream_content_preserves_plain_string_content():
         assert result == [ContentText(text="partial text")]
     finally:
         provider._client.close()
+
+
+def test_stream_merge_chunks_normalizes_typed_content_array():
+    """Typed delta.content lists are normalized before merging (#409)."""
+    import warnings
+
+    from openai.types.chat import ChatCompletionChunk
+    from openai.types.chat.chat_completion_chunk import ChoiceDelta
+
+    provider = _databricks_provider()
+    try:
+        typed_chunk = ChatCompletionChunk.model_construct(
+            choices=[
+                {
+                    "index": 0,
+                    "delta": ChoiceDelta.model_construct(
+                        content=[
+                            {
+                                "type": "reasoning",
+                                "summary": [{"text": "thinking"}],
+                            }
+                        ]
+                    ),
+                }
+            ]
+        )
+        text_chunk = ChatCompletionChunk.model_construct(
+            choices=[
+                {"index": 0, "delta": ChoiceDelta.model_construct(content="answer")}
+            ]
+        )
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            completion = provider.stream_merge_chunks(None, typed_chunk)
+            completion = provider.stream_merge_chunks(completion, text_chunk)
+
+        delta = completion["choices"][0]["delta"]
+        assert delta["content"] == "answer"
+        assert delta["reasoning"] == "thinking"
+        assert caught == []
+    finally:
+        provider._client.close()


### PR DESCRIPTION
Closes #409.

The streaming loop calls `stream_merge_chunks()` before `stream_content()`, so the inherited `OpenAICompletionsProvider.stream_merge_chunks()` called `chunk.model_dump()` on GPT-OSS chunks with list-valued `delta.content` — emitting a `PydanticSerializationUnexpectedValue` warning and letting the unnormalized list pollute the accumulated completion (a later string chunk's content got expanded into individual characters by generic list merging).

Fix: extract the normalization from `stream_content()` into a shared private helper (`_normalize_delta_content`) and call it from a new `stream_merge_chunks()` override before delegating to the inherited merger.

Includes a regression test merging a typed reasoning chunk followed by a string text chunk, asserting normalized accumulated `content`/`reasoning` and no serialization warning. Verified against the issue's reproduction script.