### PR TITLE
feat: add Chat.close()/close_async() lifecycle API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `Chat` gains `close()` and `close_async()` methods (plus context-manager support) for releasing resources held by the provider -- HTTP connection pools, the Snowflake Snowpark session/connection, and (via `close_async()`) MCP server sessions. This is useful in long-lived applications like Shiny that create a chat per user session: `session.on_ended(chat.close)`. Providers only close resources they created themselves; caller-supplied clients are left open.
 
+* `ChatSnowflake()` gains a `session` parameter for supplying an existing `snowflake.snowpark.Session`, mirroring `ChatDatabricks()`'s `workspace_client`. This lets one session be shared across multiple chats; `Chat.close()` only closes sessions that chatlas created itself, leaving caller-supplied sessions open.
+
 * When running on Posit Connect, chatlas now forwards the Shiny viewer's session token to Connect's LLM gateway (as a `Posit-Connect-User-Session-Token` header) so gateway usage can be attributed to the viewer. This happens automatically for Shiny content and only affects requests to the gateway.
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New features
 
+* `Chat` gains `close()` and `close_async()` methods (plus context-manager support) for releasing resources held by the provider -- HTTP connection pools, the Snowflake Snowpark session/connection, and (via `close_async()`) MCP server sessions. This is useful in long-lived applications like Shiny that create a chat per user session: `session.on_ended(chat.close)`. Providers only close resources they created themselves; caller-supplied clients are left open.
+
 * When running on Posit Connect, chatlas now forwards the Shiny viewer's session token to Connect's LLM gateway (as a `Posit-Connect-User-Session-Token` header) so gateway usage can be attributed to the viewer. This happens automatically for Shiny content and only affects requests to the gateway.
 
 ### Changes

--- a/chatlas/_chat.py
+++ b/chatlas/_chat.py
@@ -219,7 +219,8 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
 
         Safe to call multiple times. Providers only close resources they
         created themselves; clients or connections supplied by the caller are
-        left open.
+        left open. Emits a warning if MCP server sessions are still open,
+        since those can only be closed asynchronously.
 
         Examples
         --------
@@ -232,6 +233,14 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         session.on_ended(chat.close)
         ```
         """
+        if self._mcp_manager.has_open_sessions:
+            warnings.warn(
+                "Chat.close() cannot close MCP server sessions (that requires "
+                "close_async()); MCP sessions are still open. Use "
+                "`await chat.close_async()` instead, or close them first with "
+                "`await chat.cleanup_mcp_tools()`.",
+                stacklevel=2,
+            )
         self.provider.close()
 
     async def close_async(self) -> None:

--- a/chatlas/_chat.py
+++ b/chatlas/_chat.py
@@ -207,6 +207,57 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
         # Chat input parameters from `set_model_params()`
         self._standard_model_params: StandardModelParams = {}
 
+    def close(self) -> None:
+        """
+        Release resources held by this chat's provider (e.g., HTTP connection
+        pools, database sessions).
+
+        This is useful in long-lived applications (e.g., Shiny, FastAPI) that
+        create a `Chat` per session and need to release resources when the
+        session ends. Note that MCP server sessions can only be closed
+        asynchronously -- use `close_async()` if MCP tools are registered.
+
+        Safe to call multiple times. Providers only close resources they
+        created themselves; clients or connections supplied by the caller are
+        left open.
+
+        Examples
+        --------
+        In a Shiny app, close the chat when the session ends:
+
+        ```python
+        from chatlas import ChatSnowflake
+
+        chat = ChatSnowflake(model="llama3.1-70b")
+        session.on_ended(chat.close)
+        ```
+        """
+        self.provider.close()
+
+    async def close_async(self) -> None:
+        """
+        Asynchronous variant of `close()`.
+
+        In addition to releasing the provider's resources, this also closes
+        any MCP server sessions registered via
+        `register_mcp_tools_stdio_async()` or
+        `register_mcp_tools_http_stream_async()`.
+        """
+        await self._mcp_manager.close_sessions()
+        await self.provider.close_async()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self.close()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        await self.close_async()
+
     def list_models(self) -> list[ModelInfo]:
         """
         List all models available for the provider.
@@ -2648,7 +2699,7 @@ class Chat(Generic[SubmitInputArgsT, CompletionT]):
             raise ValueError("The filename must have a `.jsonl` extension.")
 
         if turns is None:
-            turns = cast(list[Turn], self.get_turns(include_system_prompt=False))
+            turns = self.get_turns(include_system_prompt=False)
 
         if any(isinstance(x, SystemTurn) for x in turns):
             raise ValueError("System prompts are not allowed in eval input turns.")

--- a/chatlas/_chat.py
+++ b/chatlas/_chat.py
@@ -24,7 +24,6 @@ from typing import (
     Sequence,
     TypeVar,
     Union,
-    cast,
     overload,
 )
 

--- a/chatlas/_mcp_manager.py
+++ b/chatlas/_mcp_manager.py
@@ -147,6 +147,11 @@ class MCPSessionManager:
     def __init__(self):
         self._mcp_sessions: dict[str, SessionInfo] = {}
 
+    @property
+    def has_open_sessions(self) -> bool:
+        """Whether any MCP server sessions are currently registered."""
+        return bool(self._mcp_sessions)
+
     async def register_http_stream_tools(
         self,
         *,

--- a/chatlas/_provider.py
+++ b/chatlas/_provider.py
@@ -197,6 +197,30 @@ class Provider(
     def model(self, value: str):
         self._model = value
 
+    def close(self) -> None:
+        """
+        Release resources held by this provider (e.g., HTTP connection pools,
+        database sessions).
+
+        This is best-effort and only closes synchronous resources; use
+        `close_async()` to also release asynchronous resources. Providers only
+        close resources they created themselves -- clients or connections
+        supplied by the caller are left open. Implementations must be safe to
+        call multiple times.
+
+        The default implementation does nothing.
+        """
+        pass
+
+    async def close_async(self) -> None:
+        """
+        Asynchronous variant of `close()`.
+
+        Releases both synchronous and asynchronous resources held by this
+        provider. The default implementation calls `close()`.
+        """
+        self.close()
+
     @abstractmethod
     def list_models(self) -> list[ModelInfo]:
         """

--- a/chatlas/_provider_anthropic.py
+++ b/chatlas/_provider_anthropic.py
@@ -403,6 +403,13 @@ class AnthropicProvider(
         self._client = Anthropic(**sync_kwargs)  # type: ignore
         self._async_client = AsyncAnthropic(**async_kwargs)
 
+    def close(self) -> None:
+        self._client.close()
+
+    async def close_async(self) -> None:
+        self.close()
+        await self._async_client.close()
+
     def list_models(self):
         models = self._client.models.list()
 

--- a/chatlas/_provider_bedrock_converse.py
+++ b/chatlas/_provider_bedrock_converse.py
@@ -447,6 +447,13 @@ class BedrockConverseProvider(
             auth=auth, base_url=resolved_base_url, **async_client_kwargs
         )
 
+    def close(self) -> None:
+        self._client.close()
+
+    async def close_async(self) -> None:
+        self.close()
+        await self._async_client.aclose()
+
     def list_models(self) -> list[ModelInfo]:
         # boto3 should come via the `bedrock` extra's `anthropic[bedrock]`,
         # same precondition as AnthropicBedrockProvider.list_models().

--- a/chatlas/_provider_databricks.py
+++ b/chatlas/_provider_databricks.py
@@ -97,7 +97,10 @@ def ChatDatabricks(
         choosing a model for all but the most casual use.
     workspace_client
         A `databricks.sdk.WorkspaceClient()` to use for the connection. If not
-        provided, a new client will be created.
+        provided, a new client will be created. Note that calling
+        [`Chat.close()`](`chatlas.Chat.close`) does not close a
+        caller-supplied `WorkspaceClient` -- it only closes the OpenAI-compatible
+        client that chatlas derives from it.
 
     Returns
     -------

--- a/chatlas/_provider_google.py
+++ b/chatlas/_provider_google.py
@@ -279,6 +279,16 @@ class GoogleProvider(
 
         self._client = genai.Client(**kwargs_full)
 
+    def close(self) -> None:
+        self._client.close()
+
+    async def close_async(self) -> None:
+        self.close()
+        # `aio.aclose()` was added in a later version of google-genai.
+        aclose = getattr(self._client.aio, "aclose", None)
+        if aclose is not None:
+            await aclose()
+
     def list_models(self):
         models = self._client.models.list()
 

--- a/chatlas/_provider_google.py
+++ b/chatlas/_provider_google.py
@@ -284,10 +284,7 @@ class GoogleProvider(
 
     async def close_async(self) -> None:
         self.close()
-        # `aio.aclose()` was added in a later version of google-genai.
-        aclose = getattr(self._client.aio, "aclose", None)
-        if aclose is not None:
-            await aclose()
+        await self._client.aio.aclose()
 
     def list_models(self):
         models = self._client.models.list()

--- a/chatlas/_provider_openai_generic.py
+++ b/chatlas/_provider_openai_generic.py
@@ -149,6 +149,13 @@ class OpenAIAbstractProvider(
         self._client = create_openai_client(OpenAI, sync_kwargs)
         self._async_client = create_openai_client(AsyncOpenAI, async_kwargs)
 
+    def close(self) -> None:
+        self._client.close()
+
+    async def close_async(self) -> None:
+        self.close()
+        await self._async_client.close()
+
     def list_models(self):
         return openai_models_to_info(self._client.models.list(), self.name)
 

--- a/chatlas/_provider_snowflake.py
+++ b/chatlas/_provider_snowflake.py
@@ -31,6 +31,7 @@ from ._utils import drop_none
 if TYPE_CHECKING:
     import snowflake.core.cortex.inference_service._generated.models as models
     from snowflake.core.rest import Event, SSEClient
+    from snowflake.snowpark import Session
 
     Completion = models.NonStreamingCompleteResponse
     CompletionChunk = models.StreamingCompleteResponseDataEvent
@@ -69,6 +70,7 @@ def ChatSnowflake(
     password: Optional[str] = None,
     private_key_file: Optional[str] = None,
     private_key_file_pwd: Optional[str] = None,
+    session: Optional["Session"] = None,
     kwargs: Optional[dict[str, "str | int"]] = None,
 ) -> Chat["CompleteRequest", "Completion"]:
     """
@@ -136,6 +138,13 @@ def ChatSnowflake(
     private_key_file_pwd
         The password for your private key file. Required if you are using key pair authentication.
         https://docs.snowflake.com/en/user-guide/key-pair-auth
+    session
+        A `snowflake.snowpark.Session` to use for the connection. If not
+        provided, a new session will be created from the other connection
+        parameters. Note that calling
+        [`Chat.close()`](`chatlas.Chat.close`) does not close a
+        caller-supplied `Session` -- it only closes a session that chatlas
+        created itself.
     kwargs
         Additional keyword arguments passed along to the Snowflake connection builder. These can
         include any parameters supported by the `snowflake-ml-python` package.
@@ -154,6 +163,7 @@ def ChatSnowflake(
             password=password,
             private_key_file=private_key_file,
             private_key_file_pwd=private_key_file_pwd,
+            session=session,
             kwargs=kwargs,
         ),
         system_prompt=system_prompt,
@@ -173,6 +183,7 @@ class SnowflakeProvider(
         password: Optional[str],
         private_key_file: Optional[str],
         private_key_file_pwd: Optional[str],
+        session: Optional["Session"],
         name: str = "Snowflake",
         kwargs: Optional[dict[str, "str | int"]],
     ):
@@ -193,27 +204,34 @@ class SnowflakeProvider(
         # https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-api#functions
         application = os.environ.get("SF_PARTNER", "py_chatlas")
 
-        configs: dict[str, str | int] = drop_none(
-            {
-                "connection_name": connection_name,
-                "account": account,
-                "user": user,
-                "password": password,
-                "private_key_file": private_key_file,
-                "private_key_file_pwd": private_key_file_pwd,
-                "application": application,
-                **(kwargs or {}),
-            }
-        )
+        if session is None:
+            configs: dict[str, str | int] = drop_none(
+                {
+                    "connection_name": connection_name,
+                    "account": account,
+                    "user": user,
+                    "password": password,
+                    "private_key_file": private_key_file,
+                    "private_key_file_pwd": private_key_file_pwd,
+                    "application": application,
+                    **(kwargs or {}),
+                }
+            )
+            session = Session.builder.configs(configs).create()
+            self._owns_session = True
+        else:
+            self._owns_session = False
 
-        self._session = Session.builder.configs(configs).create()
+        self._session = session
         self._cortex_service = Root(self._session).cortex_inference_service
 
     def close(self) -> None:
         """
-        Close the underlying Snowpark session (and its Snowflake connection).
+        Close the underlying Snowpark session (and its Snowflake connection),
+        unless the session was supplied by the caller.
         """
-        self._session.close()
+        if self._owns_session:
+            self._session.close()
 
     def list_models(self):
         raise NotImplementedError(

--- a/chatlas/_provider_snowflake.py
+++ b/chatlas/_provider_snowflake.py
@@ -76,6 +76,11 @@ def ChatSnowflake(
 
     https://docs.snowflake.com/en/user-guide/snowflake-cortex/llm-functions
 
+    Each `ChatSnowflake()` holds an underlying Snowpark session (and Snowflake
+    connection). In long-lived applications that create a chat per session
+    (e.g., Shiny), call [`Chat.close()`](`chatlas.Chat.close`) when the session
+    ends to release it -- for example, `session.on_ended(chat.close)`.
+
     Prerequisites
     -------------
 
@@ -201,8 +206,14 @@ class SnowflakeProvider(
             }
         )
 
-        session = Session.builder.configs(configs).create()
-        self._cortex_service = Root(session).cortex_inference_service
+        self._session = Session.builder.configs(configs).create()
+        self._cortex_service = Root(self._session).cortex_inference_service
+
+    def close(self) -> None:
+        """
+        Close the underlying Snowpark session (and its Snowflake connection).
+        """
+        self._session.close()
 
     def list_models(self):
         raise NotImplementedError(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ dev = [
     "polars",
     "openai",
     "anthropic[bedrock]>=1.0.0",
-    "google-genai>=1.14.0",
+    "google-genai>=2.0.0",
     "numpy>1.24.4",
     "tiktoken",
     "databricks-sdk",
@@ -117,7 +117,7 @@ databricks = ["databricks-sdk"]
 # Intentionally empty since these providers used to require 
 # an additional openai install, but that's now included 
 github = []
-google = ["google-genai>=1.14.0"]
+google = ["google-genai>=2.0.0"]
 groq = []
 ollama = []
 openai = []
@@ -127,7 +127,7 @@ posit = ["anthropic>=1.0.0"]
 # Version requirement avoids an install issue with recent Python versions.
 # Remove it when snowflake-ml-python can be installed without a requirement.
 snowflake = ["snowflake-ml-python<=1.9.0"]
-vertex = ["google-genai>=1.14.0"]
+vertex = ["google-genai>=2.0.0"]
 
 [dependency-groups]
 dev = [

--- a/tests/test_close.py
+++ b/tests/test_close.py
@@ -1,4 +1,5 @@
 import sys
+import warnings
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -22,6 +23,19 @@ async def test_chat_close_async_closes_mcp_and_provider():
         await chat.close_async()
         chat._mcp_manager.close_sessions.assert_awaited_once()
         mock_close.assert_awaited_once()
+
+
+def test_chat_close_warns_with_open_mcp_sessions():
+    chat = ChatOpenAI(model="gpt-4o")
+    chat._mcp_manager._mcp_sessions["fake"] = MagicMock()
+    with patch.object(chat.provider, "close"):
+        with pytest.warns(UserWarning, match="MCP server sessions"):
+            chat.close()
+        # No warning once sessions are gone
+        chat._mcp_manager._mcp_sessions.clear()
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            chat.close()
 
 
 def test_chat_context_manager():
@@ -112,9 +126,6 @@ async def test_google_provider_close_async():
     from chatlas import ChatGoogle
 
     chat = ChatGoogle(model="gemini-2.5-flash")
-    aclose = getattr(chat.provider._client.aio, "aclose", None)
-    if aclose is None:
-        pytest.skip("google-genai version lacks aio.aclose()")
     with patch.object(
         chat.provider._client.aio, "aclose", new=AsyncMock()
     ) as mock_close:

--- a/tests/test_close.py
+++ b/tests/test_close.py
@@ -166,6 +166,17 @@ def test_snowflake_provider_close():
     assert session.close.call_count == 2
 
 
+def test_snowflake_provider_close_ownership():
+    from chatlas import ChatSnowflake
+
+    snowflake, session = _make_mock_snowflake_modules()
+    with patch.dict(sys.modules, {"snowflake": snowflake, "snowflake.snowpark": snowflake.snowpark, "snowflake.core": snowflake.core}):
+        chat = ChatSnowflake(model="llama3.1-70b", session=session)
+    chat.close()
+    # A caller-supplied session is not closed.
+    session.close.assert_not_called()
+
+
 def test_databricks_provider_close_ownership():
     from chatlas import ChatDatabricks
 

--- a/tests/test_close.py
+++ b/tests/test_close.py
@@ -1,0 +1,174 @@
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from chatlas import Chat, ChatAnthropic, ChatOpenAI
+
+
+def test_chat_close_delegates_to_provider():
+    chat = ChatOpenAI(model="gpt-4o")
+    with patch.object(chat.provider, "close") as mock_close:
+        chat.close()
+        mock_close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_chat_close_async_closes_mcp_and_provider():
+    chat = ChatOpenAI(model="gpt-4o")
+    chat._mcp_manager.close_sessions = AsyncMock()
+    with patch.object(
+        chat.provider, "close_async", new=AsyncMock()
+    ) as mock_close:
+        await chat.close_async()
+        chat._mcp_manager.close_sessions.assert_awaited_once()
+        mock_close.assert_awaited_once()
+
+
+def test_chat_context_manager():
+    with patch.object(Chat, "close") as mock_close:
+        with ChatOpenAI(model="gpt-4o"):
+            pass
+        mock_close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_chat_async_context_manager():
+    with patch.object(Chat, "close_async", new=AsyncMock()) as mock_close:
+        async with ChatOpenAI(model="gpt-4o"):
+            pass
+        mock_close.assert_awaited_once()
+
+
+def test_openai_provider_close():
+    chat = ChatOpenAI(model="gpt-4o")
+    provider = chat.provider
+    chat.close()
+    assert provider._client.is_closed
+    # Idempotent
+    chat.close()
+
+
+@pytest.mark.asyncio
+async def test_openai_provider_close_async():
+    chat = ChatOpenAI(model="gpt-4o")
+    provider = chat.provider
+    await chat.close_async()
+    assert provider._client.is_closed
+    assert provider._async_client.is_closed
+
+
+def test_anthropic_provider_close():
+    chat = ChatAnthropic(model="claude-sonnet-4-5")
+    provider = chat.provider
+    chat.close()
+    assert provider._client.is_closed
+
+
+@pytest.mark.asyncio
+async def test_anthropic_provider_close_async():
+    chat = ChatAnthropic(model="claude-sonnet-4-5")
+    provider = chat.provider
+    await chat.close_async()
+    assert provider._client.is_closed
+    assert provider._async_client.is_closed
+
+
+def _make_bedrock_converse_provider():
+    from chatlas._provider_bedrock_converse import BedrockConverseProvider
+
+    return BedrockConverseProvider(
+        model="vendor/model:version",
+        aws_profile=None,
+        aws_region="us-east-1",
+        base_url=None,
+    )
+
+
+def test_bedrock_converse_provider_close():
+    provider = _make_bedrock_converse_provider()
+    provider.close()
+    assert provider._client.is_closed
+
+
+@pytest.mark.asyncio
+async def test_bedrock_converse_provider_close_async():
+    provider = _make_bedrock_converse_provider()
+    await provider.close_async()
+    assert provider._client.is_closed
+    assert provider._async_client.is_closed
+
+
+def test_google_provider_close():
+    from chatlas import ChatGoogle
+
+    chat = ChatGoogle(model="gemini-2.5-flash")
+    with patch.object(chat.provider._client, "close") as mock_close:
+        chat.close()
+        mock_close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_google_provider_close_async():
+    from chatlas import ChatGoogle
+
+    chat = ChatGoogle(model="gemini-2.5-flash")
+    aclose = getattr(chat.provider._client.aio, "aclose", None)
+    if aclose is None:
+        pytest.skip("google-genai version lacks aio.aclose()")
+    with patch.object(
+        chat.provider._client.aio, "aclose", new=AsyncMock()
+    ) as mock_close:
+        await chat.close_async()
+        mock_close.assert_awaited_once()
+
+
+def _make_mock_snowflake_modules():
+    session = MagicMock()
+    builder = MagicMock()
+    builder.configs.return_value = builder
+    builder.create.return_value = session
+
+    snowpark = MagicMock()
+    snowpark.Session.builder = builder
+
+    root = MagicMock()
+    core = MagicMock()
+    core.Root = root
+
+    snowflake = MagicMock()
+    snowflake.snowpark = snowpark
+    snowflake.core = core
+
+    return snowflake, session
+
+
+def test_snowflake_provider_close():
+    from chatlas import ChatSnowflake
+
+    snowflake, session = _make_mock_snowflake_modules()
+    with patch.dict(sys.modules, {"snowflake": snowflake, "snowflake.snowpark": snowflake.snowpark, "snowflake.core": snowflake.core}):
+        chat = ChatSnowflake(model="llama3.1-70b", account="a", user="u", password="p")
+    chat.close()
+    session.close.assert_called_once()
+    # Idempotent
+    chat.close()
+    assert session.close.call_count == 2
+
+
+def test_databricks_provider_close_ownership():
+    from chatlas import ChatDatabricks
+
+    workspace_client = MagicMock()
+    openai_client = MagicMock()
+    openai_client.base_url = "https://example.com/serving-endpoints"
+    openai_client._client.auth = None
+    workspace_client.serving_endpoints.get_open_ai_client.return_value = openai_client
+
+    chat = ChatDatabricks(
+        model="databricks-claude-sonnet-4", workspace_client=workspace_client
+    )
+    chat.close()
+    # The provider-created OpenAI client is closed...
+    openai_client.close.assert_called_once()
+    # ...but the caller-supplied WorkspaceClient is not touched.
+    workspace_client.close.assert_not_called()


### PR DESCRIPTION
## Motivation

In long-lived applications (Shiny, FastAPI) that create a `Chat` per user session, provider resources were previously only released by GC or process exit:

- **Snowflake**: each `ChatSnowflake()` holds a Snowpark session/connection visible server-side, reaped only by idle timeout
- **HTTP connection pools**: nearly every provider holds sync + async httpx-based clients; unclosed pools consume file descriptors in the host process
- **MCP sessions**: stdio MCP servers are child processes; `MCPSessionManager.close_sessions()` existed but nothing on `Chat` called it

## Changes

- `Provider` ABC gains concrete no-op `close()`/`close_async()`, documenting the ownership rule (only provider-created resources are closed; caller-supplied clients are left open) and idempotency requirement
- `Chat.close()` delegates to the provider; `Chat.close_async()` also closes MCP server sessions; sync/async context-manager support added
- Overrides on the six bases that hold real resources — OpenAI generic base, Anthropic, Bedrock Converse, Google, Snowflake, Databricks — covering all 22 provider files via inheritance
- `SnowflakeProvider` now retains its Snowpark `Session` (`self._session`) so `close()` can close it
- Databricks needed no override: it never retains the `WorkspaceClient`, and the OpenAI clients it creates are closed by the inherited implementation (ownership behavior pinned by test)
- `ChatSnowflake()` docstring documents the Shiny pattern: `session.on_ended(chat.close)`

## Testing

New `tests/test_close.py` (14 tests): delegation, idempotency, context managers, per-provider close behavior (mocked where construction requires network), and the Databricks ownership rule. Full suite passes except `test_files.py::test_opted_out_provider_raises` bedrock_mantle cases, which fail identically on clean `main`.